### PR TITLE
Unit 5: cli-plan waves + graph

### DIFF
--- a/crates/codex1/src/cli/plan/graph.rs
+++ b/crates/codex1/src/cli/plan/graph.rs
@@ -1,0 +1,231 @@
+//! `codex1 plan graph` — emit the task DAG in Mermaid, Graphviz, or JSON
+//! form. Node styling reflects each task's effective status (derived from
+//! STATE.json task records plus DAG readiness).
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use super::waves::{load_plan_tasks, ParsedTask};
+use super::GraphFormat;
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::CliResult;
+use crate::core::mission::resolve_mission;
+use crate::state::{self, TaskStatus};
+
+/// Node-level status used in graph output. Mirrors the CLI contract —
+/// same snake_case tokens that STATE.json uses for TaskStatus, with
+/// "ready"/"blocked" filled in for tasks that have no record yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeStatus {
+    Complete,
+    InProgress,
+    AwaitingReview,
+    Ready,
+    Blocked,
+    Superseded,
+}
+
+impl NodeStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::InProgress => "in_progress",
+            Self::AwaitingReview => "awaiting_review",
+            Self::Ready => "ready",
+            Self::Blocked => "blocked",
+            Self::Superseded => "superseded",
+        }
+    }
+}
+
+pub fn run(ctx: &Ctx, format: GraphFormat, out: Option<PathBuf>) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let tasks = load_plan_tasks(&paths.plan())?;
+    let statuses = derive_node_statuses(&tasks, &state.tasks);
+
+    let (inline_key, body) = match format {
+        GraphFormat::Mermaid => ("mermaid", render_mermaid(&tasks, &statuses)),
+        GraphFormat::Dot => ("dot", render_dot(&tasks, &statuses)),
+        GraphFormat::Json => ("graph", render_json(&tasks, &statuses).to_string()),
+    };
+
+    let data = if let Some(path) = out {
+        write_to(&path, &body)?;
+        json!({ "path": path })
+    } else if inline_key == "graph" {
+        // Re-parse the JSON so it's emitted as structured data, not a string.
+        let graph: Value = serde_json::from_str(&body)?;
+        json!({ "graph": graph })
+    } else {
+        json!({ inline_key: body })
+    };
+
+    let env = JsonOk::new(Some(state.mission_id.clone()), Some(state.revision), data);
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+fn write_to(path: &Path, body: &str) -> CliResult<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, body)?;
+    Ok(())
+}
+
+fn derive_node_statuses(
+    tasks: &[ParsedTask],
+    state_tasks: &BTreeMap<String, crate::state::TaskRecord>,
+) -> BTreeMap<String, NodeStatus> {
+    let mut out = BTreeMap::new();
+    for t in tasks {
+        let status = match state_tasks.get(&t.id).map(|r| r.status.clone()) {
+            Some(TaskStatus::Complete) => NodeStatus::Complete,
+            Some(TaskStatus::InProgress) => NodeStatus::InProgress,
+            Some(TaskStatus::AwaitingReview) => NodeStatus::AwaitingReview,
+            Some(TaskStatus::Superseded) => NodeStatus::Superseded,
+            Some(TaskStatus::Ready) => NodeStatus::Ready,
+            Some(TaskStatus::Pending) | None => {
+                if deps_are_done(t, state_tasks) {
+                    NodeStatus::Ready
+                } else {
+                    NodeStatus::Blocked
+                }
+            }
+        };
+        out.insert(t.id.clone(), status);
+    }
+    out
+}
+
+fn deps_are_done(
+    task: &ParsedTask,
+    state_tasks: &BTreeMap<String, crate::state::TaskRecord>,
+) -> bool {
+    task.depends_on.iter().all(|dep| {
+        matches!(
+            state_tasks.get(dep).map(|r| r.status.clone()),
+            Some(TaskStatus::Complete | TaskStatus::Superseded)
+        )
+    })
+}
+
+fn render_mermaid(tasks: &[ParsedTask], statuses: &BTreeMap<String, NodeStatus>) -> String {
+    let mut out = String::new();
+    out.push_str("flowchart TD\n");
+    out.push_str("    classDef complete fill:#b7e4c7,stroke:#2d6a4f,color:#1b4332\n");
+    out.push_str("    classDef in_progress fill:#ffe066,stroke:#b08900,color:#5a4500\n");
+    out.push_str("    classDef awaiting_review fill:#ffd6a5,stroke:#c75d2c,color:#5a2b12\n");
+    out.push_str("    classDef ready fill:#bde0fe,stroke:#1d4ed8,color:#0b2559\n");
+    out.push_str("    classDef blocked fill:#e5e7eb,stroke:#6b7280,color:#374151\n");
+    out.push_str(
+        "    classDef superseded fill:#f5f5f4,stroke:#a8a29e,color:#57534e,stroke-dasharray: 4 2\n",
+    );
+
+    for t in tasks {
+        let label = node_label(&t.id, &t.title);
+        let _ = writeln!(out, "    {}[\"{label}\"]", t.id);
+    }
+    for t in tasks {
+        for dep in &t.depends_on {
+            let _ = writeln!(out, "    {dep} --> {}", t.id);
+        }
+    }
+    for t in tasks {
+        if let Some(status) = statuses.get(&t.id) {
+            let _ = writeln!(out, "    class {} {}", t.id, status.as_str());
+        }
+    }
+    out
+}
+
+/// Shared node label: `"ID · title"` with quotes/newlines stripped so the
+/// result is safe inside either Mermaid `["..."]` nodes or Graphviz
+/// `label="..."` attributes.
+fn node_label(id: &str, title: &str) -> String {
+    let clean: String = title
+        .chars()
+        .map(|c| match c {
+            '"' => '\'',
+            '\n' | '\r' => ' ',
+            c => c,
+        })
+        .collect();
+    let clean = clean.trim();
+    if clean.is_empty() {
+        id.to_string()
+    } else {
+        format!("{id} · {clean}")
+    }
+}
+
+fn render_dot(tasks: &[ParsedTask], statuses: &BTreeMap<String, NodeStatus>) -> String {
+    let mut out = String::new();
+    out.push_str("digraph Plan {\n");
+    out.push_str("    rankdir=TB;\n");
+    out.push_str("    node [shape=box, style=\"rounded,filled\"];\n");
+    for t in tasks {
+        let status = statuses.get(&t.id).copied().unwrap_or(NodeStatus::Blocked);
+        let (fill, stroke) = dot_colors(status);
+        let label = node_label(&t.id, &t.title);
+        let _ = writeln!(
+            out,
+            "    {} [label=\"{label}\", fillcolor=\"{fill}\", color=\"{stroke}\"];",
+            t.id
+        );
+    }
+    for t in tasks {
+        for dep in &t.depends_on {
+            let _ = writeln!(out, "    {dep} -> {};", t.id);
+        }
+    }
+    out.push_str("}\n");
+    out
+}
+
+fn dot_colors(status: NodeStatus) -> (&'static str, &'static str) {
+    match status {
+        NodeStatus::Complete => ("#b7e4c7", "#2d6a4f"),
+        NodeStatus::InProgress => ("#ffe066", "#b08900"),
+        NodeStatus::AwaitingReview => ("#ffd6a5", "#c75d2c"),
+        NodeStatus::Ready => ("#bde0fe", "#1d4ed8"),
+        NodeStatus::Blocked => ("#e5e7eb", "#6b7280"),
+        NodeStatus::Superseded => ("#f5f5f4", "#a8a29e"),
+    }
+}
+
+fn render_json(tasks: &[ParsedTask], statuses: &BTreeMap<String, NodeStatus>) -> Value {
+    let nodes: Vec<Value> = tasks
+        .iter()
+        .map(|t| {
+            let status = statuses
+                .get(&t.id)
+                .copied()
+                .unwrap_or(NodeStatus::Blocked)
+                .as_str();
+            json!({
+                "id": t.id,
+                "title": t.title,
+                "kind": t.kind,
+                "status": status,
+            })
+        })
+        .collect();
+    let edges: Vec<Value> = tasks
+        .iter()
+        .flat_map(|t| {
+            t.depends_on
+                .iter()
+                .map(|dep| json!({ "from": dep, "to": t.id }))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    json!({ "nodes": nodes, "edges": edges })
+}

--- a/crates/codex1/src/cli/plan/mod.rs
+++ b/crates/codex1/src/cli/plan/mod.rs
@@ -7,6 +7,9 @@ use clap::{Subcommand, ValueEnum};
 use crate::cli::Ctx;
 use crate::core::error::{CliError, CliResult};
 
+pub mod graph;
+pub mod waves;
+
 #[derive(Debug, Subcommand)]
 pub enum PlanCmd {
     /// Interactive planning-level selection handshake.
@@ -44,15 +47,18 @@ pub enum GraphFormat {
     Json,
 }
 
-pub fn dispatch(cmd: PlanCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        PlanCmd::ChooseLevel { .. } => "plan choose-level",
-        PlanCmd::Scaffold { .. } => "plan scaffold",
-        PlanCmd::Check => "plan check",
-        PlanCmd::Graph { .. } => "plan graph",
-        PlanCmd::Waves => "plan waves",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: PlanCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        PlanCmd::Waves => waves::run(ctx),
+        PlanCmd::Graph { format, out } => graph::run(ctx, format, out),
+        PlanCmd::ChooseLevel { .. } => Err(CliError::NotImplemented {
+            command: "plan choose-level".to_string(),
+        }),
+        PlanCmd::Scaffold { .. } => Err(CliError::NotImplemented {
+            command: "plan scaffold".to_string(),
+        }),
+        PlanCmd::Check => Err(CliError::NotImplemented {
+            command: "plan check".to_string(),
+        }),
+    }
 }

--- a/crates/codex1/src/cli/plan/waves.rs
+++ b/crates/codex1/src/cli/plan/waves.rs
@@ -1,0 +1,284 @@
+//! `codex1 plan waves` — derive wave ordering from the DAG plus current
+//! task state. Waves are never stored; they are recomputed on every call.
+//!
+//! Algorithm (in short): parse PLAN.yaml, build DAG depth on the task
+//! graph, use STATE.json task statuses only to compute
+//! `current_ready_wave` and `all_tasks_complete`. The wave *list* itself
+//! is structural (depth-driven), not state-filtered.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::{self, TaskStatus};
+
+/// Minimal task shape needed for wave derivation and graph emission. Kept
+/// local so this module does not depend on Unit 4's parser.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParsedTask {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub exclusive_resources: Vec<String>,
+    #[serde(default)]
+    pub unknown_side_effects: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParsedPlan {
+    #[serde(default)]
+    tasks: Vec<ParsedTask>,
+}
+
+/// Load and parse PLAN.yaml into the minimal task shape used by waves/graph.
+pub fn load_plan_tasks(plan_path: &Path) -> CliResult<Vec<ParsedTask>> {
+    if !plan_path.is_file() {
+        return Err(CliError::PlanInvalid {
+            message: format!("PLAN.yaml not found at {}", plan_path.display()),
+            hint: Some("Run `codex1 plan scaffold --level <level>` first.".to_string()),
+        });
+    }
+    let raw = std::fs::read_to_string(plan_path)?;
+    let plan: ParsedPlan = serde_yaml::from_str(&raw).map_err(|err| CliError::PlanInvalid {
+        message: format!("Failed to parse PLAN.yaml: {err}"),
+        hint: Some("Check YAML syntax and task shape (id, depends_on, ...).".to_string()),
+    })?;
+    Ok(plan.tasks)
+}
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+
+    // If the plan is not locked yet, return empty waves with a note rather
+    // than surfacing a PLAN_INVALID from parsing work-in-progress YAML.
+    if !state.plan.locked {
+        let env = JsonOk::new(
+            Some(state.mission_id.clone()),
+            Some(state.revision),
+            json!({
+                "waves": [],
+                "current_ready_wave": Value::Null,
+                "all_tasks_complete": false,
+                "note": "Plan is not locked yet; waves cannot be derived.",
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    let tasks = load_plan_tasks(&paths.plan())?;
+    let waves = derive_waves(&tasks, &state.tasks)?;
+
+    let current_ready_wave = waves
+        .iter()
+        .find(|w| wave_is_current_ready(w, &state.tasks))
+        .map(|w| w.wave_id.clone());
+
+    let all_tasks_complete = !tasks.is_empty()
+        && tasks.iter().all(|t| {
+            matches!(
+                state
+                    .tasks
+                    .get(&t.id)
+                    .map_or(TaskStatus::Pending, |r| r.status.clone()),
+                TaskStatus::Complete | TaskStatus::Superseded
+            )
+        });
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        json!({
+            "waves": waves.iter().map(Wave::to_json).collect::<Vec<_>>(),
+            "current_ready_wave": current_ready_wave,
+            "all_tasks_complete": all_tasks_complete,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct Wave {
+    pub wave_id: String,
+    pub tasks: Vec<String>,
+    pub parallel_safe: bool,
+    pub blockers: Vec<String>,
+}
+
+impl Wave {
+    fn to_json(&self) -> Value {
+        json!({
+            "wave_id": self.wave_id,
+            "tasks": self.tasks,
+            "parallel_safe": self.parallel_safe,
+            "blockers": self.blockers,
+        })
+    }
+}
+
+/// Compute DAG-depth-based waves plus per-wave parallel-safety data. The
+/// wave list itself is structural; task state only affects
+/// `current_ready_wave` (computed by the caller).
+pub fn derive_waves(
+    tasks: &[ParsedTask],
+    state_tasks: &BTreeMap<String, crate::state::TaskRecord>,
+) -> CliResult<Vec<Wave>> {
+    if tasks.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Skip tasks that are Superseded in state; they are history, not part
+    // of the live DAG.
+    let live: Vec<&ParsedTask> = tasks
+        .iter()
+        .filter(|t| {
+            !matches!(
+                state_tasks.get(&t.id).map(|r| r.status.clone()),
+                Some(TaskStatus::Superseded)
+            )
+        })
+        .collect();
+
+    let ids: BTreeSet<&str> = live.iter().map(|t| t.id.as_str()).collect();
+
+    // Validate every depends_on points at a known live task. Missing deps
+    // are a PLAN.yaml integrity failure — Unit 4's `plan check` catches
+    // them too, but we surface a clear error here in case a user runs
+    // `plan waves` directly.
+    for t in &live {
+        for dep in &t.depends_on {
+            if !ids.contains(dep.as_str()) {
+                return Err(CliError::DagMissingDep {
+                    message: format!("Task {} depends on unknown task {dep}", t.id),
+                });
+            }
+        }
+    }
+
+    // Compute depth for every task via memoized DFS. Cycles cause a
+    // DAG_CYCLE error — again this is redundant with `plan check` but
+    // keeps waves fail-closed.
+    let mut depth: BTreeMap<String, usize> = BTreeMap::new();
+    let mut visiting: BTreeSet<String> = BTreeSet::new();
+    let by_id: BTreeMap<&str, &ParsedTask> = live.iter().map(|t| (t.id.as_str(), *t)).collect();
+    for t in &live {
+        compute_depth(&t.id, &by_id, &mut depth, &mut visiting)?;
+    }
+
+    // Bucket tasks by depth. Keep plan-order within each bucket for
+    // deterministic output.
+    let mut buckets: BTreeMap<usize, Vec<&ParsedTask>> = BTreeMap::new();
+    for t in &live {
+        let d = depth[&t.id];
+        buckets.entry(d).or_default().push(*t);
+    }
+
+    let mut waves = Vec::with_capacity(buckets.len());
+    for (idx, (_d, bucket)) in buckets.into_iter().enumerate() {
+        let wave_id = format!("W{}", idx + 1);
+        let tasks: Vec<String> = bucket.iter().map(|t| t.id.clone()).collect();
+        let (parallel_safe, blockers) = compute_parallel_safety(&bucket);
+        waves.push(Wave {
+            wave_id,
+            tasks,
+            parallel_safe,
+            blockers,
+        });
+    }
+    Ok(waves)
+}
+
+fn compute_depth(
+    id: &str,
+    by_id: &BTreeMap<&str, &ParsedTask>,
+    depth: &mut BTreeMap<String, usize>,
+    visiting: &mut BTreeSet<String>,
+) -> CliResult<usize> {
+    if let Some(d) = depth.get(id) {
+        return Ok(*d);
+    }
+    if !visiting.insert(id.to_string()) {
+        return Err(CliError::DagCycle {
+            message: format!("Cycle detected at task {id}"),
+        });
+    }
+    let task = by_id.get(id).ok_or_else(|| CliError::DagMissingDep {
+        message: format!("Unknown task {id}"),
+    })?;
+    let mut d = 0usize;
+    for dep in &task.depends_on {
+        let parent = compute_depth(dep, by_id, depth, visiting)?;
+        if parent + 1 > d {
+            d = parent + 1;
+        }
+    }
+    depth.insert(id.to_string(), d);
+    visiting.remove(id);
+    Ok(d)
+}
+
+/// Parallel-safe unless two tasks share an exclusive resource or any task
+/// has `unknown_side_effects`. Blockers are deduplicated for readability.
+fn compute_parallel_safety(bucket: &[&ParsedTask]) -> (bool, Vec<String>) {
+    let mut blockers: Vec<String> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+
+    let mut resource_owners: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for task in bucket {
+        for res in &task.exclusive_resources {
+            resource_owners
+                .entry(res.as_str())
+                .or_default()
+                .push(task.id.as_str());
+        }
+    }
+    for (res, owners) in &resource_owners {
+        if owners.len() > 1 {
+            let key = format!("exclusive_resource:{res}");
+            if seen.insert(key.clone()) {
+                blockers.push(key);
+            }
+        }
+    }
+
+    for task in bucket {
+        if task.unknown_side_effects {
+            let key = format!("unknown_side_effects:{}", task.id);
+            if seen.insert(key.clone()) {
+                blockers.push(key);
+            }
+        }
+    }
+
+    (blockers.is_empty(), blockers)
+}
+
+/// True when every task in the wave is either Pending or explicitly
+/// Ready — i.e. the wave has not started yet. Waves that contain
+/// InProgress, AwaitingReview, Complete, or Superseded tasks do not
+/// match; the "current ready" wave is the next *untouched* one.
+fn wave_is_current_ready(
+    wave: &Wave,
+    state_tasks: &BTreeMap<String, crate::state::TaskRecord>,
+) -> bool {
+    wave.tasks.iter().all(|id| {
+        matches!(
+            state_tasks
+                .get(id)
+                .map_or(TaskStatus::Pending, |r| r.status.clone()),
+            TaskStatus::Pending | TaskStatus::Ready
+        )
+    })
+}

--- a/crates/codex1/tests/plan_waves.rs
+++ b/crates/codex1/tests/plan_waves.rs
@@ -1,0 +1,288 @@
+//! Integration tests for Phase B Unit 5 (`plan waves` / `plan graph`).
+//!
+//! Each test seeds its own PLANS/<mission>/ layout on disk via the real
+//! `codex1 init` binary, then rewrites PLAN.yaml and STATE.json to
+//! exercise the derivation logic. Waves are derived on every call, so
+//! STATE.json changes should reshape `current_ready_wave` without
+//! changing the wave list itself.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_mission(tmp: &TempDir, mission: &str) -> PathBuf {
+    let mission_dir = tmp.path().join("PLANS").join(mission);
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", mission])
+        .assert()
+        .success();
+    mission_dir
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(stdout).unwrap_or_else(|e| {
+        panic!("expected JSON stdout, got:\n{stdout}\nerror: {e}");
+    })
+}
+
+/// Overwrite the mission's PLAN.yaml and mark plan.locked = true in
+/// STATE.json, preserving the schema-version and revision fields.
+fn seed_plan(mission_dir: &Path, plan_yaml: &str) {
+    fs::write(mission_dir.join("PLAN.yaml"), plan_yaml).unwrap();
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    state["plan"]["locked"] = Value::Bool(true);
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+/// Write a STATE.json task record with a specific status. All tests use
+/// this instead of relying on tasks being absent (which is treated as
+/// Pending by the derivation).
+fn set_task_status(mission_dir: &Path, task_id: &str, status: &str) {
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    let tasks = state["tasks"].as_object_mut().unwrap();
+    tasks.insert(
+        task_id.to_string(),
+        serde_json::json!({ "id": task_id, "status": status }),
+    );
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+const FIVE_TASK_PLAN: &str = r"mission_id: demo
+tasks:
+  - id: T1
+    title: Root
+    kind: code
+    depends_on: []
+  - id: T2
+    title: Branch A
+    kind: code
+    depends_on: [T1]
+  - id: T3
+    title: Branch B
+    kind: code
+    depends_on: [T1]
+  - id: T4
+    title: Join
+    kind: code
+    depends_on: [T2, T3]
+  - id: T5
+    title: Review after join
+    kind: review
+    depends_on: [T4]
+";
+
+fn run_waves(tmp: &TempDir, mission: &str) -> Value {
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["plan", "waves", "--mission", mission])
+        .output()
+        .expect("runs");
+    parse_stdout_json(&output)
+}
+
+fn run_graph(tmp: &TempDir, mission: &str, extra: &[&str]) -> Value {
+    let mut args = vec!["plan", "graph", "--mission", mission];
+    args.extend_from_slice(extra);
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(&args)
+        .output()
+        .expect("runs");
+    parse_stdout_json(&output)
+}
+
+#[test]
+fn waves_from_five_task_dag() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp, "demo");
+    seed_plan(&mission_dir, FIVE_TASK_PLAN);
+
+    let json = run_waves(&tmp, "demo");
+    assert_eq!(json["ok"], Value::Bool(true), "{json}");
+    let waves = json["data"]["waves"].as_array().unwrap();
+    assert_eq!(waves.len(), 4, "waves: {waves:?}");
+    assert_eq!(waves[0]["wave_id"], "W1");
+    assert_eq!(waves[0]["tasks"], serde_json::json!(["T1"]));
+    assert_eq!(waves[1]["wave_id"], "W2");
+    let mut w2 = waves[1]["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    w2.sort();
+    assert_eq!(w2, vec!["T2", "T3"]);
+    assert_eq!(waves[2]["wave_id"], "W3");
+    assert_eq!(waves[2]["tasks"], serde_json::json!(["T4"]));
+    assert_eq!(waves[3]["wave_id"], "W4");
+    assert_eq!(waves[3]["tasks"], serde_json::json!(["T5"]));
+
+    assert_eq!(json["data"]["current_ready_wave"], "W1");
+    assert_eq!(json["data"]["all_tasks_complete"], Value::Bool(false));
+    for wave in waves {
+        assert_eq!(wave["parallel_safe"], Value::Bool(true));
+        assert_eq!(wave["blockers"], serde_json::json!([]));
+    }
+}
+
+#[test]
+fn current_ready_wave_advances_when_t1_complete() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp, "demo");
+    seed_plan(&mission_dir, FIVE_TASK_PLAN);
+    set_task_status(&mission_dir, "T1", "complete");
+
+    let json = run_waves(&tmp, "demo");
+    // The wave list itself does NOT recompute — it stays structural.
+    let waves = json["data"]["waves"].as_array().unwrap();
+    assert_eq!(waves.len(), 4);
+    assert_eq!(waves[0]["tasks"], serde_json::json!(["T1"]));
+    // But current_ready_wave skips past the completed W1.
+    assert_eq!(json["data"]["current_ready_wave"], "W2");
+}
+
+#[test]
+fn exclusive_resource_collision_marks_wave_unsafe() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp, "demo");
+    let plan = r"mission_id: demo
+tasks:
+  - id: T1
+    title: Root
+    kind: code
+    depends_on: []
+  - id: T2
+    title: Branch A
+    kind: code
+    depends_on: [T1]
+    exclusive_resources: [shared-db]
+  - id: T3
+    title: Branch B
+    kind: code
+    depends_on: [T1]
+    exclusive_resources: [shared-db]
+";
+    seed_plan(&mission_dir, plan);
+    let json = run_waves(&tmp, "demo");
+    let waves = json["data"]["waves"].as_array().unwrap();
+    assert_eq!(waves[1]["wave_id"], "W2");
+    assert_eq!(waves[1]["parallel_safe"], Value::Bool(false));
+    let blockers = waves[1]["blockers"].as_array().unwrap();
+    assert!(
+        blockers.iter().any(|b| b == "exclusive_resource:shared-db"),
+        "blockers missing shared-db: {blockers:?}"
+    );
+}
+
+#[test]
+fn unknown_side_effects_marks_wave_unsafe() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp, "demo");
+    let plan = r"mission_id: demo
+tasks:
+  - id: T1
+    title: Root
+    kind: code
+    depends_on: []
+  - id: T2
+    title: Branch A
+    kind: code
+    depends_on: [T1]
+    unknown_side_effects: true
+  - id: T3
+    title: Branch B
+    kind: code
+    depends_on: [T1]
+";
+    seed_plan(&mission_dir, plan);
+    let json = run_waves(&tmp, "demo");
+    let waves = json["data"]["waves"].as_array().unwrap();
+    assert_eq!(waves[1]["wave_id"], "W2");
+    assert_eq!(waves[1]["parallel_safe"], Value::Bool(false));
+    let blockers = waves[1]["blockers"].as_array().unwrap();
+    assert!(
+        blockers.iter().any(|b| b == "unknown_side_effects:T2"),
+        "blockers missing unknown_side_effects:T2: {blockers:?}"
+    );
+}
+
+#[test]
+fn waves_on_fresh_mission_without_plan_lock() {
+    let tmp = TempDir::new().unwrap();
+    init_mission(&tmp, "demo");
+    // plan.locked is false straight out of init.
+    let json = run_waves(&tmp, "demo");
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["waves"], serde_json::json!([]));
+    assert_eq!(json["data"]["current_ready_wave"], Value::Null);
+    assert_eq!(json["data"]["all_tasks_complete"], Value::Bool(false));
+    assert!(json["data"]["note"].is_string());
+}
+
+#[test]
+fn graph_mermaid_emits_flowchart_with_all_nodes() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp, "demo");
+    seed_plan(&mission_dir, FIVE_TASK_PLAN);
+    let json = run_graph(&tmp, "demo", &["--format", "mermaid"]);
+    let mermaid = json["data"]["mermaid"].as_str().unwrap();
+    assert!(mermaid.starts_with("flowchart TD\n"), "got: {mermaid}");
+    for id in ["T1", "T2", "T3", "T4", "T5"] {
+        assert!(
+            mermaid.contains(&format!("{id}[\"")),
+            "mermaid missing node {id}:\n{mermaid}"
+        );
+    }
+    // Edges rendered.
+    assert!(mermaid.contains("T1 --> T2"));
+    assert!(mermaid.contains("T4 --> T5"));
+    // Class lines use snake_case tokens.
+    assert!(mermaid.contains("class T1 ready"));
+}
+
+#[test]
+fn graph_json_emits_nodes_and_edges() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp, "demo");
+    seed_plan(&mission_dir, FIVE_TASK_PLAN);
+    let json = run_graph(&tmp, "demo", &["--format", "json"]);
+    let graph = &json["data"]["graph"];
+    let nodes = graph["nodes"].as_array().unwrap();
+    let edges = graph["edges"].as_array().unwrap();
+    assert_eq!(nodes.len(), 5);
+    assert_eq!(edges.len(), 5);
+    let ids: Vec<&str> = nodes.iter().map(|n| n["id"].as_str().unwrap()).collect();
+    for id in ["T1", "T2", "T3", "T4", "T5"] {
+        assert!(ids.contains(&id), "nodes missing {id}: {ids:?}");
+    }
+    // Every node reports a status string.
+    assert!(nodes.iter().all(|n| n["status"].is_string()));
+}
+
+#[test]
+fn graph_out_flag_writes_file_and_reports_path() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp, "demo");
+    seed_plan(&mission_dir, FIVE_TASK_PLAN);
+    let out = tmp.path().join("graph.mmd");
+    let json = run_graph(
+        &tmp,
+        "demo",
+        &["--format", "mermaid", "--out", out.to_str().unwrap()],
+    );
+    assert_eq!(json["data"]["path"], out.to_string_lossy().as_ref());
+    let content = fs::read_to_string(&out).unwrap();
+    assert!(content.starts_with("flowchart TD\n"));
+    assert!(content.contains("T1 --> T2"));
+}


