### PR TITLE
Unit 3: cli-plan choose-level + scaffold

### DIFF
--- a/crates/codex1/src/cli/plan/choose_level.rs
+++ b/crates/codex1/src/cli/plan/choose_level.rs
@@ -1,0 +1,158 @@
+//! `codex1 plan choose-level` — record the requested/effective planning level.
+//!
+//! Accepts `1`/`2`/`3` or `light`/`medium`/`hard` (never `low`/`high`).
+//! When `--escalate <reason>` is supplied, the effective level is bumped
+//! to `hard`. Interactive TTY callers see a STDERR prompt; non-interactive
+//! callers without `--level` get `PARSE_ERROR`.
+
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use serde_json::json;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::{self, Phase, PlanLevel};
+
+/// Handle `codex1 plan choose-level`.
+pub fn run(level: Option<String>, escalate: Option<String>, ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+
+    let requested = match level {
+        Some(raw) => parse_level(&raw)?,
+        None => prompt_for_level()?,
+    };
+    let (effective, escalation_reason) = match escalate {
+        Some(reason) => (PlanLevel::Hard, Some(reason)),
+        None => (requested.clone(), None),
+    };
+
+    let data = build_payload(&requested, &effective, escalation_reason.as_deref());
+
+    if ctx.dry_run {
+        // Validate against current state, but do not write.
+        let state = state::load(&paths)?;
+        if let Some(expected) = ctx.expect_revision {
+            if expected != state.revision {
+                return Err(CliError::RevisionConflict {
+                    expected,
+                    actual: state.revision,
+                });
+            }
+        }
+        let env = JsonOk::new(
+            Some(paths.mission_id.clone()),
+            Some(state.revision),
+            with_dry_run(data),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    let payload_event = json!({
+        "requested_level": level_str(&requested),
+        "effective_level": level_str(&effective),
+        "escalation_reason": escalation_reason,
+    });
+
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        "plan.choose_level",
+        payload_event,
+        |state| {
+            state.plan.requested_level = Some(requested.clone());
+            state.plan.effective_level = Some(effective.clone());
+            if matches!(state.phase, Phase::Clarify) {
+                state.phase = Phase::Plan;
+            }
+            Ok(())
+        },
+    )?;
+
+    let env = JsonOk::new(
+        Some(paths.mission_id.clone()),
+        Some(mutation.new_revision),
+        data,
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+/// Parse a raw level string into a `PlanLevel`. Accepts product verbs and
+/// the `1/2/3` numeric aliases. Rejects `low`/`high` or anything else.
+///
+/// Shared with `plan scaffold` so both commands use the same rules.
+pub fn parse_level(raw: &str) -> CliResult<PlanLevel> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "light" => Ok(PlanLevel::Light),
+        "2" | "medium" => Ok(PlanLevel::Medium),
+        "3" | "hard" => Ok(PlanLevel::Hard),
+        other => Err(CliError::ParseError {
+            message: format!(
+                "invalid planning level `{other}`; expected one of 1/light, 2/medium, 3/hard"
+            ),
+        }),
+    }
+}
+
+/// Print the menu to STDERR and read one line from STDIN. Used only when
+/// stdin is a TTY; non-interactive callers must pass `--level`.
+fn prompt_for_level() -> CliResult<PlanLevel> {
+    let stdin = io::stdin();
+    if !stdin.is_terminal() {
+        return Err(CliError::ParseError {
+            message: "`--level` required in non-interactive mode".to_string(),
+        });
+    }
+    let mut stderr = io::stderr().lock();
+    writeln!(
+        stderr,
+        "Choose planning level:\n1. light  - small/local/obvious work\n2. medium - normal multi-step work\n3. hard   - architecture/risky/autonomous/multi-agent work"
+    )?;
+    stderr.flush()?;
+    drop(stderr);
+
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+    parse_level(line.trim())
+}
+
+/// Canonical string form of a `PlanLevel` (always lowercase verbs).
+pub fn level_str(level: &PlanLevel) -> &'static str {
+    match level {
+        PlanLevel::Light => "light",
+        PlanLevel::Medium => "medium",
+        PlanLevel::Hard => "hard",
+    }
+}
+
+fn build_payload(
+    requested: &PlanLevel,
+    effective: &PlanLevel,
+    escalation_reason: Option<&str>,
+) -> serde_json::Value {
+    let effective_str = level_str(effective);
+    let mut data = json!({
+        "requested_level": level_str(requested),
+        "effective_level": effective_str,
+        "next_action": {
+            "kind": "plan_scaffold",
+            "args": ["codex1", "plan", "scaffold", "--level", effective_str],
+        },
+    });
+    if let Some(reason) = escalation_reason {
+        data.as_object_mut()
+            .expect("object")
+            .insert("escalation_reason".to_string(), json!(reason));
+    }
+    data
+}
+
+fn with_dry_run(mut data: serde_json::Value) -> serde_json::Value {
+    if let Some(obj) = data.as_object_mut() {
+        obj.insert("dry_run".to_string(), json!(true));
+    }
+    data
+}

