### PR TITLE
Unit 15: skill-plan

### DIFF
--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: plan
+description: >
+  Create a full Codex1 mission plan with a task DAG at the chosen level (light, medium, hard). Use when OUTCOME.md is ratified but PLAN.yaml is not yet locked, when the user explicitly asks to plan, or when a replan is required. Runs `codex1 plan choose-level`, scaffolds PLAN.yaml, fills architecture + task DAG + specs + review tasks + mission-close criteria, and validates with `codex1 plan check` before locking. At hard level, spawns explorer/advisor/plan-reviewer subagents for evidence and critique.
+---
+
+# Plan
+
+## Overview
+
+`$plan` produces a full mission plan for Codex1, not only a DAG. The output is a locked `PLAN.yaml` under `PLANS/<mission-id>/` that `codex1 plan check` accepts, plus one `specs/T<id>/SPEC.md` per executable or review task. The plan captures outcome interpretation, architecture, task DAG, proof strategy, planned review tasks, and mission-close criteria.
+
+`$plan` does not execute tasks, does not record review findings, and does not close the mission.
+
+## Preconditions
+
+Before running `$plan`:
+
+- `PLANS/<mission-id>/OUTCOME.md` exists and is ratified.
+- `codex1 --json status` shows `outcome.ratified: true` (verdict is not `needs_user` for the outcome).
+
+If the outcome is not ratified, stop and hand off to `$clarify`.
+
+## Required workflow
+
+### 1. Choose planning level
+
+```bash
+codex1 --json plan choose-level --level <light|medium|hard>
+```
+
+Record both `requested_level` and `effective_level` from the envelope. Escalate to `hard` when the mission touches any of:
+
+- global hooks or mission-close behavior
+- destructive actions, secrets, money, or external deploys
+- multi-agent coordination or role boundaries
+- architecture that spans subsystems
+- new CLI contracts or schema changes
+
+When escalating, pass the escalated level explicitly on the next command and include an `escalation_reason` string in the plan.
+
+### 2. Scaffold PLAN.yaml
+
+```bash
+codex1 --json plan scaffold --level <effective-level>
+```
+
+This writes a `PLAN.yaml` skeleton with fill markers and creates `specs/` placeholders. Do not edit `STATE.json` or `EVENTS.jsonl` directly.
+
+### 3. Fill PLAN.yaml
+
+Required sections (canonical shape in `docs/codex1-rebuild-handoff/03-planning-artifacts.md`):
+
+```yaml
+mission_id: <id>
+planning_level:
+  requested: <level>
+  effective: <level>
+  escalation_reason: "..."   # only when effective != requested
+
+outcome_interpretation:
+  summary: |
+    Concrete restatement of what the mission will deliver.
+
+architecture:
+  summary: |
+    How the system will be shaped. Name the subsystems, interfaces, and data flows.
+  key_decisions:
+    - "..."
+
+planning_process:
+  evidence:
+    - kind: explorer | advisor | docs_lookup | plan_review | direct_reasoning
+      actor: "<id>"
+      summary: "..."
+      required_for_hard: true   # set true on hard-level missions
+
+tasks:
+  # Executable task (design | code | docs | test | research | repair):
+  - id: T1
+    title: "..."
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+    read_paths: []
+    write_paths: []
+    exclusive_resources: []
+    unknown_side_effects: false
+    acceptance:
+      - "..."
+    proof:
+      - "..."
+
+  # Review task:
+  - id: T2
+    title: "Review ..."
+    kind: review
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+    review_target:
+      tasks: [T1]
+    review_profiles:
+      - code_bug_correctness
+      - integration_intent
+
+risks:
+  - risk: "..."
+    mitigation: "..."
+
+mission_close:
+  criteria:
+    - "..."
+```
+
+Fill every section. No fill markers, no empty required fields.
+
+### 4. Hard-level evidence (hard only)
+
+On `hard`, spawn subagents and record at least one `explorer` (if repo context is unclear), one `advisor`, and one `plan_review` entry before locking. Read `references/hard-planning-evidence.md` for ready-to-paste spawn prompts and model choices.
+
+### 5. Write task SPECs
+
+For every executable task, write `specs/T<id>/SPEC.md` with:
+
+- Task goal.
+- Relevant context and references.
+- Allowed read/write paths.
+- Implementation steps or notes.
+- Acceptance criteria.
+- Proof commands.
+- Review expectations.
+
+For review tasks, SPEC.md lists `review_target.tasks`, the review profiles to run, and how reviewers should interpret the target (what "clean" means for this boundary).
+
+### 6. Validate with CLI
+
+```bash
+codex1 --json plan check
+```
+
+If the envelope returns `PLAN_INVALID`, `DAG_CYCLE`, or `DAG_MISSING_DEP`, read `context` to find the bad task, dependency, or cycle. Repair and re-run until the envelope is `ok: true`. Only a passing `plan check` locks the plan.
+
+### 7. Sanity-check the DAG (optional)
+
+```bash
+codex1 --json plan graph --format mermaid
+codex1 --json plan waves
+```
+
+Confirm the derived waves match the intended execution order and that no wave is unsafely parallel.
+
+## Task DAG rules
+
+Every task has:
+
+- `id` — `T1`, `T2`, ..., unique across the mission, never reused (replans append new IDs).
+- `title` — one short line.
+- `kind` — one of `design | code | docs | test | research | repair | review`.
+- `depends_on` — explicit array. Use `[]` for roots.
+- `spec` — path to `specs/T<id>/SPEC.md`.
+
+Executable tasks (`design | code | docs | test | research | repair`) additionally declare:
+
+- `read_paths`, `write_paths`, `exclusive_resources`, `unknown_side_effects`.
+- `acceptance` — testable criteria.
+- `proof` — commands or artifacts that prove acceptance.
+- Any of `generated_paths`, `shared_state`, `commands`, `external_services`, `env_mutations`, `package_manager_mutation`, `schema_or_migration` that apply.
+
+Review tasks declare `review_target.tasks` (the tasks under review) and `review_profiles` (subset of `code_bug_correctness`, `local_spec_intent`, `integration_intent`, `plan_quality`, `mission_close`). Review tasks must not declare `write_paths`.
+
+See `references/dag-quality.md` for DAG design heuristics (root independence, exclusive resources, parallel-safe waves, review placement).
+
+## Planned review tasks
+
+Insert a review task in the DAG:
+
+- After any meaningful code slice that lands a user-facing capability.
+- At the end of a wave of tasks that interact with shared state.
+- At subsystem completion boundaries.
+- After high-risk workflow changes (hooks, mission-close, destructive actions, secrets).
+- At integration boundaries between subsystems.
+
+Mission-close review is mandatory at the end even if no review task is listed there. Include a final review task or rely on the mission-close loop, but make it explicit in `mission_close.criteria`.
+
+## Replan
+
+If `$plan` is invoked during execution for a replan:
+
+- Append new tasks with new IDs; never reuse IDs.
+- Record `codex1 replan record --supersedes <id>` for each task that is being superseded.
+- Re-run `codex1 --json plan check` before locking.
+- Update `planning_process.evidence` with a new `advisor` or `plan_review` entry that explains why the replan is needed.
+
+## Do not
+
+- Do not execute tasks from `$plan`. Hand off to `$execute`.
+- Do not record review findings from `$plan`. That belongs to `$review-loop` and the main thread.
+- Do not close the mission. That belongs to `$close` and `codex1 close complete`.
+- Do not store waves inside `PLAN.yaml`. Waves are derived.
+- Do not edit `STATE.json` or `EVENTS.jsonl` directly.
+
+## Resources
+
+- `references/hard-planning-evidence.md` — spawn prompt templates for explorer, advisor, and plan-reviewer subagents, with model recommendations.
+- `references/dag-quality.md` — DAG design heuristics for root tasks, parallel-safe waves, exclusive resources, and review-task placement.

