### PR TITLE
Unit 19: skill-autopilot

### DIFF
--- a/.codex/skills/autopilot/SKILL.md
+++ b/.codex/skills/autopilot/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: autopilot
+description: >
+  Take a Codex1 mission from start to terminal close autonomously, pausing only for genuine user
+  input (scope, risk, money, deploy, destructive operations). Use when the user asks to "just run
+  the whole thing" or wants the mission driven end-to-end. Composes $clarify, $plan, $execute,
+  $review-loop, and $close around `codex1 status --json` as the single source of truth. Handles
+  replans, repairs, mission-close review, and terminal close automatically.
+---
+
+# Autopilot
+
+## Overview
+
+`$autopilot` drives a Codex1 mission from clarify to terminal close without requiring the user to
+invoke each sub-skill by hand. The loop is simple:
+
+1. Read `codex1 status --json` (single source of truth).
+2. Dispatch on `next_action.kind` to the appropriate sub-skill or CLI call.
+3. Stop only on terminal completion, a `$close` pause, an error, or a pause trigger that requires
+   genuine user input.
+
+`$autopilot` never writes STATE.json, PLAN.yaml, or OUTCOME.md directly. Every mutation goes
+through the CLI.
+
+## Preconditions
+
+A mission directory must already exist. If the user has not initialized one, ask for a mission id
+and run:
+
+```bash
+codex1 init --mission <id>
+```
+
+Then begin the loop.
+
+## Main loop
+
+Each iteration re-reads status. Never cache verdicts between iterations.
+
+### Step 1 - Read status
+
+```bash
+codex1 --json status --mission <id>
+```
+
+Parse `verdict`, `next_action`, `loop`, `stop`, and `close_ready`. Ignore any chat-derived
+assumption about state; trust only the envelope.
+
+### Step 2 - Dispatch on `next_action.kind`
+
+| `next_action.kind`          | Autopilot action                                                |
+|-----------------------------|-----------------------------------------------------------------|
+| `clarify`                   | Invoke `$clarify`, then return to Step 1.                       |
+| `plan`                      | Choose level (see below), invoke `$plan`, return to Step 1.     |
+| `run_task` / `run_wave`     | Invoke `$execute` for one step, return to Step 1.               |
+| `run_review`                | Invoke `$review-loop` (planned task mode), return to Step 1.    |
+| `mission_close_review`      | Invoke `$review-loop` (mission-close mode), return to Step 1.   |
+| `repair`                    | Invoke `$execute` with the repair task, return to Step 1.       |
+| `replan`                    | Invoke `$plan replan`, return to Step 1.                        |
+| `close`                     | Confirm with the user, then `codex1 close complete`, then stop. |
+| `blocked`                   | Escalate to the user; do not loop.                              |
+| `closed`                    | Report terminal completion and stop.                            |
+
+The full verdict x next_action.kind dispatch table plus the pseudocode main loop with
+pause-on-`$close` handling live in `references/autopilot-state-machine.md`. Read it when a
+next_action shape is unfamiliar or when implementing the dispatch.
+
+### Step 3 - Honor `$close`
+
+Before every iteration, check whether the user has invoked `$close`. If yes, yield immediately and
+do NOT resume without explicit user agreement. `$close` is the discussion boundary; `$autopilot`
+must not fight it.
+
+## When to pause for user input (MUST)
+
+`$autopilot` MUST pause and hand control back to the user for:
+
+- **Scope changes** - adding features, retargeting outcome, or altering OUTCOME.md intent.
+- **Risk discovery** - architectural mismatch, security exposure, data-loss potential.
+- **Money / billing / API credits / deployments** - anything that spends money or ships artifacts
+  to users.
+- **Destructive operations** - force-push, deleting production data, irreversible migrations,
+  rewriting shared git history.
+- **External systems not scoped in OUTCOME.md** - integrations, third-party auth, new vendors.
+- **Any `blocked` verdict with a non-obvious resolution** - surface the status envelope and wait.
+
+When in doubt, pause. Never invent user preferences to unblock a loop.
+
+## Planning level
+
+When dispatch hits `plan`, `$autopilot` must choose a level before invoking `$plan`:
+
+- Default: `medium` for unambiguous missions.
+- Escalate to `hard` when any pause trigger above applies (risk, security, data loss, money,
+  deploy, destructive ops, architectural unknowns).
+- Use `light` only when the mission is explicitly small and local (e.g. a documentation tweak in
+  a single file, no architecture involved).
+
+Record the effective level via:
+
+```bash
+codex1 plan choose-level --mission <id> --level <light|medium|hard>
+```
+
+Allow effective-level escalation if `choose-level` reports a higher required level than
+requested.
+
+## Stop conditions
+
+Stop the loop when any of the following are true:
+
+- `verdict: terminal_complete` in status.
+- The user has invoked `$close` (pause, not terminate).
+- The CLI returns an error code that autopilot cannot safely retry (anything non-`retryable`).
+- A pause trigger above fires.
+
+## Safety
+
+`$autopilot` MUST NOT:
+
+- Invent user preferences that change scope, risk, money, deploy, or destructive operations.
+- Record review findings or verdicts; that belongs to `$review-loop`.
+- Bypass mission-close review.
+- Run `codex1 close complete` before `codex1 close check` reports `ready: true`.
+- Modify STATE.json, PLAN.yaml, or OUTCOME.md directly. Always go through the CLI.
+- Suppress Ralph stop pressure; respond to status, do not mute it.
+
+## Resources
+
+- `references/autopilot-state-machine.md` - complete verdict x next_action.kind dispatch table and
+  the pseudocode main loop with pause-on-`$close` handling. Read before implementing dispatch
+  logic or when a next_action shape is unfamiliar.