### PR DESCRIPTION
## Summary
- Adds `codex1 plan waves --json`: DAG-depth-based wave derivation (never stored). Uses STATE.json only to compute `current_ready_wave` and `all_tasks_complete`; wave list itself is structural. Flags `parallel_safe: false` on `exclusive_resources` collisions (`exclusive_resource:<name>`) and on `unknown_side_effects: true` (`unknown_side_effects:<task-id>`).
- Adds `codex1 plan graph --format <mermaid|dot|json> [--out <file>]`: renders the task DAG with status-driven styling. `--out` writes the chosen format to disk and returns `{ "path": ... }`; inline output goes under `data.mermaid` / `data.dot` / `data.graph`.
- Gates on `state.plan.locked == false` with an empty-waves note so work-in-progress YAML never surfaces `PLAN_INVALID`.
- Wires new arms into `PlanCmd` dispatch; `ChooseLevel`, `Scaffold`, and `Check` remain `NotImplemented` for sibling units (Unit 3 / Unit 4).

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green
- [x] Seeded-plan tests in `crates/codex1/tests/plan_waves.rs`:
  - 4+review-task DAG yields W1..W4 with correct tasks and default `parallel_safe: true`
  - Marking T1 complete moves `current_ready_wave` to W2 without reshaping the wave list
  - Shared `exclusive_resources: [shared-db]` marks W2 unsafe with the expected blocker
  - `unknown_side_effects: true` on a single task marks its wave unsafe
  - Fresh mission (plan unlocked) returns `waves: [], current_ready_wave: null` plus a note
  - `plan graph --format mermaid` starts with `flowchart TD`, contains every node and expected edges/classes
  - `plan graph --format json` emits structured `nodes`/`edges`
  - `plan graph --out <file>` writes the file and payload reports the path

🤖 Generated with [Claude Code](https://claude.com/claude-code)