### PR TITLE
Unit 17: skill-review-loop

### DIFF
--- a/.codex/skills/review-loop/SKILL.md
+++ b/.codex/skills/review-loop/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: review-loop
+description: >
+  Run reviewer subagents for a planned review task or mission-close review and record findings through `codex1 review record`. Use when `codex1 task next` reports `kind: run_review` or `kind: mission_close_review`. Spawns one or more reviewer subagents per profile (code_bug_correctness, local_spec_intent, integration_intent, plan_quality, mission_close). Reviewers return NONE or P0/P1/P2 findings only. Main thread records the outcome. Triggers replan at six consecutive dirty reviews for the same active target.
+---
+
+# Review Loop
+
+## Overview
+
+`$review-loop` orchestrates reviewer subagents for a planned review task or the mission-close review. Reviewers return findings only (NONE or P0/P1/P2). They do not edit files, invoke Codex1 skills, or run CLI mutations. The main thread is the sole writer of mission truth: it records clean/dirty via `codex1 review record` (planned review) or `codex1 close record-review` (mission close).
+
+## Preconditions
+
+`codex1 task next --json` returned `kind: run_review` or `kind: mission_close_review`. If neither, stop and report status; do not spawn reviewers.
+
+## Required workflow (planned review task)
+
+1. **Start.** Run `codex1 --json review start T<id>` to open the review.
+
+2. **Fetch packet.** Run `codex1 --json review packet T<id>`. Note `data.review_profile` (or `profiles`), `data.targets`, `data.diffs`, `data.proofs`, and `data.mission_summary`.
+
+3. **Spawn reviewers.** Spawn one reviewer subagent per profile (see `references/reviewer-profiles.md` for spawn templates and models). Paste the packet into the prompt. Reviewers must return `NONE` or `P0/P1/P2` findings with evidence refs only — no edits, no CLI, no repair.
+
+4. **Record outcome on main thread.** Collect all reviewer responses.
+   - If every reviewer returned `NONE`:
+     ```bash
+     codex1 --json review record T<id> --clean --reviewers <csv>
+     ```
+   - If any reviewer returned `P0/P1/P2`: aggregate findings into a markdown file (e.g. `PLANS/<mission-id>/reviews/findings-T<id>-<timestamp>.md`), then:
+     ```bash
+     codex1 --json review record T<id> --findings-file <path> --reviewers <csv>
+     ```
+
+5. **Check replan.** Inspect `data.replan_triggered` on the record response. If true, hand off to `$plan replan`. Otherwise return control to `$execute`.
+
+## Required workflow (mission-close review)
+
+1. **Confirm readiness.** Run `codex1 --json close check`. Require `data.verdict == ready_for_mission_close_review`. If not, stop.
+
+2. **Spawn mission-close reviewers.** Spawn 1-2 reviewers with profiles `mission_close` and (optionally) `integration_intent`. The packet must include `OUTCOME.md`, `PLAN.yaml`, and the final `CLOSEOUT-preview` — see `references/reviewer-profiles.md` for templates.
+
+3. **Record outcome on main thread.**
+   - Clean: `codex1 --json close record-review --clean`
+   - Dirty: `codex1 --json close record-review --findings-file <path>`
+
+4. **Replan or close.** If mission-close review has gone dirty six times in a row, hand off to `$plan replan`. Otherwise, once clean, re-run `codex1 --json close check`; when `data.ready == true`, hand off to the user or `$close` for `codex1 close complete`.
+
+## Reviewer profiles
+
+| Profile | When | Model | Lanes |
+| --- | --- | --- | --- |
+| `code_bug_correctness` | Code-producing or code-heavy repair task | `claude-opus-4-7` high | 1-2 |
+| `local_spec_intent` | One task/spec versus intended behavior | `claude-opus-4-7` or `gpt-5.4` high | 1 |
+| `integration_intent` | Multi-task / wave / subsystem interaction | `gpt-5.4` high | 1 |
+| `plan_quality` | Plan critique before lock (hard plans) | `gpt-5.4` high or xhigh | 1-2 |
+| `mission_close` | Final mission-close review | `gpt-5.4` high | 2 for important missions |
+
+See `references/reviewer-profiles.md` for the spawn-prompt template per profile.
+
+## Reviewer standing instructions
+
+Every spawn prompt must begin with the standing reviewer block in `references/reviewer-profiles.md` (findings-only, no edits, no `codex1` mutations, no repairs, no marking clean anywhere). The main thread is the sole writer of mission truth. Reviewer writeback is forbidden.
+
+## Late-output categories
+
+`codex1 review record` classifies each record into one of:
+
+- `accepted_current` — recorded before the review boundary closed. Only this category moves the dirty counter.
+- `late_same_boundary` — arrived after current but within the same boundary revision.
+- `stale_superseded` — belongs to a superseded task/review boundary.
+- `contaminated_after_terminal` — arrived after mission terminal.
+
+`late_same_boundary`, `stale_superseded`, and `contaminated_after_terminal` records are appended to `EVENTS.jsonl` for audit but do not change mission truth. Do not retry a stale record by editing state directly; let the CLI classify.
+
+## Do not
+
+- Edit files on behalf of reviewers.
+- Record review results from inside a reviewer subagent — only the main thread records.
+- Replan from this skill — hand off to `$plan replan` when the replan trigger fires.
+- Close the mission from this skill — `$close` / `codex1 close complete` owns terminal.

