### PR TITLE
Unit 8: cli-replan check + record

### DIFF
--- a/crates/codex1/src/cli/replan/check.rs
+++ b/crates/codex1/src/cli/replan/check.rs
@@ -1,0 +1,38 @@
+//! `codex1 replan check` — read-only trigger probe.
+
+use serde_json::{json, Value};
+
+use crate::cli::replan::triggers;
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::CliResult;
+use crate::core::mission::resolve_mission;
+use crate::state;
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+
+    let (required, reason) = match triggers::breach(&state) {
+        Some((target, count)) => (
+            true,
+            Value::String(format!(
+                "Target {target} has {count} consecutive dirty reviews"
+            )),
+        ),
+        None => (false, Value::Null),
+    };
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        json!({
+            "required": required,
+            "reason": reason,
+            "consecutive_dirty_by_target": state.replan.consecutive_dirty_by_target,
+            "triggered_already": state.replan.triggered,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/replan/mod.rs
+++ b/crates/codex1/src/cli/replan/mod.rs
@@ -1,9 +1,19 @@
-//! `codex1 replan` stub — owned by Phase B Unit 8.
+//! `codex1 replan` — detect and record replan decisions.
+//!
+//! `check` inspects `state.replan.consecutive_dirty_by_target` and
+//! reports whether the "six consecutive dirty reviews on the same
+//! active target" threshold has been reached. `record` mutates
+//! `state.replan`, supersedes referenced tasks, clears the plan lock,
+//! and transitions the mission back to `Phase::Plan`.
 
 use clap::Subcommand;
 
 use crate::cli::Ctx;
-use crate::core::error::{CliError, CliResult};
+use crate::core::error::CliResult;
+
+pub mod check;
+pub mod record;
+pub mod triggers;
 
 #[derive(Debug, Subcommand)]
 pub enum ReplanCmd {
@@ -13,17 +23,15 @@ pub enum ReplanCmd {
     Record {
         #[arg(long, value_name = "CODE")]
         reason: String,
+        /// Task id to mark `Superseded` (may be passed multiple times).
         #[arg(long, value_name = "TASK_ID")]
-        supersedes: Option<String>,
+        supersedes: Vec<String>,
     },
 }
 
-pub fn dispatch(cmd: ReplanCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        ReplanCmd::Check => "replan check",
-        ReplanCmd::Record { .. } => "replan record",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: ReplanCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        ReplanCmd::Check => check::run(ctx),
+        ReplanCmd::Record { reason, supersedes } => record::run(ctx, &reason, &supersedes),
+    }
 }

--- a/crates/codex1/src/cli/replan/record.rs
+++ b/crates/codex1/src/cli/replan/record.rs
@@ -1,0 +1,164 @@
+//! `codex1 replan record` — record a replan decision.
+//!
+//! Effects (non-dry-run):
+//! - Each `--supersedes <id>` task is set to `TaskStatus::Superseded` with
+//!   `superseded_by: Some("replan-<revision>")`.
+//! - `state.replan.consecutive_dirty_by_target` is cleared.
+//! - `state.replan.triggered = true` and `triggered_reason` is recorded.
+//! - `state.plan.locked = false` so `plan check` must re-run.
+//! - `state.phase = Phase::Plan` (unconditional).
+//! - One `replan.recorded` event is appended to EVENTS.jsonl.
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+
+use crate::cli::replan::triggers;
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::{
+    self,
+    schema::{MissionState, Phase, TaskStatus},
+};
+
+pub fn run(ctx: &Ctx, reason: &str, supersedes: &[String]) -> CliResult<()> {
+    if !triggers::ALLOWED_REASONS.contains(&reason) {
+        return Err(CliError::PlanInvalid {
+            message: format!("Unknown replan reason '{reason}'"),
+            hint: Some(format!(
+                "Use one of: {}.",
+                triggers::ALLOWED_REASONS.join(", ")
+            )),
+        });
+    }
+
+    let paths = resolve_mission(&ctx.selector(), true)?;
+
+    if ctx.dry_run {
+        let state = state::load(&paths)?;
+        if let Some(expected) = ctx.expect_revision {
+            if expected != state.revision {
+                return Err(CliError::RevisionConflict {
+                    expected,
+                    actual: state.revision,
+                });
+            }
+        }
+        validate_supersedes(&state, supersedes)?;
+        emit_result(&state.mission_id, state.revision, reason, supersedes, true);
+        return Ok(());
+    }
+
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        "replan.recorded",
+        json!({ "reason": reason, "supersedes": supersedes }),
+        |state| {
+            validate_supersedes(state, supersedes)?;
+            apply_replan(state, reason, supersedes);
+            Ok(())
+        },
+    )?;
+    emit_result(
+        &mutation.state.mission_id,
+        mutation.new_revision,
+        reason,
+        supersedes,
+        false,
+    );
+    Ok(())
+}
+
+fn emit_result(
+    mission_id: &str,
+    revision: u64,
+    reason: &str,
+    supersedes: &[String],
+    dry_run: bool,
+) {
+    let mut data = json!({
+        "reason": reason,
+        "supersedes": supersedes,
+        "phase_after": "plan",
+        "plan_locked": false,
+    });
+    if dry_run {
+        if let Value::Object(map) = &mut data {
+            map.insert("dry_run".to_string(), Value::Bool(true));
+        }
+    }
+    let env = JsonOk::new(Some(mission_id.to_string()), Some(revision), data);
+    println!("{}", env.to_pretty());
+}
+
+/// Verify every superseded id is present in `state.tasks` and is
+/// currently replaceable (not already `Superseded` or `Complete`).
+fn validate_supersedes(state: &MissionState, ids: &[String]) -> CliResult<()> {
+    let mut unknown: Vec<String> = Vec::new();
+    let mut not_supersedable: BTreeMap<String, String> = BTreeMap::new();
+
+    for id in ids {
+        match state.tasks.get(id) {
+            None => unknown.push(id.clone()),
+            Some(record) => match record.status {
+                TaskStatus::Complete | TaskStatus::Superseded => {
+                    not_supersedable.insert(id.clone(), status_label(&record.status));
+                }
+                _ => {}
+            },
+        }
+    }
+
+    if !unknown.is_empty() {
+        return Err(CliError::PlanInvalid {
+            message: format!("Unknown --supersedes task ids: {}", unknown.join(", ")),
+            hint: Some(
+                "Pass only task ids present in PLAN.yaml (and reflected in STATE.json)."
+                    .to_string(),
+            ),
+        });
+    }
+
+    if !not_supersedable.is_empty() {
+        let list: Vec<String> = not_supersedable
+            .iter()
+            .map(|(id, status)| format!("{id} ({status})"))
+            .collect();
+        return Err(CliError::PlanInvalid {
+            message: format!("Tasks cannot be superseded: {}", list.join(", ")),
+            hint: Some(
+                "Only Pending / Ready / InProgress / AwaitingReview tasks may be superseded."
+                    .to_string(),
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn apply_replan(state: &mut MissionState, reason: &str, supersedes: &[String]) {
+    let marker = format!("replan-{}", state.revision);
+    for id in supersedes {
+        if let Some(record) = state.tasks.get_mut(id) {
+            record.status = TaskStatus::Superseded;
+            record.superseded_by = Some(marker.clone());
+        }
+    }
+    state.replan.consecutive_dirty_by_target.clear();
+    state.replan.triggered = true;
+    state.replan.triggered_reason = Some(reason.to_string());
+    state.plan.locked = false;
+    state.phase = Phase::Plan;
+}
+
+/// Render a `TaskStatus` the same way serde would (snake_case), so error
+/// messages match the strings callers see in STATE.json.
+fn status_label(status: &TaskStatus) -> String {
+    serde_json::to_value(status)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{status:?}"))
+}

--- a/crates/codex1/src/cli/replan/triggers.rs
+++ b/crates/codex1/src/cli/replan/triggers.rs
@@ -1,0 +1,31 @@
+//! Pure helpers for the replan trigger rule.
+//!
+//! The only automatic replan trigger is "six consecutive dirty reviews
+//! on the same active target". `cli-review` increments the per-target
+//! counter; this module reads it.
+
+use crate::state::schema::{MissionState, TaskId};
+
+/// Minimum consecutive-dirty count that forces a replan.
+pub const DIRTY_THRESHOLD: u32 = 6;
+
+/// Allowed `--reason` codes for `replan record`.
+pub const ALLOWED_REASONS: &[&str] = &[
+    "six_dirty",
+    "scope_change",
+    "architecture_shift",
+    "risk_discovered",
+    "user_request",
+];
+
+/// Find the first target whose consecutive-dirty counter has reached the
+/// threshold. Returns the target id and its counter value.
+#[must_use]
+pub fn breach(state: &MissionState) -> Option<(TaskId, u32)> {
+    state
+        .replan
+        .consecutive_dirty_by_target
+        .iter()
+        .find(|(_, &count)| count >= DIRTY_THRESHOLD)
+        .map(|(id, &count)| (id.clone(), count))
+}

--- a/crates/codex1/tests/replan.rs
+++ b/crates/codex1/tests/replan.rs
@@ -1,0 +1,378 @@
+//! Integration tests for `codex1 replan check` and `codex1 replan record`.
+//!
+//! These tests drive the binary through `assert_cmd`, seeding STATE.json
+//! directly where the scenarios require pre-populated task records and
+//! dirty-review counters.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_demo(tmp: &TempDir, mission: &str) -> PathBuf {
+    let mission_dir = tmp.path().join("PLANS").join(mission);
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", mission])
+        .assert()
+        .success();
+    mission_dir
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(stdout).unwrap_or_else(|e| {
+        panic!("expected JSON stdout, got:\n{stdout}\nerror: {e}");
+    })
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    let raw = fs::read_to_string(mission_dir.join("STATE.json")).expect("state file readable");
+    serde_json::from_str(&raw).expect("state file parses")
+}
+
+fn write_state(mission_dir: &Path, state: &Value) {
+    let raw = serde_json::to_string_pretty(state).expect("state serializes");
+    fs::write(mission_dir.join("STATE.json"), raw).expect("state file writable");
+}
+
+/// Mutate the mission state in place via a closure so tests can seed
+/// tasks, counters, or flags without spinning up multiple CLI runs.
+fn patch_state<F: FnOnce(&mut Value)>(mission_dir: &Path, patch: F) {
+    let mut state = read_state(mission_dir);
+    patch(&mut state);
+    write_state(mission_dir, &state);
+}
+
+fn task(status: &str) -> Value {
+    json!({ "id": "", "status": status })
+}
+
+#[test]
+fn check_fresh_mission_reports_no_replan() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["replan", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["required"], false);
+    assert!(json["data"]["reason"].is_null());
+    assert_eq!(json["data"]["consecutive_dirty_by_target"], json!({}));
+    assert_eq!(json["data"]["triggered_already"], false);
+}
+
+#[test]
+fn check_reports_required_when_target_reaches_threshold() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    patch_state(&mission_dir, |state| {
+        state["replan"]["consecutive_dirty_by_target"] = json!({ "T4": 6 });
+    });
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["replan", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["required"], true);
+    let reason = json["data"]["reason"].as_str().expect("reason string");
+    assert!(reason.contains("T4"), "reason should name T4: {reason}");
+    assert_eq!(json["data"]["consecutive_dirty_by_target"]["T4"], 6);
+}
+
+#[test]
+fn check_reports_triggered_already() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    patch_state(&mission_dir, |state| {
+        state["replan"]["triggered"] = json!(true);
+        state["replan"]["triggered_reason"] = json!("six_dirty");
+    });
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["replan", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["triggered_already"], true);
+}
+
+#[test]
+fn record_six_dirty_supersedes_tasks_and_unlocks_plan() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    patch_state(&mission_dir, |state| {
+        state["phase"] = json!("execute");
+        state["plan"]["locked"] = json!(true);
+        state["replan"]["consecutive_dirty_by_target"] = json!({ "T2": 6 });
+        let mut t2 = task("in_progress");
+        t2["id"] = json!("T2");
+        let mut t5 = task("ready");
+        t5["id"] = json!("T5");
+        state["tasks"] = json!({ "T2": t2, "T5": t5 });
+    });
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "replan",
+            "record",
+            "--mission",
+            "demo",
+            "--reason",
+            "six_dirty",
+            "--supersedes",
+            "T2",
+            "--supersedes",
+            "T5",
+        ])
+        .output()
+        .expect("runs");
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["reason"], "six_dirty");
+    assert_eq!(json["data"]["supersedes"], json!(["T2", "T5"]));
+    assert_eq!(json["data"]["phase_after"], "plan");
+    assert_eq!(json["data"]["plan_locked"], false);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["phase"], "plan");
+    assert_eq!(state["plan"]["locked"], false);
+    assert_eq!(state["replan"]["triggered"], true);
+    assert_eq!(state["replan"]["triggered_reason"], "six_dirty");
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"], json!({}));
+    assert_eq!(state["tasks"]["T2"]["status"], "superseded");
+    assert_eq!(state["tasks"]["T5"]["status"], "superseded");
+    for id in ["T2", "T5"] {
+        let marker = state["tasks"][id]["superseded_by"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{id} missing superseded_by"));
+        assert!(
+            marker.starts_with("replan-"),
+            "{id} superseded_by should be a replan-<rev> marker: {marker}"
+        );
+    }
+
+    let events = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap();
+    let last = events.lines().last().expect("at least one event line");
+    let event: Value = serde_json::from_str(last).expect("event is JSON");
+    assert_eq!(event["kind"], "replan.recorded");
+    assert_eq!(event["payload"]["reason"], "six_dirty");
+    assert_eq!(event["payload"]["supersedes"], json!(["T2", "T5"]));
+}
+
+#[test]
+fn record_rejects_unknown_reason() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "replan",
+            "record",
+            "--mission",
+            "demo",
+            "--reason",
+            "invalid",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+}
+
+#[test]
+fn record_rejects_unknown_supersedes_id() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    patch_state(&mission_dir, |state| {
+        // No T99 in tasks.
+        let mut t1 = task("ready");
+        t1["id"] = json!("T1");
+        state["tasks"] = json!({ "T1": t1 });
+    });
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "replan",
+            "record",
+            "--mission",
+            "demo",
+            "--reason",
+            "six_dirty",
+            "--supersedes",
+            "T99",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    let message = json["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("T99"),
+        "message should mention T99: {message}"
+    );
+}
+
+#[test]
+fn record_rejects_supersedes_of_complete_task() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    patch_state(&mission_dir, |state| {
+        let mut t1 = task("complete");
+        t1["id"] = json!("T1");
+        state["tasks"] = json!({ "T1": t1 });
+    });
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "replan",
+            "record",
+            "--mission",
+            "demo",
+            "--reason",
+            "six_dirty",
+            "--supersedes",
+            "T1",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    let message = json["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("T1"),
+        "message should mention T1: {message}"
+    );
+    assert!(
+        message.to_lowercase().contains("cannot be superseded")
+            || message.to_lowercase().contains("superseded"),
+        "message should flag non-supersedable: {message}"
+    );
+}
+
+#[test]
+fn record_dry_run_does_not_mutate() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    patch_state(&mission_dir, |state| {
+        state["plan"]["locked"] = json!(true);
+        state["phase"] = json!("execute");
+        let mut t2 = task("in_progress");
+        t2["id"] = json!("T2");
+        state["tasks"] = json!({ "T2": t2 });
+    });
+    let before = read_state(&mission_dir);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "replan",
+            "record",
+            "--mission",
+            "demo",
+            "--reason",
+            "scope_change",
+            "--supersedes",
+            "T2",
+            "--dry-run",
+        ])
+        .output()
+        .expect("runs");
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["phase_after"], "plan");
+    assert_eq!(json["data"]["plan_locked"], false);
+
+    let after = read_state(&mission_dir);
+    assert_eq!(before, after, "state must not change on --dry-run");
+
+    // EVENTS.jsonl still empty.
+    let events = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap();
+    assert!(!events.contains("replan.recorded"), "events: {events}");
+}
+
+#[test]
+fn record_enforces_expect_revision() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "replan",
+            "record",
+            "--mission",
+            "demo",
+            "--reason",
+            "user_request",
+            "--expect-revision",
+            "999",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+    assert_eq!(json["retryable"], true);
+}
+
+#[test]
+fn check_after_record_shows_cleared_counters_and_triggered() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    patch_state(&mission_dir, |state| {
+        state["replan"]["consecutive_dirty_by_target"] = json!({ "T3": 6 });
+        let mut t3 = task("awaiting_review");
+        t3["id"] = json!("T3");
+        state["tasks"] = json!({ "T3": t3 });
+    });
+
+    cmd()
+        .current_dir(tmp.path())
+        .args([
+            "replan",
+            "record",
+            "--mission",
+            "demo",
+            "--reason",
+            "six_dirty",
+            "--supersedes",
+            "T3",
+        ])
+        .assert()
+        .success();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["replan", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["required"], false);
+    assert_eq!(json["data"]["consecutive_dirty_by_target"], json!({}));
+    assert_eq!(json["data"]["triggered_already"], true);
+}