--- a/crates/codex1/src/cli/plan/mod.rs
+++ b/crates/codex1/src/cli/plan/mod.rs
@@ -1,4 +1,10 @@
-//! `codex1 plan` stub — owned by Phase B Units 3/4/5.
+//! `codex1 plan` — Phase B Unit 3 owns `ChooseLevel` and `Scaffold`.
+//!
+//! Units 4 and 5 will replace the `Check`, `Graph`, and `Waves` arms with
+//! real handlers and add sibling modules; this unit does not touch those.
+
+pub mod choose_level;
+pub mod scaffold;
 
 use std::path::PathBuf;
 
@@ -44,15 +50,18 @@ pub enum GraphFormat {
     Json,
 }
 
-pub fn dispatch(cmd: PlanCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        PlanCmd::ChooseLevel { .. } => "plan choose-level",
-        PlanCmd::Scaffold { .. } => "plan scaffold",
-        PlanCmd::Check => "plan check",
-        PlanCmd::Graph { .. } => "plan graph",
-        PlanCmd::Waves => "plan waves",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: PlanCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        PlanCmd::ChooseLevel { level, escalate } => choose_level::run(level, escalate, ctx),
+        PlanCmd::Scaffold { level } => scaffold::run(level, ctx),
+        PlanCmd::Check => Err(CliError::NotImplemented {
+            command: "plan check".to_string(),
+        }),
+        PlanCmd::Graph { .. } => Err(CliError::NotImplemented {
+            command: "plan graph".to_string(),
+        }),
+        PlanCmd::Waves => Err(CliError::NotImplemented {
+            command: "plan waves".to_string(),
+        }),
+    }
 }