--- a/.codex/skills/review-loop/agents/openai.yaml
+++ b/.codex/skills/review-loop/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Review Loop"
+  short_description: "Run reviewer subagents and record findings"
+  default_prompt: "Use $review-loop to run reviewer subagents and record clean/dirty findings."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/review-loop/references/reviewer-profiles.md
+++ b/.codex/skills/review-loop/references/reviewer-profiles.md
@@ -1,0 +1,165 @@
+# Reviewer Profiles and Spawn Templates
+
+One section per profile. Every spawn prompt begins with the standing instructions, then narrows to profile-specific scope. Reviewers return findings only.
+
+## Standing reviewer instructions (paste first in every spawn prompt)
+
+```text
+You are a Codex1 reviewer.
+
+Do not edit files.
+Do not invoke Codex1 skills.
+Do not run codex1 mutating commands (no `review record`, `task finish`, `close *`, etc.).
+Do not record mission truth.
+Do not perform repairs.
+Do not mark anything clean in files or CLI.
+
+You may:
+- Inspect files.
+- Inspect diffs provided in the packet.
+- Run safe read-only commands (ls, rg, cat, git log, git diff).
+- Run tests only if the packet explicitly authorises it.
+
+Return only:
+- NONE
+- or P0/P1/P2 findings with evidence refs (file:line) and concise rationale.
+
+Do not report P3 / future-work / nice-to-have issues unless explicitly asked.
+Do not propose alternate architecture unless the current implementation violates the locked outcome, spec, or review profile at P0/P1/P2 severity.
+```
+
+## Spawn template skeleton
+
+```text
+<standing instructions>
+
+You are reviewing <TARGET> for task <TASK_ID>.
+
+Mission summary:
+<mission_summary>
+
+Outcome excerpt:
+<relevant OUTCOME.md fields>
+
+Plan context:
+<task IDs, dependencies, why these tasks exist>
+
+Review target:
+<tasks / files / diffs / proofs from packet>
+
+Proof:
+<proof commands + results>
+
+Review profile: <profile>
+
+Scope:
+Only review the assigned target against the mission, outcome, plan, and profile.
+Do not review unrelated future work.
+
+Return:
+- NONE
+- or P0/P1/P2 findings with evidence refs and concise rationale.
+```
+
+## `code_bug_correctness`
+
+When: code-producing or code-heavy repair task.
+
+Model: `claude-opus-4-7`, reasoning `high`. Use 1-2 lanes for high-risk code.
+
+Profile-specific scope:
+
+```text
+Focus on:
+- Bugs, incorrect logic, wrong types, broken error handling.
+- Missing or incorrect tests for the asserted behavior.
+- Unsafe concurrency, race conditions, data loss, resource leaks.
+- Deviations between code and spec.
+
+Do not:
+- Propose style-only changes.
+- Rewrite architecture if the current structure meets the spec at P0/P1/P2 severity.
+```
+
+## `local_spec_intent`
+
+When: reviewing one task or spec against its intended behavior.
+
+Model: `claude-opus-4-7` or `gpt-5.4`, reasoning `high`. 1 lane.
+
+Profile-specific scope:
+
+```text
+Focus on:
+- Does the implementation satisfy the task spec exactly?
+- Are the proof artifacts valid evidence for the spec's success criteria?
+- Are there silent scope changes vs the spec?
+
+Do not:
+- Review integration effects; that is integration_intent's job.
+- Review architecture; that is plan_quality's job.
+```
+
+## `integration_intent`
+
+When: multi-task, wave, or subsystem interaction.
+
+Model: `gpt-5.4`, reasoning `high`. 1 lane. Escalate to `xhigh` for cross-system architecture.
+
+Profile-specific scope:
+
+```text
+Focus on:
+- Contracts between the listed tasks (types, JSON shapes, CLI envelopes).
+- Ordering / dependency assumptions implied by the packet.
+- Regressions in sibling subsystems introduced by the reviewed tasks.
+- Cross-cutting concerns: state transitions, event ordering, error codes.
+
+Do not:
+- Re-review individual task correctness if already covered by code_bug_correctness.
+```
+
+## `plan_quality`
+
+When: plan critique before lock, especially hard plans.
+
+Model: `gpt-5.4`, reasoning `high` or `xhigh`. 1-2 lanes.
+
+Profile-specific scope:
+
+```text
+Focus on:
+- Missing tasks needed to satisfy OUTCOME.md.
+- Dangling or cyclic dependencies.
+- Review tasks missing for risky targets.
+- Unrealistic proof strategies.
+- Hard-plan evidence gaps (no explorer / advisor / plan review recorded when required).
+
+Do not:
+- Propose a different architecture unless the plan demonstrably fails the outcome at P0/P1/P2 severity.
+```
+
+## `mission_close`
+
+When: final mission-close review.
+
+Model: `gpt-5.4`, reasoning `high`. 2 lanes for important missions.
+
+Profile-specific scope:
+
+```text
+Focus on:
+- Does the mission as-built match OUTCOME.md (must_be_true, success_criteria, non_goals)?
+- Are all planned review tasks clean and non-superseded?
+- Does CLOSEOUT-preview honestly describe the final state?
+- Are there unresolved blockers, unratified assumptions, or quietly dropped requirements?
+
+Packet includes:
+- OUTCOME.md
+- PLAN.yaml (final)
+- CLOSEOUT-preview
+- Proof index
+
+Do not:
+- Reopen settled planned reviews unless you find P0/P1/P2 evidence of a mission-level failure.
+```


### PR DESCRIPTION
## Summary
- Adds the `$review-loop` skill at `.codex/skills/review-loop/`.
- Spawns reviewer subagents per profile (code_bug_correctness, local_spec_intent, integration_intent, plan_quality, mission_close), collects findings on the main thread, and records clean/dirty via `codex1 review record` (planned) or `codex1 close record-review` (mission close).
- Reviewers are findings-only (NONE | P0/P1/P2). Reviewer writeback is forbidden; only the main thread writes mission truth.
- `references/reviewer-profiles.md` holds the paste-ready standing reviewer block plus per-profile scope and model guidance.

## Test plan
- [x] `quick_validate.py` on `.codex/skills/review-loop/` passes.
- [x] Only `SKILL.md`, `agents/openai.yaml`, and `references/reviewer-profiles.md` exist under the skill.
- [x] SKILL.md references mirror the CLI contract in `docs/cli-contract-schemas.md` (review record envelope, late-output categories, replan trigger at six consecutive dirty).
- [x] No changes outside `.codex/skills/review-loop/`.

Generated with [Claude Code](https://claude.com/claude-code)