### PR DESCRIPTION
## Summary

- `codex1 replan check --json` — read-only probe of `state.replan.consecutive_dirty_by_target`; reports `required` / `reason` / counters / `triggered_already`. Threshold is 6 consecutive dirty reviews on the same active target.
- `codex1 replan record --reason <code> [--supersedes <id>]... --json` — validates the reason (`six_dirty`, `scope_change`, `architecture_shift`, `risk_discovered`, `user_request`), supersedes referenced tasks (with a `replan-<revision>` marker), clears the dirty counters, flips `replan.triggered`, unlocks PLAN.yaml, and transitions back to `Phase::Plan`. Emits one `replan.recorded` event. Honors `--dry-run` and `--expect-revision`.
- `--supersedes` now accepts repeated uses via `Vec<String>` (the enum variant name stays, so `cli::mod` still compiles).

## Design notes

- Validation runs against `state.tasks` (populated by `plan check`) rather than re-parsing PLAN.yaml, keeping this unit in its domain and avoiding a second YAML reader.
- Both failure modes for `--supersedes` use `PLAN_INVALID` per the task's permission ("pick one and document"); unknown ids carry an "Unknown --supersedes task ids" message, while non-supersedable tasks carry a "Tasks cannot be superseded" message with their current status.
- The task explicitly authorizes phase/plan-lock mutations here, which is why this unit writes `state.phase` and `state.plan.locked` despite the schema doc listing them under other owners.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 23 passing (13 foundation + 10 replan)
- [x] 10-test replan matrix: fresh mission, threshold breach, triggered mirror, full record semantics (state, event payload, marker shape), invalid reason, unknown id, non-supersedable task, dry-run no-op, revision conflict, post-record check

Generated with Claude Code.