--- a/crates/codex1/src/cli/plan/scaffold.rs
+++ b/crates/codex1/src/cli/plan/scaffold.rs
@@ -1,0 +1,180 @@
+//! `codex1 plan scaffold` — write a PLAN.yaml skeleton for the chosen level.
+//!
+//! Requires a prior `plan choose-level` so the `--level` argument can be
+//! matched against the recorded requested/effective level. Level mismatch
+//! returns `PLAN_INVALID`. Does **not** set `plan.locked`; that transition
+//! belongs to `plan check` (Phase B Unit 4).
+
+use serde_json::json;
+
+use crate::cli::plan::choose_level::{level_str, parse_level};
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::core::paths::MissionPaths;
+use crate::state::{self, fs_atomic::atomic_write, MissionState, PlanLevel};
+
+/// Handle `codex1 plan scaffold --level <level>`.
+pub fn run(level_raw: String, ctx: &Ctx) -> CliResult<()> {
+    let level = parse_level(&level_raw)?;
+    let paths = resolve_mission(&ctx.selector(), true)?;
+
+    let plan_relpath = relative_plan_path(&paths);
+
+    if ctx.dry_run {
+        let state = state::load(&paths)?;
+        if let Some(expected) = ctx.expect_revision {
+            if expected != state.revision {
+                return Err(CliError::RevisionConflict {
+                    expected,
+                    actual: state.revision,
+                });
+            }
+        }
+        check_level_matches_recorded(&state, &level)?;
+        let env = JsonOk::new(
+            Some(paths.mission_id.clone()),
+            Some(state.revision),
+            json!({
+                "dry_run": true,
+                "wrote": plan_relpath,
+                "specs_created": Vec::<String>::new(),
+                "level": level_str(&level),
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    // Idempotently ensure specs/reviews dirs exist (normally created by init).
+    std::fs::create_dir_all(paths.specs_dir())?;
+    std::fs::create_dir_all(paths.reviews_dir())?;
+
+    let payload_event = json!({
+        "level": level_str(&level),
+        "wrote": plan_relpath.clone(),
+    });
+
+    let plan_path = paths.plan();
+    let mut skeleton = String::new();
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        "plan.scaffold",
+        payload_event,
+        |state| {
+            // Validate level match under the mutation lock to avoid a
+            // TOCTOU window between load and mutate.
+            check_level_matches_recorded(state, &level)?;
+            skeleton = render_skeleton(state, &level);
+            // No state-field mutations; the revision bump marks the
+            // scaffold event for audit. `plan.locked` stays false.
+            Ok(())
+        },
+    )?;
+
+    atomic_write(&plan_path, skeleton.as_bytes())?;
+
+    let env = JsonOk::new(
+        Some(paths.mission_id.clone()),
+        Some(mutation.new_revision),
+        json!({
+            "wrote": plan_relpath,
+            "specs_created": Vec::<String>::new(),
+            "level": level_str(&level),
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+/// Return `PLAN_INVALID` unless the recorded effective (or requested)
+/// level matches `level`.
+fn check_level_matches_recorded(state: &MissionState, level: &PlanLevel) -> CliResult<()> {
+    let recorded = state
+        .plan
+        .effective_level
+        .as_ref()
+        .or(state.plan.requested_level.as_ref())
+        .ok_or_else(|| CliError::PlanInvalid {
+            message: "no planning level recorded; run `codex1 plan choose-level` first".to_string(),
+            hint: Some("Example: `codex1 plan choose-level --level medium --json`.".to_string()),
+        })?;
+    if recorded != level {
+        let recorded_str = level_str(recorded);
+        return Err(CliError::PlanInvalid {
+            message: "--level does not match recorded plan level".to_string(),
+            hint: Some(format!(
+                "Recorded effective level is `{recorded_str}`. Re-run with --level {recorded_str}, or re-run `plan choose-level` to change it."
+            )),
+        });
+    }
+    Ok(())
+}
+
+/// Compose the skeleton PLAN.yaml for the given level. `mission_id` and
+/// `planning_level` reflect the STATE.json-recorded values. Hard plans
+/// include explorer/advisor/plan_reviewer evidence markers.
+fn render_skeleton(state: &MissionState, level: &PlanLevel) -> String {
+    let mission_id = &state.mission_id;
+    let requested = state
+        .plan
+        .requested_level
+        .as_ref()
+        .map_or("[codex1-fill:planning_level]", level_str);
+    let effective = level_str(level);
+
+    let evidence_block = match level {
+        PlanLevel::Hard => {
+            "  evidence:\n\
+             \x20   - kind: explorer\n\
+             \x20     summary: '[codex1-fill:explorer_evidence]'\n\
+             \x20     required_for_hard: true\n\
+             \x20   - kind: advisor\n\
+             \x20     summary: '[codex1-fill:advisor_evidence]'\n\
+             \x20     required_for_hard: true\n\
+             \x20   - kind: plan_review\n\
+             \x20     summary: '[codex1-fill:plan_reviewer_evidence]'\n\
+             \x20     required_for_hard: true\n"
+        }
+        _ => "  evidence: []\n",
+    };
+
+    format!(
+        "mission_id: {mission_id}\n\
+         \n\
+         planning_level:\n\
+         \x20 requested: {requested}\n\
+         \x20 effective: {effective}\n\
+         \n\
+         outcome_interpretation:\n\
+         \x20 summary: '[codex1-fill:outcome_interpretation]'\n\
+         \n\
+         architecture:\n\
+         \x20 summary: '[codex1-fill:architecture_summary]'\n\
+         \x20 key_decisions:\n\
+         \x20   - '[codex1-fill:architecture_key_decision_1]'\n\
+         \n\
+         planning_process:\n\
+         {evidence_block}\n\
+         tasks: []\n\
+         \n\
+         risks:\n\
+         \x20 - risk: '[codex1-fill:risk_1]'\n\
+         \x20   mitigation: '[codex1-fill:mitigation_1]'\n\
+         \n\
+         mission_close:\n\
+         \x20 criteria:\n\
+         \x20   - '[codex1-fill:mission_close_criteria_1]'\n"
+    )
+}
+
+fn relative_plan_path(paths: &MissionPaths) -> String {
+    let abs = paths.plan();
+    if let Ok(rel) = abs.strip_prefix(&paths.repo_root) {
+        rel.display().to_string()
+    } else {
+        abs.display().to_string()
+    }
+}

--- a/crates/codex1/tests/plan_scaffold.rs
+++ b/crates/codex1/tests/plan_scaffold.rs
@@ -1,0 +1,359 @@
+//! Integration tests for Unit 3 (`codex1 plan choose-level` / `plan scaffold`).
+//!
+//! Exercises the parsing rules (product verbs + 1/2/3 aliases, rejection of
+//! `low`/`high`/out-of-range), the STATE.json mutation (phase transition,
+//! requested/effective level), `--escalate`, `--dry-run`, the scaffolded
+//! PLAN.yaml shape, and the level-mismatch guard.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_demo(tmp: &TempDir, mission: &str) -> PathBuf {
+    let mission_dir = tmp.path().join("PLANS").join(mission);
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", mission])
+        .assert()
+        .success();
+    mission_dir
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(stdout).unwrap_or_else(|e| {
+        panic!("expected JSON stdout, got:\n{stdout}\nerror: {e}");
+    })
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(mission_dir.join("STATE.json")).unwrap()).unwrap()
+}
+
+fn read_events(mission_dir: &Path) -> Vec<Value> {
+    let raw = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap();
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).unwrap())
+        .collect()
+}
+
+#[test]
+fn choose_level_accepts_numeric_alias_1() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["plan", "choose-level", "--mission", "demo", "--level", "1"])
+        .output()
+        .expect("runs");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["requested_level"], "light");
+    assert_eq!(json["data"]["effective_level"], "light");
+    assert_eq!(json["data"]["next_action"]["kind"], "plan_scaffold");
+    assert_eq!(json["data"]["next_action"]["args"][4], "light");
+    assert!(json["data"].get("escalation_reason").is_none());
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["plan"]["requested_level"], "light");
+    assert_eq!(state["plan"]["effective_level"], "light");
+    assert_eq!(state["phase"], "plan");
+    assert_eq!(state["revision"], 1);
+
+    let events = read_events(&mission_dir);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["kind"], "plan.choose_level");
+    assert_eq!(events[0]["payload"]["requested_level"], "light");
+}
+
+#[test]
+fn choose_level_accepts_string_light() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "plan",
+            "choose-level",
+            "--mission",
+            "demo",
+            "--level",
+            "light",
+        ])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["requested_level"], "light");
+    assert_eq!(json["data"]["effective_level"], "light");
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["plan"]["requested_level"], "light");
+}
+
+#[test]
+fn choose_level_with_escalate_bumps_to_hard() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "plan",
+            "choose-level",
+            "--mission",
+            "demo",
+            "--level",
+            "medium",
+            "--escalate",
+            "touches hooks",
+        ])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["requested_level"], "medium");
+    assert_eq!(json["data"]["effective_level"], "hard");
+    assert_eq!(json["data"]["escalation_reason"], "touches hooks");
+    assert_eq!(json["data"]["next_action"]["args"][4], "hard");
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["plan"]["requested_level"], "medium");
+    assert_eq!(state["plan"]["effective_level"], "hard");
+
+    let events = read_events(&mission_dir);
+    assert_eq!(
+        events[0]["payload"]["escalation_reason"], "touches hooks",
+        "audit event should capture escalation reason"
+    );
+}
+
+#[test]
+fn choose_level_rejects_high() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "plan",
+            "choose-level",
+            "--mission",
+            "demo",
+            "--level",
+            "high",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PARSE_ERROR");
+}
+
+#[test]
+fn choose_level_rejects_low() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "plan",
+            "choose-level",
+            "--mission",
+            "demo",
+            "--level",
+            "low",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PARSE_ERROR");
+}
+
+#[test]
+fn choose_level_rejects_out_of_range_numeric() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["plan", "choose-level", "--mission", "demo", "--level", "4"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PARSE_ERROR");
+}
+
+#[test]
+fn scaffold_hard_writes_hard_evidence_and_rejects_level_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    cmd()
+        .current_dir(tmp.path())
+        .args([
+            "plan",
+            "choose-level",
+            "--mission",
+            "demo",
+            "--level",
+            "hard",
+        ])
+        .assert()
+        .success();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["plan", "scaffold", "--mission", "demo", "--level", "hard"])
+        .output()
+        .expect("runs");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["level"], "hard");
+    assert!(json["data"]["wrote"]
+        .as_str()
+        .unwrap()
+        .ends_with("PLAN.yaml"));
+
+    let plan = fs::read_to_string(mission_dir.join("PLAN.yaml")).unwrap();
+    for marker in [
+        "mission_id: demo",
+        "requested: hard",
+        "effective: hard",
+        "kind: explorer",
+        "kind: advisor",
+        "kind: plan_review",
+        "[codex1-fill:explorer_evidence]",
+        "[codex1-fill:advisor_evidence]",
+        "[codex1-fill:plan_reviewer_evidence]",
+        "outcome_interpretation:",
+        "architecture:",
+        "planning_process:",
+        "tasks:",
+        "risks:",
+        "mission_close:",
+    ] {
+        assert!(
+            plan.contains(marker),
+            "scaffolded PLAN.yaml missing `{marker}`:\n{plan}"
+        );
+    }
+
+    // Parse to YAML to confirm shape is valid.
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&plan).expect("parses as yaml");
+    assert_eq!(yaml["mission_id"], serde_yaml::Value::String("demo".into()));
+    assert_eq!(
+        yaml["planning_level"]["effective"],
+        serde_yaml::Value::String("hard".into())
+    );
+    assert!(yaml["planning_process"]["evidence"].is_sequence());
+    assert_eq!(
+        yaml["planning_process"]["evidence"]
+            .as_sequence()
+            .unwrap()
+            .len(),
+        3
+    );
+
+    // Second scaffold at the wrong level must reject.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["plan", "scaffold", "--mission", "demo", "--level", "medium"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+}
+
+#[test]
+fn choose_level_dry_run_does_not_mutate() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let before = read_state(&mission_dir);
+    assert_eq!(before["revision"], 0);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "plan",
+            "choose-level",
+            "--mission",
+            "demo",
+            "--level",
+            "medium",
+            "--dry-run",
+        ])
+        .output()
+        .expect("runs");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["requested_level"], "medium");
+
+    let after = read_state(&mission_dir);
+    assert_eq!(after["revision"], 0);
+    assert!(after["plan"]["requested_level"].is_null());
+    assert_eq!(after["phase"], "clarify");
+    let events = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap();
+    assert_eq!(events, "");
+}
+
+#[test]
+fn choose_level_non_interactive_requires_flag() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    // `assert_cmd` pipes stdin, which is not a TTY — so this run hits the
+    // non-interactive branch without a `--level`.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["plan", "choose-level", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PARSE_ERROR");
+    assert!(
+        json["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("required in non-interactive mode"),
+        "unexpected message: {}",
+        json["message"]
+    );
+}
+
+#[test]
+fn scaffold_before_choose_level_rejects() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["plan", "scaffold", "--mission", "demo", "--level", "hard"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+}