--- a/.codex/skills/autopilot/agents/openai.yaml
+++ b/.codex/skills/autopilot/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Autopilot"
+  short_description: "End-to-end Codex1 mission autopilot"
+  default_prompt: "Use $autopilot to take a Codex1 mission from clarify to terminal close."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/autopilot/references/autopilot-state-machine.md
+++ b/.codex/skills/autopilot/references/autopilot-state-machine.md
@@ -1,0 +1,134 @@
+# Autopilot State Machine
+
+Full dispatch table and pseudocode for `$autopilot`.
+
+Every iteration re-reads `codex1 status --json` and dispatches on the combination of `verdict`
+and `next_action.kind`. Trust the envelope; do not cache.
+
+## Dispatch table
+
+| verdict                         | next_action.kind         | Autopilot action                               |
+|---------------------------------|--------------------------|------------------------------------------------|
+| needs_user                      | clarify                  | `$clarify`                                     |
+| needs_user                      | plan                     | `$plan` (choose level, then invoke)            |
+| continue_required               | run_task                 | `$execute`                                     |
+| continue_required               | run_wave                 | `$execute`                                     |
+| continue_required               | run_review               | `$review-loop` (planned task mode)             |
+| continue_required               | repair                   | `$execute` (repair task)                       |
+| blocked                         | repair                   | `$execute` (repair task)                       |
+| blocked                         | replan                   | `$plan replan`                                 |
+| ready_for_mission_close_review  | mission_close_review     | `$review-loop` (mission-close mode)            |
+| mission_close_review_open       | mission_close_review     | `$review-loop` (mission-close mode)            |
+| mission_close_review_passed     | close                    | Confirm with user, then `codex1 close complete`|
+| terminal_complete               | closed                   | Stop; report terminal                          |
+| invalid_state                   | fix_state                | Escalate to user; do not auto-fix              |
+
+Any `verdict` + `next_action.kind` combination not in this table is a surface for user
+escalation, not for silent progress.
+
+## Pause-for-user triggers
+
+Independent of the dispatch table, `$autopilot` MUST pause when any of the following are detected
+during any step (pre-status, during sub-skill, on tool output, or on user message):
+
+- Scope change requested or discovered.
+- Risk discovery (security, data loss, architectural mismatch).
+- Money / billing / API credits / deployment steps.
+- Destructive operations (force-push, prod data deletion, irreversible migration).
+- External systems not scoped in OUTCOME.md.
+- `blocked` verdict with a non-obvious resolution.
+- User invoked `$close`.
+
+## Pseudocode main loop
+
+```text
+autopilot(mission_id):
+    loop:
+        if close_requested():
+            yield_to_user()        # $close -> pause; do not resume without explicit agreement
+            return
+
+        status = run("codex1 --json status --mission " + mission_id)
+
+        if status.ok is False:
+            if status.retryable:
+                continue           # transient (e.g. REVISION_CONFLICT) -> re-read
+            escalate(status)       # non-retryable CLI error
+            return
+
+        verdict = status.data.verdict
+        action  = status.data.next_action
+        kind    = action.kind
+
+        # Terminal / closed
+        if verdict == "terminal_complete" or kind == "closed":
+            report_terminal(status)
+            return
+
+        # Explicit close step: confirm with user, then complete
+        if kind == "close":
+            if status.data.close_ready is False:
+                escalate(status)   # status disagrees with itself -> user input
+                return
+            confirm_with_user("About to run `codex1 close complete`. Proceed?")
+            run("codex1 close complete --mission " + mission_id)
+            continue               # next iteration should observe terminal_complete
+
+        # Escalations we must not attempt to resolve
+        if verdict == "blocked" and kind not in {"repair", "replan"}:
+            escalate(status)
+            return
+        if verdict == "invalid_state" or kind == "fix_state":
+            escalate(status)
+            return
+
+        # Pause-for-user triggers fire here even if dispatch would otherwise proceed
+        if requires_genuine_user_input(status):
+            escalate(status)
+            return
+
+        # Normal dispatch
+        match kind:
+            case "clarify":
+                invoke("$clarify", mission_id)
+            case "plan":
+                level = choose_plan_level(status)           # medium default, escalate on risk
+                run("codex1 plan choose-level --mission " + mission_id + " --level " + level)
+                invoke("$plan", mission_id, level)
+            case "replan":
+                invoke("$plan", mission_id, mode="replan")
+            case "run_task" | "run_wave":
+                invoke("$execute", mission_id, action)      # one step
+            case "repair":
+                invoke("$execute", mission_id, action)      # repair task is still a task
+            case "run_review":
+                invoke("$review-loop", mission_id, mode="planned_task")
+            case "mission_close_review":
+                invoke("$review-loop", mission_id, mode="mission_close")
+            case _:
+                escalate(status)
+                return
+
+        # Loop back to Step 1: re-read status
+```
+
+## Pause-on-close handshake
+
+`close_requested()` must be checked at the top of every iteration. The user's `$close` invocation
+translates to `codex1 loop pause --json`; until `codex1 loop resume --json` runs (by explicit
+user decision), `$autopilot` yields. Do not inspect user chat to infer intent to resume.
+
+## Planning-level selection
+
+See the "Planning level" section in `SKILL.md`. In short: `medium` default, `hard` on any
+pause-for-user trigger, `light` only for explicitly small/local missions. Record via
+`codex1 plan choose-level`; honor CLI-returned escalation.
+
+## Do-not-do list
+
+- Do not run `codex1 close complete` unless `status.close_ready == true` and the most recent
+  `codex1 close check --json` returned `ready: true`.
+- Do not mutate STATE.json / PLAN.yaml / OUTCOME.md directly.
+- Do not record review verdicts; that is `$review-loop`'s job.
+- Do not attempt to resolve `invalid_state` automatically.
+- Do not resume after `$close` without explicit user agreement.