--- a/.codex/skills/plan/agents/openai.yaml
+++ b/.codex/skills/plan/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Plan"
+  short_description: "Create a full Codex1 mission plan with a task DAG"
+  default_prompt: "Use $plan to scaffold, fill, and lock PLAN.yaml for the active mission."
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/plan/references/dag-quality.md
+++ b/.codex/skills/plan/references/dag-quality.md
@@ -1,0 +1,75 @@
+# DAG Quality
+
+Heuristics for designing the Codex1 task DAG inside `PLAN.yaml`. Read this when the DAG is more than a straight line, when parallel-safe waves matter, or when `codex1 plan check` keeps returning `PLAN_INVALID`.
+
+## Root tasks
+
+Root tasks have `depends_on: []`. Keep them independent. If two roots share files, one of them is not really a root; give it an explicit dependency or merge them.
+
+- Prefer design/research tasks as roots when architecture is open.
+- Prefer a single schema/contract root when multiple downstream coders need the same interface.
+- Avoid more than three or four roots unless the mission is genuinely parallel at the source.
+
+## Wave shape
+
+Waves are derived by `codex1 plan waves` from `depends_on`. A wave includes every task whose dependencies are satisfied and whose state is ready. Design the DAG so each wave is deliberate.
+
+- A wave should either be parallel-safe (no shared `write_paths`, no shared `exclusive_resources`, no overlapping `schema_or_migration`) or explicitly serial (tasks lined up by dependency).
+- Two tasks in the same wave that both write to the same crate or the same module are usually a DAG bug, not parallelism. Split them serially or merge them.
+- Use `exclusive_resources` to mark shared identities that are not files — a stored schema, a global lockfile, a migration id, a daemon port.
+
+## Executable task fields
+
+Every executable task should answer four questions:
+
+1. What does it read? (`read_paths`)
+2. What does it write? (`write_paths`)
+3. What resources does it block? (`exclusive_resources`, `schema_or_migration`, `package_manager_mutation`, `env_mutations`)
+4. How do we know it worked? (`acceptance`, `proof`)
+
+Leaving any of these blank when they apply causes `plan check` failures, unsafe parallelism, or unreviewable work.
+
+## Review task placement
+
+Review tasks do not advance the work. They gate correctness. Place them:
+
+- After a code wave that lands a user-facing capability.
+- Before a wave that depends on unverified behavior from the previous wave.
+- At every subsystem seam.
+- After any task that is marked `unknown_side_effects: true`.
+- Before mission close (always).
+
+A review task's `depends_on` must include every task in `review_target.tasks`. Tasks downstream of a planned review should depend on the review task, not on the reviewed work directly, so review-clean gating works.
+
+## Replans
+
+When replanning, append new tasks with new IDs. Never reuse an ID. Use `codex1 replan record --supersedes <id>` for tasks being abandoned. The DAG can contain superseded tasks; the CLI excludes them from ready waves.
+
+- Name the failure class in `planning_process.evidence` (advisor or plan_review entry).
+- Make the new tasks smaller and more specific than the ones they replace; replans that look like the original plan repeat the original failures.
+
+## Common failures and fixes
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `DAG_CYCLE` | A downstream task appeared in an upstream `depends_on`. | Trace the cycle via `plan graph --format mermaid`; remove the back-edge. |
+| `DAG_MISSING_DEP` | `depends_on` lists a task id that does not exist. | Fix typo, or add the missing task. |
+| Wave has conflicting writes | Two tasks share `write_paths` or `exclusive_resources`. | Serialize by adding a dependency, or merge tasks. |
+| Reviewer cannot verify | Task lacks `proof` or `acceptance`. | Add explicit commands and testable criteria. |
+| Replan triggers repeatedly | Review target is too broad. | Split the work into smaller tasks with tighter review boundaries. |
+
+## Sanity check before lock
+
+Run all three:
+
+```bash
+codex1 --json plan check
+codex1 --json plan graph --format mermaid
+codex1 --json plan waves
+```
+
+Read the mermaid graph visually and confirm:
+
+- Every leaf of the DAG is either a review task or a mission-close-criteria contributor.
+- Every review task sits on the critical path of the work it is reviewing.
+- No wave is larger than the main thread can orchestrate comfortably.