### PR DESCRIPTION
## Summary
- Implements `codex1 plan choose-level` (records requested + effective planning level, supports `--escalate`, TTY-only interactive prompt, numeric + string aliases).
- Implements `codex1 plan scaffold --level <level>` (writes a PLAN.yaml skeleton gated by the recorded level; hard plans get explorer/advisor/plan_review evidence markers).
- Both commands honor `--dry-run`, `--expect-revision`, and emit the stable envelope contract.
- Level-match check runs inside the `state::mutate` closure to avoid a TOCTOU window between load and write.

## Scope
- Adds `crates/codex1/src/cli/plan/choose_level.rs` and `crates/codex1/src/cli/plan/scaffold.rs`.
- Edits `crates/codex1/src/cli/plan/mod.rs` to dispatch the two new arms; leaves `Check`, `Graph`, and `Waves` as `NotImplemented` stubs for Units 4 and 5.
- Adds `crates/codex1/tests/plan_scaffold.rs` (10 integration tests).
- No Foundation or DO-NOT-TOUCH files modified.

## Test plan
- [x] `cargo fmt` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test` — 13 foundation + 10 plan_scaffold tests pass.
- [x] Smoke: `init demo` → `plan choose-level --level hard` → `plan scaffold --level hard` produces a PLAN.yaml with hard evidence markers and bumps revision twice.
- [x] Rejection paths: `--level low`, `--level high`, `--level 4` all return `PARSE_ERROR`; scaffold mismatch returns `PLAN_INVALID`.
- [x] `--dry-run` on `plan choose-level` leaves STATE.json revision at 0.

Unit 3 of the Codex1 v3 rebuild.