### PR DESCRIPTION
## Summary
- Add the `$autopilot` skill at `.codex/skills/autopilot/` composing `$clarify`, `$plan`, `$execute`, `$review-loop`, and `$close` around `codex1 status --json` as the single source of truth.
- `SKILL.md` documents the main loop (read status → dispatch on `next_action.kind` → honor `$close`), mandatory pause triggers (scope, risk, money, deploy, destructive, external systems, non-obvious blocked), planning-level selection (medium default, hard on risk, light only for small/local), stop conditions, and safety rules (no direct STATE/PLAN/OUTCOME writes, no review-record writes, no `close complete` before `close check` ready).
- `references/autopilot-state-machine.md` provides the full verdict × `next_action.kind` dispatch table (including `ready_for_mission_close_review`, `mission_close_review_open`, `mission_close_review_passed`, `invalid_state`), pause-for-user trigger list, and pseudocode main loop with `$close` handshake.
- `agents/openai.yaml` carries UI metadata and `policy.allow_implicit_invocation: true`.

## Test plan
- [x] `quick_validate.py` passes on the skill folder.
- [x] Only the three owned files exist: `SKILL.md`, `agents/openai.yaml`, `references/autopilot-state-machine.md`.
- [x] No touch to Rust, Cargo.toml, Makefile, docs/cli-contract-schemas.md, other skills, or scripts/.
- [x] Frontmatter description contains no angle brackets; name is hyphen-case `autopilot`.
- [x] Dispatch table matches the `status.next_action` shapes in `docs/cli-contract-schemas.md` and the autopilot flow in `docs/codex1-rebuild-handoff/01-product-flow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)