--- a/.codex/skills/plan/references/hard-planning-evidence.md
+++ b/.codex/skills/plan/references/hard-planning-evidence.md
@@ -1,0 +1,190 @@
+# Hard Planning Evidence
+
+Spawn prompt templates for the three subagent roles that `$plan` uses during `hard` planning. Copy the block, substitute the bracketed placeholders, and run the subagent. Record each result as a `planning_process.evidence` entry in `PLAN.yaml` with `kind`, `actor`, `summary`, and `required_for_hard: true`.
+
+Model choices follow `docs/codex1-rebuild-handoff/04-roles-models-prompts.md`. Do not use `mini` models for advisor critique or plan review.
+
+## Explorer
+
+Use an explorer when repo context for the mission is unclear (new subsystems, unfamiliar crates, existing code that will be touched). Do not use an explorer for pure product judgment.
+
+Recommended model: `gpt-5.4-mini` with `high` reasoning. Escalate to `gpt-5.4` if architecture judgment is needed during the exploration.
+
+Standing instructions:
+
+```text
+You are a Codex1 explorer.
+
+Search and read only.
+Do not edit files.
+Do not record mission truth.
+Do not perform formal review.
+
+Return a concise context summary with file refs or source refs.
+```
+
+Spawn prompt:
+
+```text
+You are exploring for a Codex1 mission plan.
+
+Target subsystem / area:
+<name the paths, crates, commands, or docs to map>
+
+Mission context (short):
+<one-paragraph summary of what the mission will change>
+
+Scope:
+- Map the existing shape of the target area.
+- Identify interfaces, data flow, and shared resources.
+- Note risks, unknowns, and anything that looks fragile.
+
+Return:
+- File references (absolute paths, key line ranges).
+- One-paragraph architecture summary.
+- Open questions the planner should resolve.
+
+Do not propose a plan. Do not edit files.
+```
+
+Record the evidence entry:
+
+```yaml
+- kind: explorer
+  actor: explorer-1
+  summary: "Mapped <area>. Key paths: ... Notable risks: ..."
+  required_for_hard: true
+```
+
+## Advisor / CritiqueScout
+
+Use an advisor before locking a hard plan, and again if the plan looks overcomplicated or review findings keep recurring.
+
+Recommended model: `gpt-5.4` with `high` reasoning. Use `xhigh` before hard-plan lock or mission-close.
+
+Standing instructions:
+
+```text
+You are a Codex1 advisor.
+
+Do not edit files.
+Do not record mission truth.
+Do not perform formal review.
+
+Critique the current approach, name risks, suggest simplifications, and say whether to continue, repair, or replan.
+
+Your output is advice, not review evidence.
+```
+
+Spawn prompt:
+
+```text
+You are advising on a Codex1 mission plan.
+
+Mission goal:
+<concise mission destination>
+
+Outcome excerpt:
+<key must-be-true and success-criteria entries>
+
+Current plan draft:
+<paste the draft PLAN.yaml, or the sections under critique>
+
+Focus:
+- Name the top three risks in this plan.
+- Name any task, dependency, or review boundary that is underspecified.
+- Suggest simplifications; mark any task that can be cut or merged.
+- Verdict: continue | repair | replan, with one-paragraph rationale.
+
+Do not rewrite the plan. Do not replace tasks. Return advice only.
+```
+
+Record the evidence entry:
+
+```yaml
+- kind: advisor
+  actor: advisor-1
+  summary: "Advised <continue|repair|replan>. Main risks: ... Suggested cuts: ..."
+  required_for_hard: true
+```
+
+## Plan reviewer
+
+Use a plan reviewer just before locking the plan. The reviewer finds structural problems the planner missed.
+
+Recommended model: `gpt-5.4` with `high` reasoning; `xhigh` for high-stakes missions.
+
+Standing reviewer instructions apply (do not edit, do not record, return findings only):
+
+```text
+You are a Codex1 reviewer running the plan_quality profile.
+
+Do not edit files.
+Do not invoke Codex1 skills.
+Do not record mission truth.
+
+Return only:
+- NONE
+- or P0/P1/P2 findings with evidence refs and concise rationale.
+```
+
+Spawn prompt:
+
+```text
+You are reviewing a Codex1 PLAN.yaml under the plan_quality profile.
+
+Mission goal:
+<concise mission destination>
+
+Outcome excerpt:
+<must-be-true and success-criteria entries>
+
+Plan draft:
+<paste PLAN.yaml>
+
+Look for:
+- Missing or unreachable dependencies.
+- Duplicate or reused task IDs.
+- Tasks without read_paths / write_paths / proof when they should have them.
+- Missing review tasks at subsystem boundaries, after risky waves, at integration seams.
+- Hard-level missions lacking at least one explorer, advisor, and plan_review evidence entry.
+- Acceptance criteria that are not testable.
+- Mission-close criteria that do not match success_criteria in OUTCOME.md.
+
+Return:
+- NONE, or
+- P0/P1/P2 findings with the task ID or section ref, the evidence, and the reason.
+
+Do not propose replacement tasks. Do not edit.
+```
+
+Record the evidence entry:
+
+```yaml
+- kind: plan_review
+  actor: plan-reviewer-1
+  summary: "Plan review: <NONE|N findings>. Key finding(s): ..."
+  required_for_hard: true
+```
+
+## Docs lookup (when external APIs or libraries matter)
+
+If the mission depends on external docs (APIs, library upgrades, protocol changes), add a docs_lookup evidence entry. Use `$find-docs` or the project-standard docs skill. Record the source URLs or fetched file paths in the summary.
+
+```yaml
+- kind: docs_lookup
+  actor: find-docs
+  summary: "Confirmed <API/library> behavior at <version>. Source: <url>."
+  required_for_hard: true
+```
+
+## Acceptance for hard-level evidence
+
+Before running `codex1 --json plan check`, confirm `planning_process.evidence` includes:
+
+- At least one `advisor` entry (always).
+- At least one `plan_review` entry (always).
+- At least one `explorer` entry, unless the planner can justify in the plan why repo context was already clear.
+- A `docs_lookup` entry whenever external docs materially drive decisions.
+
+Low-effort evidence entries defeat the purpose. Summaries should be specific enough that a future Codex thread reading the plan knows what was checked.


### PR DESCRIPTION
## Summary

Adds the `$plan` skill. Runs `codex1 plan choose-level` → `plan scaffold` → task-DAG authorship → `plan check` to lock.

- `SKILL.md` — frontmatter only (name + description). Body lists required workflow, DAG rules, review-task insertion guidance, replan rules, and a do-not list.
- `agents/openai.yaml` — `default_prompt: "Use \$plan to scaffold, fill, and lock PLAN.yaml for the active mission."`
- `references/hard-planning-evidence.md` — ready-to-paste explorer / advisor / plan-reviewer spawn templates.
- `references/dag-quality.md` — concise failure/fix table and DAG design heuristics.

## Test plan
- [x] `quick_validate.py .codex/skills/plan` passes.
- [ ] Manual: ratify an OUTCOME, spawn a subagent with "use \$plan at hard level" and confirm it runs `codex1 plan choose-level --level hard`, scaffolds, fills PLAN.yaml, and calls `plan check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)