### PR TITLE
Unit 13: install + user docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,125 @@
 # Codex1
 
-Skills-first native Codex workflow harness.
+Codex1 is a skills-first native Codex workflow. You invoke one of six public skills — `$clarify`, `$plan`, `$execute`, `$review-loop`, `$close`, `$autopilot` — and the skill drives a small deterministic `codex1` CLI on rails: the CLI validates artifacts, records mission state, derives execution waves, and emits stable JSON for Ralph, a tiny Stop hook that only reads `codex1 status --json`. All mission truth lives in visible files under `PLANS/<mission-id>/`. There is no hidden `.ralph/` state, no caller-identity enforcement, and no stored waves.
 
-Codex1 turns long-running Codex missions (clarify → plan → execute → review → close) into visible, auditable work. You invoke one of six public skills — `$clarify`, `$plan`, `$execute`, `$review-loop`, `$close`, `$autopilot` — and they drive a small deterministic `codex1` CLI that validates, records, and projects mission state.
+> **Build state.** Phase B features land as their PRs merge. Foundation (`init`, `doctor`, `hook snippet`, `status`) is already wired. Phase B commands (`outcome`, `plan`, `task`, `review`, `replan`, `loop`, `close`) currently return `NOT_IMPLEMENTED`; the clap tree is complete, so `codex1 --help` shows the full surface today.
 
-Ralph, the stop guard, only reads `codex1 status --json`. There is no hidden `.ralph/` state, no caller-identity enforcement, and no stored waves.
-
-> **Build state:** this is the Foundation cut. Phase B feature commands (`outcome`, `plan`, `task`, `review`, `replan`, `loop`, `close`, full `status`) are scaffolded and return `NOT_IMPLEMENTED`. Phase B PRs implement them.
-
-## Install
+## Quick start
 
 ```bash
-git clone https://github.com/joel-nilsson/codex1 && cd codex1
-make install-local                 # builds release + copies to ~/.local/bin/codex1
+make install-local           # builds release + copies to ~/.local/bin/codex1
 export PATH="$HOME/.local/bin:$PATH"
-cd /tmp && command -v codex1       # verify from outside the source folder
-codex1 --help
-codex1 doctor                      # never crashes; reports CLI health as JSON
+codex1 --help                # shows the full command tree
+codex1 --json doctor         # health check; never crashes
+codex1 --json init --mission demo   # creates PLANS/demo/
 ```
 
-## Minimum verification
+Verify the install from outside the source folder. See [`docs/install-verification.md`](docs/install-verification.md) for the `/tmp` recipe.
+
+## Skills
+
+The six public skills are the user-facing product. Each is invoked by its `$` name in a Codex session.
+
+| Skill | Purpose |
+| --- | --- |
+| `$clarify` | Interview the user until `OUTCOME.md` is ratifiable, then ratify it. |
+| `$plan` | Produce a full mission plan with a valid task DAG; lock it with `codex1 plan check`. |
+| `$execute` | Run the next ready task or parallel-safe wave from the DAG. |
+| `$review-loop` | Orchestrate reviewer subagents for a planned review task or mission-close review; record outcomes via `codex1 review record`. |
+| `$close` | Pause the active loop so the user can discuss without Ralph forcing continuation. |
+| `$autopilot` | Compose the whole manual flow end-to-end, pausing for genuine user input. |
+
+The skills ship from Phase B under `.codex/skills/`. The workflow each skill drives is documented in [`docs/codex1-rebuild-handoff/01-product-flow.md`](docs/codex1-rebuild-handoff/01-product-flow.md).
+
+## Manual CLI flow
+
+For users (or automation) driving the mission without skills, the end-to-end CLI sequence is:
 
 ```bash
-make verify-contract    # fmt + clippy + cargo test + install-local + smoke tests
+codex1 init --mission m1
+# edit PLANS/m1/OUTCOME.md
+codex1 outcome check --mission m1
+codex1 outcome ratify --mission m1
+
+codex1 plan choose-level --mission m1 --level medium
+codex1 plan scaffold --mission m1 --level medium
+# edit PLANS/m1/PLAN.yaml
+codex1 plan check --mission m1
+codex1 plan waves --mission m1
+
+codex1 task next --mission m1
+codex1 task start T1 --mission m1
+# do the work; write PLANS/m1/specs/T1/PROOF.md
+codex1 task finish T1 --proof PLANS/m1/specs/T1/PROOF.md --mission m1
+
+# repeat for each task; planned review tasks use `review packet` + `review record`.
+
+codex1 close check --mission m1
+codex1 close complete --mission m1
 ```
 
-## Try a mission (Foundation can do this much)
+Every mutating command accepts `--expect-revision <N>` for strict-equality stale-writer protection. Every command supports `--json` (default), `--help`, `--mission <id>`, and `--repo-root <path>`. Per-command shapes and error codes are in [`docs/cli-reference.md`](docs/cli-reference.md).
+
+## Visible mission files
+
+A mission is everything under `PLANS/<mission-id>/`. `OUTCOME.md` is the clarified destination; `PLAN.yaml` is the route and task DAG; `STATE.json` is the operational state (CLI-owned, never edited by hand); `EVENTS.jsonl` is the append-only audit log; `specs/T<id>/{SPEC,PROOF}.md` are task-local; `reviews/*.md` are main-thread-recorded review findings; `CLOSEOUT.md` is the terminal summary.
+
+File-by-file ownership, mutation protocol, revision discipline, and late-output vocabulary are in [`docs/mission-anatomy.md`](docs/mission-anatomy.md).
+
+## Ralph stop hook
+
+Ralph is tiny. It runs `codex1 status --json` and blocks the Stop event iff the loop is active, not paused, and `stop.allow` is false. Ralph does not read plan or review files, does not manage subagents, and does not keep its own state.
+
+Print the wiring one-liner:
 
 ```bash
-cd /tmp && mkdir demo && cd demo
-codex1 init --mission demo          # creates PLANS/demo/ with STATE.json, OUTCOME.md, PLAN.yaml
-cat PLANS/demo/STATE.json           # revision:0, phase:"clarify"
-codex1 status --mission demo        # verdict:"needs_user"; stop.allow:true
+codex1 --json hook snippet
 ```
 
-Further commands (`codex1 outcome …`, `codex1 plan …`, etc.) land in Phase B. The clap tree is already wired, so `codex1 --help` shows the full command surface today.
+The shell script and its install guide ship from Phase B Unit 12; see [`scripts/README-hook.md`](scripts/README-hook.md) once that unit lands.
+
+## Contract
+
+Every command emits a stable JSON envelope on stdout. Success shape:
+
+```json
+{ "ok": true, "mission_id": "demo", "revision": 7, "data": { /* command-specific */ } }
+```
+
+Error shape:
+
+```json
+{ "ok": false, "code": "PLAN_INVALID", "message": "...", "hint": "...", "retryable": false, "context": { /* ... */ } }
+```
+
+Exit codes: `0` success, `1` handled error, `2` harness bug (IO / JSON / YAML). The authoritative envelope, error-code set, STATE.json schema, mutation protocol, verdict derivation, and per-command data shapes are in [`docs/cli-contract-schemas.md`](docs/cli-contract-schemas.md). Phase B must not modify that file.
+
+## Install verification
+
+`make verify-contract` runs `fmt` + `clippy` + `test` + `install-local` + the installed-binary smoke check. The step-by-step install, PATH, and verify-from-`/tmp` recipe is in [`docs/install-verification.md`](docs/install-verification.md).
 
 ## Layout
 
 ```
-Cargo.toml                 # workspace; pins dependency versions
-crates/codex1/             # single binary + library
-  src/bin/codex1.rs        # thin entry point
-  src/lib.rs               # declares modules + run()
-  src/cli/                 # clap dispatch + per-command subcommands
-  src/core/                # envelope, error codes, mission resolution, config
-  src/state/               # STATE.json / EVENTS.jsonl with atomic writes + fs2 locks
-  tests/foundation.rs      # contract-surface integration tests
-Makefile                   # install-local, verify-installed, verify-contract
-docs/cli-contract-schemas.md   # authoritative JSON envelope + error code reference
-docs/codex1-rebuild-handoff/   # normative product docs (6 files)
-.codex/skills/             # six public skills (Phase B)
-scripts/                   # Ralph stop hook (Phase B)
+Cargo.toml                           # workspace; pins dependency versions
+Makefile                             # install-local, verify-installed, verify-contract
+crates/codex1/                       # single binary + library
+  src/bin/codex1.rs                  # thin entry point
+  src/lib.rs                         # declares modules + run()
+  src/cli/                           # clap dispatch + per-command subcommands
+  src/core/                          # envelope, error codes, mission resolution, config
+  src/state/                         # STATE.json / EVENTS.jsonl with atomic writes + fs2 locks
+  tests/                             # contract-surface integration tests
+docs/
+  cli-contract-schemas.md            # authoritative envelope + error code reference
+  cli-reference.md                   # per-command reference (this documentation set)
+  install-verification.md            # install + verify-from-/tmp recipe
+  mission-anatomy.md                 # PLANS/<id>/ file-by-file anatomy
+  codex1-rebuild-handoff/            # normative product docs (6 files)
+.codex/skills/                       # six public skills (Phase B)
+scripts/                             # Ralph stop hook (Phase B)
 ```
 
-## Skills-first, CLI-on-rails
+## License
 
-- **Skills** (`$clarify`, `$plan`, `$execute`, `$review-loop`, `$close`, `$autopilot`) are the user product.
-- **CLI** (`codex1`) is the deterministic substrate that validates artifacts, records state, and emits stable JSON.
-- **Visible files** under `PLANS/<mission-id>/` own mission truth. There is no hidden state.
-- **Subagents** are governed by prompts, not by CLI identity checks.
-- **Ralph** is a tiny Stop hook that asks `codex1 status --json` whether to allow termination.
-
-## Contract (full spec in `docs/cli-contract-schemas.md`)
-
-Every command:
-- Supports `--help`, `--json`, `--mission <id>`, `--repo-root <path>`.
-- Mutating commands also support `--dry-run` and `--expect-revision <N>` (strict equality; returns `REVISION_CONFLICT` on mismatch).
-- Emits JSON on stdout. Success envelope: `{"ok":true,"mission_id":…,"revision":…,"data":…}`. Error envelope: `{"ok":false,"code":…,"message":…,"hint":…,"retryable":…,"context":…}`.
-- Exits `0` on success (including empty results), `1` on handled error, `2` on harness bug.
-
-## Licensing
-
-MIT. See workspace `Cargo.toml` for the metadata.
+MIT. See the workspace `Cargo.toml` metadata block.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,478 @@
+# CLI Reference
+
+One section per `codex1` subcommand. The authoritative JSON envelope shapes and error codes live in [`cli-contract-schemas.md`](cli-contract-schemas.md); this document lifts the per-command surface directly from the clap definitions in `crates/codex1/src/cli/` so the `--help` text and the flags listed here match the installed binary.
+
+Unless noted, every command:
+
+- Prints a JSON envelope on stdout.
+- Accepts the global flags `--mission <id>`, `--repo-root <path>`, `--json`, `--dry-run`, `--expect-revision <N>`.
+- Returns `NOT_IMPLEMENTED` today if it belongs to a Phase B unit that has not merged yet. The clap tree is complete from Foundation, so `codex1 <cmd> --help` works for every command below.
+
+Phase B ownership is tracked in the handoff package: see [`codex1-rebuild-handoff/02-cli-contract.md`](codex1-rebuild-handoff/02-cli-contract.md) for the minimal command surface and [`codex1-rebuild-handoff/03-planning-artifacts.md`](codex1-rebuild-handoff/03-planning-artifacts.md) for the file layout these commands read and write.
+
+---
+
+## codex1 init
+
+**Purpose:** Create `PLANS/<mission>/` with a blank `OUTCOME.md` (fill markers), a minimal `PLAN.yaml` header, a fresh `STATE.json` at `revision: 0`, `phase: "clarify"`, an empty `EVENTS.jsonl`, and `specs/` + `reviews/` directories.
+**Mutates state:** yes (creates a new mission directory).
+**Arguments:** none beyond the global flags. Requires `--mission <id>`.
+**Success:** `{"ok":true,"mission_id":"<id>","revision":0,"data":{"created":{…},"next_action":{"kind":"clarify","command":"$clarify","hint":"Fill in OUTCOME.md, then run `codex1 outcome ratify`."}}}`
+**Errors:** `MISSION_NOT_FOUND` (if `PLANS/<id>/` already exists, or `--repo-root` is not a directory), `PARSE_ERROR` (IO failure).
+**`--dry-run`:** supported. Reports what would be created without touching disk.
+**Example:**
+```bash
+codex1 --json init --mission demo
+```
+
+---
+
+## codex1 doctor
+
+**Purpose:** Report CLI health. Must never crash on missing auth or config.
+**Mutates state:** no.
+**Arguments:** none.
+**Success:** `{"ok":true,"data":{"version":"…","config":{…},"install":{…},"auth":{"required":false,…},"cwd":"…","warnings":[…]}}`
+**Errors:** none under normal use; an IO failure on the probe file would surface as `PARSE_ERROR`.
+**Example:**
+```bash
+codex1 --json doctor
+```
+
+---
+
+## codex1 hook snippet
+
+**Purpose:** Print the install one-liner and example `codex/hooks.json` stanza for the Ralph Stop hook.
+**Mutates state:** no.
+**Arguments:** none.
+**Success:** `{"ok":true,"data":{"hook":{"event":"Stop","script_path_hint":"<repo-root>/scripts/ralph-stop-hook.sh",…},"install":{"codex_hooks_json_example":{…}},"note":"…"}}`
+**Errors:** none.
+**Example:**
+```bash
+codex1 --json hook snippet
+```
+
+The shell script itself lives at `scripts/ralph-stop-hook.sh` and is owned by Phase B Unit 12; see [`scripts/README-hook.md`](../scripts/README-hook.md) for wiring details once that unit lands.
+
+---
+
+## codex1 outcome check
+
+**Purpose:** Validate `OUTCOME.md` mechanical completeness — required fields present, no `[codex1-fill:*]` markers, no empty-required sections, no obvious placeholder text (`TODO`, `TBD`, etc.). Does not judge semantic quality.
+**Mutates state:** no.
+**Arguments:** none beyond globals. Requires `--mission <id>`.
+**Success:** `{"ok":true,"data":{"ratifiable":true,"missing_fields":[],"placeholders":[]}}`
+**Errors:** `OUTCOME_INCOMPLETE` (with `context.missing_fields` and `context.placeholders`), `MISSION_NOT_FOUND`, `PARSE_ERROR`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 2 (`cli-outcome`) implements this.
+**Example:**
+```bash
+codex1 --json outcome check --mission demo
+```
+
+---
+
+## codex1 outcome ratify
+
+**Purpose:** Flip `STATE.json` `outcome.ratified = true` and advance `phase` from `clarify` to `plan`. Only succeeds if `outcome check` passes.
+**Mutates state:** yes.
+**Arguments:** none beyond globals. Requires `--mission <id>`.
+**Success:** `{"ok":true,"mission_id":"demo","revision":1,"data":{"ratified_at":"2026-04-20T…Z"}}`
+**Errors:** `OUTCOME_INCOMPLETE`, `MISSION_NOT_FOUND`, `REVISION_CONFLICT` (if `--expect-revision` mismatches).
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 2 implements this.
+**Example:**
+```bash
+codex1 --json outcome ratify --mission demo --expect-revision 0
+```
+
+---
+
+## codex1 plan choose-level
+
+**Purpose:** Record the requested planning level and emit the `plan scaffold` next-action. Accepts interactive and non-interactive invocations.
+**Mutates state:** yes (records `plan.requested_level` / `plan.effective_level`).
+**Arguments:**
+- `--level <LEVEL>` — accepts `light` / `medium` / `hard` or numeric aliases `1` / `2` / `3`.
+- `--escalate <REASON>` — reason the effective level is higher than requested.
+**Success:** `{"ok":true,"data":{"requested_level":"medium","effective_level":"hard","escalation_reason":"…","next_action":{"kind":"plan_scaffold","args":["codex1","plan","scaffold","--level","hard"]}}}`
+**Errors:** `OUTCOME_NOT_RATIFIED`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 3 (`cli-plan-level`) implements this.
+**Example:**
+```bash
+codex1 --json plan choose-level --level medium
+```
+
+Use the product verbs `light` / `medium` / `hard` in docs and skill prompts. Numeric values are CLI input aliases; `low` and `high` are not product terms.
+
+---
+
+## codex1 plan scaffold
+
+**Purpose:** Write a `PLAN.yaml` skeleton for the chosen level and create the matching `specs/T*/SPEC.md` stubs.
+**Mutates state:** yes (writes `PLAN.yaml`, may set `plan.requested_level`).
+**Arguments:**
+- `--level <LEVEL>` (required) — `light` / `medium` / `hard` or `1` / `2` / `3`.
+**Success:** `{"ok":true,"data":{"wrote":"PLANS/demo/PLAN.yaml","specs_created":[]}}`
+**Errors:** `OUTCOME_NOT_RATIFIED`, `MISSION_NOT_FOUND`, `PARSE_ERROR`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 4 (`cli-plan-scaffold`) implements this.
+**Example:**
+```bash
+codex1 --json plan scaffold --level hard --mission demo
+```
+
+---
+
+## codex1 plan check
+
+**Purpose:** Validate `PLAN.yaml` structure and DAG — required sections present, every task has `id`/`kind`/`depends_on`/`spec`, root tasks use `depends_on: []`, all dependencies resolve, no cycles, unique task IDs, review tasks reference valid targets, hard planning evidence present when `effective: hard`. Locks the plan on success.
+**Mutates state:** yes (sets `plan.locked = true`, computes `plan.hash`).
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"data":{"tasks":4,"review_tasks":1,"hard_evidence":3}}`
+**Errors:** `PLAN_INVALID`, `DAG_CYCLE`, `DAG_MISSING_DEP`, `OUTCOME_NOT_RATIFIED`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 5 (`cli-plan-check`) implements this.
+**Example:**
+```bash
+codex1 --json plan check --mission demo
+```
+
+---
+
+## codex1 plan graph
+
+**Purpose:** Emit the DAG in a tool-friendly format.
+**Mutates state:** no.
+**Arguments:**
+- `--format <mermaid|dot|json>` (default `mermaid`).
+- `--out <FILE>` — optional; writes the rendering to this path in addition to echoing it in the envelope.
+**Success:** `{"ok":true,"data":{"mermaid":"flowchart TD …"}}` (field name matches the chosen format).
+**Errors:** `PLAN_INVALID`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 5 implements this.
+**Example:**
+```bash
+codex1 --json plan graph --format mermaid --mission demo
+codex1 --json plan graph --format dot --out /tmp/plan.dot --mission demo
+```
+
+---
+
+## codex1 plan waves
+
+**Purpose:** Derive waves from `depends_on` + current task state. Waves are never stored — each call recomputes from the DAG and task status.
+**Mutates state:** no.
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"data":{"waves":[{"wave_id":"W1","tasks":["T1"],"parallel_safe":true,"blockers":[]}],"current_ready_wave":"W1","all_tasks_complete":false}}`
+**Errors:** `PLAN_INVALID`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 5 implements this.
+**Example:**
+```bash
+codex1 --json plan waves --mission demo
+```
+
+---
+
+## codex1 task next
+
+**Purpose:** Report the next ready action — a single task, a parallel-safe wave, a review target, a replan prompt, or a mission-close handoff.
+**Mutates state:** no.
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"data":{"next":{"kind":"run_wave","wave_id":"W1","tasks":["T1"],"parallel_safe":true}}}` (alternate shapes for review / close / replan kinds).
+**Errors:** `PLAN_INVALID`, `REPLAN_REQUIRED`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 6 (`cli-task`) implements this.
+**Example:**
+```bash
+codex1 --json task next --mission demo
+```
+
+---
+
+## codex1 task start
+
+**Purpose:** Transition a task to `InProgress`.
+**Mutates state:** yes (updates `tasks[id].status`).
+**Arguments:**
+- `<TASK_ID>` (positional, required).
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"task_id":"T2","status":"InProgress"}}`
+**Errors:** `TASK_NOT_READY`, `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 6 implements this.
+**Example:**
+```bash
+codex1 --json task start T2 --mission demo --expect-revision 5
+```
+
+---
+
+## codex1 task finish
+
+**Purpose:** Mark a task complete after proof has been written.
+**Mutates state:** yes.
+**Arguments:**
+- `<TASK_ID>` (positional, required).
+- `--proof <PATH>` (required) — path to the proof file (usually `specs/T<id>/PROOF.md`).
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"task_id":"T2","status":"Complete","proof_path":"specs/T2/PROOF.md"}}`
+**Errors:** `PROOF_MISSING`, `TASK_NOT_READY`, `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 6 implements this.
+**Example:**
+```bash
+codex1 --json task finish T2 --proof PLANS/demo/specs/T2/PROOF.md --mission demo
+```
+
+---
+
+## codex1 task status
+
+**Purpose:** Show the record for a single task.
+**Mutates state:** no.
+**Arguments:**
+- `<TASK_ID>` (positional, required).
+**Success:** `{"ok":true,"data":{"task_id":"T2","status":"Complete","depends_on":["T1"],"proof_path":"…"}}`
+**Errors:** `TASK_NOT_READY` (unknown task id), `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 6 implements this.
+**Example:**
+```bash
+codex1 --json task status T2 --mission demo
+```
+
+---
+
+## codex1 task packet
+
+**Purpose:** Emit a worker packet — the exact text a main-thread can paste into a worker subagent prompt. Contains task title, spec excerpt, allowed write paths, proof commands, and a mission summary.
+**Mutates state:** no.
+**Arguments:**
+- `<TASK_ID>` (positional, required).
+**Success:** `{"ok":true,"data":{"task_id":"T3","title":"…","spec_excerpt":"…","write_paths":["src/cli/outcome/**"],"proof_commands":["cargo test outcome"],"mission_summary":"…"}}`
+**Errors:** `TASK_NOT_READY`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 6 implements this.
+**Example:**
+```bash
+codex1 --json task packet T3 --mission demo
+```
+
+---
+
+## codex1 review start
+
+**Purpose:** Begin a planned review task. Transitions the review record to `Open`.
+**Mutates state:** yes.
+**Arguments:**
+- `<TASK_ID>` (positional, required) — the review task id.
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"review_task_id":"T4","state":"Open"}}`
+**Errors:** `TASK_NOT_READY`, `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 7 (`cli-review`) implements this.
+**Example:**
+```bash
+codex1 --json review start T4 --mission demo
+```
+
+---
+
+## codex1 review packet
+
+**Purpose:** Emit a reviewer packet — target files, diffs, proofs, review profile, and mission summary. Paste into reviewer subagent prompts.
+**Mutates state:** no.
+**Arguments:**
+- `<TASK_ID>` (positional, required).
+**Success:** `{"ok":true,"data":{"task_id":"T4","review_profile":"code_bug_correctness","targets":["T2"],"diffs":[{"path":"…","lines":[…]}],"proofs":["specs/T2/PROOF.md"],"mission_summary":"…"}}`
+**Errors:** `TASK_NOT_READY`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 7 implements this.
+**Example:**
+```bash
+codex1 --json review packet T4 --mission demo
+```
+
+---
+
+## codex1 review record
+
+**Purpose:** Record the review outcome. Only the main thread should invoke this; reviewer subagents return findings text only. The CLI does not enforce caller identity — workflow prompts govern who calls it.
+**Mutates state:** yes (updates `reviews[id]`, may bump `replan.consecutive_dirty_by_target`).
+**Arguments:**
+- `<TASK_ID>` (positional, required).
+- `--clean` — marks the review clean. Mutually exclusive with `--findings-file`.
+- `--findings-file <PATH>` — markdown file containing P0/P1/P2 findings.
+- `--reviewers <LIST>` — comma-separated reviewer actor ids (e.g. `code-reviewer,intent-reviewer`).
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"review_task_id":"T4","verdict":"clean","category":"accepted_current","reviewers":["code-reviewer","intent-reviewer"]}}`
+**Errors:** `STALE_REVIEW_RECORD`, `REVIEW_FINDINGS_BLOCK` (if the call would push the consecutive-dirty counter over the threshold with no active repair path), `REPLAN_REQUIRED`, `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 7 implements this.
+**Examples:**
+```bash
+codex1 --json review record T4 --clean --reviewers code-reviewer,intent-reviewer --mission demo
+codex1 --json review record T4 --findings-file /tmp/T4-findings.md --mission demo
+```
+
+---
+
+## codex1 review status
+
+**Purpose:** Show the review record for a task.
+**Mutates state:** no.
+**Arguments:**
+- `<TASK_ID>` (positional, required).
+**Success:** `{"ok":true,"data":{"review_task_id":"T4","state":"Passed","last_verdict":"clean","consecutive_dirty":0}}`
+**Errors:** `TASK_NOT_READY`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 7 implements this.
+**Example:**
+```bash
+codex1 --json review status T4 --mission demo
+```
+
+---
+
+## codex1 replan check
+
+**Purpose:** Report whether replan is required. The canonical trigger is six consecutive dirty reviews against the same active target.
+**Mutates state:** no.
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"data":{"required":false,"reason":null,"consecutive_dirty_by_target":{"T4":2}}}`
+**Errors:** `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 8 (`cli-replan`) implements this.
+**Example:**
+```bash
+codex1 --json replan check --mission demo
+```
+
+---
+
+## codex1 replan record
+
+**Purpose:** Record a replan decision and reset the consecutive-dirty counter. New task rows are added by editing `PLAN.yaml` and running `plan check` — this command does not generate tasks.
+**Mutates state:** yes (updates `replan`, resets `consecutive_dirty_by_target`).
+**Arguments:**
+- `--reason <CODE>` (required) — e.g. `six_consecutive_dirty`, `architecture_shift`.
+- `--supersedes <TASK_ID>` — optional; the task id whose boundary is superseded.
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"reason":"six_consecutive_dirty","supersedes":"T4","triggered":true}}`
+**Errors:** `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 8 implements this.
+**Example:**
+```bash
+codex1 --json replan record --reason six_consecutive_dirty --supersedes T4 --mission demo
+```
+
+---
+
+## codex1 loop pause
+
+**Purpose:** Pause the active loop. Used by `$close` to let the user talk without Ralph forcing continuation.
+**Mutates state:** yes (sets `loop.paused = true`).
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"active":true,"paused":true,"mode":"execute"}}`
+**Errors:** `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 9 (`cli-loop`) implements this.
+**Example:**
+```bash
+codex1 --json loop pause --mission demo
+```
+
+---
+
+## codex1 loop resume
+
+**Purpose:** Resume a paused loop. Clears `loop.paused`.
+**Mutates state:** yes.
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"active":true,"paused":false,"mode":"execute"}}`
+**Errors:** `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 9 implements this.
+**Example:**
+```bash
+codex1 --json loop resume --mission demo
+```
+
+---
+
+## codex1 loop deactivate
+
+**Purpose:** Deactivate the loop entirely. Used when abandoning a run or after `close complete`.
+**Mutates state:** yes (sets `loop.active = false`).
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"active":false,"paused":false,"mode":"none"}}`
+**Errors:** `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 9 implements this.
+**Example:**
+```bash
+codex1 --json loop deactivate --mission demo
+```
+
+---
+
+## codex1 close check
+
+**Purpose:** Check terminal readiness. Shares readiness logic with `codex1 status` so the two cannot disagree. Required: outcome ratified, plan locked, all non-superseded tasks complete or review-clean, planned review tasks clean, mission-close review clean, no active blockers.
+**Mutates state:** no.
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"data":{"ready":false,"verdict":"continue_required","blockers":[{"code":"TASK_NOT_READY","detail":"T7 is pending"}]}}`
+**Errors:** `MISSION_NOT_FOUND`. Blockers are reported inside `data.blockers`, not as top-level errors.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 10 (`cli-close`) implements this.
+**Example:**
+```bash
+codex1 --json close check --mission demo
+```
+
+---
+
+## codex1 close complete
+
+**Purpose:** Write `CLOSEOUT.md` and mark the mission terminal. Only succeeds if `close check` would pass.
+**Mutates state:** yes (sets `close.terminal_at`, advances `phase` to `terminal`).
+**Arguments:** none beyond globals.
+**Success:** `{"ok":true,"mission_id":"demo","revision":N,"data":{"closeout_path":"PLANS/demo/CLOSEOUT.md","terminal_at":"2026-04-20T…Z","mission_id":"demo"}}`
+**Errors:** `CLOSE_NOT_READY`, `TERMINAL_ALREADY_COMPLETE` (idempotent re-invocation), `REVISION_CONFLICT`, `MISSION_NOT_FOUND`.
+**Phase status:** Currently returns `NOT_IMPLEMENTED`; Phase B Unit 10 implements this.
+**Example:**
+```bash
+codex1 --json close complete --mission demo
+```
+
+---
+
+## codex1 status
+
+**Purpose:** Unified mission status. Consumed by skills, the main thread, Ralph, and humans debugging mission state. Shares `verdict` / `close_ready` derivation with `codex1 close check` via `state::readiness`.
+**Mutates state:** no.
+**Arguments:** none beyond globals. Omitting `--mission` causes the command to walk up from CWD; if no single mission resolves, it emits a graceful `stop.allow: true` envelope so Ralph never blocks the shell on a stray CWD.
+**Success (Phase B target shape):**
+```json
+{
+  "ok": true,
+  "mission_id": "demo",
+  "revision": 7,
+  "data": {
+    "phase": "execute",
+    "verdict": "continue_required",
+    "loop": { "active": true, "paused": false, "mode": "execute" },
+    "next_action": { "kind": "run_wave", "wave_id": "W2", "tasks": ["T2","T3"] },
+    "ready_tasks": ["T2","T3"],
+    "parallel_safe": true,
+    "parallel_blockers": [],
+    "review_required": [],
+    "replan_required": false,
+    "close_ready": false,
+    "stop": {
+      "allow": false,
+      "reason": "active_loop",
+      "message": "Run wave W2 or use $close to pause."
+    }
+  }
+}
+```
+**Errors:** `MISSION_NOT_FOUND` (only when `--mission` is given explicitly and cannot be resolved), `STATE_CORRUPT`, `PARSE_ERROR`.
+**Foundation status:** already wired. The Foundation projection emits `phase`, `verdict`, `loop`, `close_ready`, `stop`, a `"foundation_only": true` flag, and a note that Phase B Unit 11 broadens the payload to include `next_action`, `ready_tasks`, `parallel_safe`, `parallel_blockers`, `review_required`, and `replan_required`. The `stop.allow` and `verdict` fields already come from the shared readiness helper, so the Ralph contract is honored.
+**Example:**
+```bash
+codex1 --json status --mission demo
+```
+
+---
+
+## Global flags
+
+| Flag | Scope | Purpose |
+| --- | --- | --- |
+| `--mission <ID>` | all | Directory name under `PLANS/`. Optional for `doctor` and `hook snippet`. |
+| `--repo-root <PATH>` | all | Overrides CWD discovery. Resolves to `<PATH>/PLANS/<id>/`. |
+| `--json` | all | Reserved; JSON is the default on every command. Present for cli-creator parity. |
+| `--dry-run` | mutating | Validate and report without writing. |
+| `--expect-revision <N>` | mutating | Strict equality against `STATE.json` revision. Returns `REVISION_CONFLICT` on mismatch. |
+| `--help` | all | Clap-generated help. Always works, even for unimplemented commands. |
+
+Mission resolution precedence and the full STATE.json / envelope / error-code schemas are spelled out in [`cli-contract-schemas.md`](cli-contract-schemas.md).

--- a/docs/install-verification.md
+++ b/docs/install-verification.md
@@ -1,0 +1,80 @@
+# Install and verification
+
+This recipe installs `codex1` to `$HOME/.local/bin/` and verifies it from `/tmp`. The "verify from outside the source folder" step is the critical one — a CLI that only works via `cargo run` is not an installed CLI.
+
+## Toolchain
+
+- Rust `>= 1.89` (install via `rustup` if missing: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
+- `git`, `make`, and a POSIX shell.
+
+## Build
+
+```bash
+git clone https://github.com/JoelEmanuelNilsson/codex1 && cd codex1
+make install-local
+```
+
+`make install-local` runs `cargo build --release` and copies `target/release/codex1` to `$HOME/.local/bin/codex1`. To install elsewhere, pass `INSTALL_DIR=<path> make install-local`.
+
+## PATH
+
+```bash
+echo "$PATH" | tr ':' '\n' | grep -qx "$HOME/.local/bin" \
+  || echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+exec "$SHELL"
+```
+
+If you use bash, replace `~/.zshrc` with `~/.bashrc` (or `~/.bash_profile` on macOS).
+
+## Verify from /tmp (the critical step)
+
+```bash
+cd /tmp
+command -v codex1                           # must print $HOME/.local/bin/codex1
+codex1 --help                               # must show the full command tree
+codex1 --json doctor                        # must print {"ok":true,...} without errors
+codex1 --json init --mission demo           # creates PLANS/demo/
+cat PLANS/demo/STATE.json                   # valid JSON, "revision":0, "phase":"clarify"
+codex1 --json status --mission demo         # {"ok":true,"data":{"verdict":"needs_user", …}}
+```
+
+Every one of these must succeed before you move on. If `codex1 status` prints an error envelope instead of a JSON success, stop and investigate — the Ralph stop hook relies on this command returning stable JSON.
+
+## Contract tests
+
+```bash
+make verify-contract      # fmt + clippy + cargo test + install-local + smoke (verify-installed)
+```
+
+The Makefile target chains `fmt clippy test install-local verify-installed`; `verify-installed` does the installed-binary smoke check.
+
+## Skill auto-discovery
+
+Phase B Units deliver six public skills under `.codex/skills/{clarify,plan,execute,review-loop,close,autopilot}`. Once merged, these are auto-discovered by Codex when the repo is on the current working path. You can also symlink a shared copy from `~/.codex/skills/` if you maintain them outside this repo:
+
+```bash
+ln -s /path/to/codex1/.codex/skills/clarify ~/.codex/skills/clarify
+# repeat per skill
+```
+
+See the handoff package at [`codex1-rebuild-handoff/01-product-flow.md`](codex1-rebuild-handoff/01-product-flow.md) for the workflow each skill drives.
+
+## Ralph stop hook
+
+The Ralph Stop hook is a short shell script that runs `codex1 status --json` and blocks the Stop event iff the loop is active, not paused, and `stop.allow` is false. Wire it via your Codex `hooks.json` as described by:
+
+```bash
+codex1 --json hook snippet
+```
+
+The shell script itself and its install README ship from Phase B Unit 12; see [`../scripts/README-hook.md`](../scripts/README-hook.md) once that unit lands.
+
+## Troubleshooting
+
+- `codex1: command not found` — `$HOME/.local/bin` is not on `PATH`; add it and `exec $SHELL`, or re-run `make install-local`.
+- `MISSION_NOT_FOUND` — either pass `--mission <id>` explicitly or `cd` into a directory whose `PLANS/` subdirectory contains exactly one mission.
+- `REVISION_CONFLICT` — another writer advanced `STATE.json` while you were staging a mutation. Re-read it (`cat PLANS/<id>/STATE.json`) and retry with the correct `--expect-revision`. The error envelope's `context.actual` field carries the current revision.
+- `NOT_IMPLEMENTED` — the command's Phase B unit has not merged yet. See [`cli-reference.md`](cli-reference.md) for per-command ownership.
+- `doctor` warns about a network filesystem — prefer local disk for mission state; `fs2` advisory locks behave unevenly over NFS/SMB.
+
+Per-command shapes, envelopes, and error codes live in [`cli-reference.md`](cli-reference.md) and [`cli-contract-schemas.md`](cli-contract-schemas.md).

--- a/docs/mission-anatomy.md
+++ b/docs/mission-anatomy.md
@@ -1,0 +1,123 @@
+# Mission anatomy
+
+A mission lives entirely under `PLANS/<mission-id>/`. There is no hidden state directory, no `.ralph/`, no side-cache. Everything the CLI or a human needs is visible in files you can `cat` and diff.
+
+## Layout
+
+```
+PLANS/<mission-id>/
+  OUTCOME.md           # clarified destination truth
+  PLAN.yaml            # route, architecture, task DAG
+  STATE.json           # current operational state
+  EVENTS.jsonl         # append-only audit log
+  specs/
+    T1/
+      SPEC.md          # task-local spec (static)
+      PROOF.md         # task-local proof (written at task finish)
+    T2/
+      ...
+  reviews/
+    R1.md              # main-thread-recorded review findings
+    R2.md
+  CLOSEOUT.md          # final terminal summary (written at close complete)
+```
+
+See [`codex1-rebuild-handoff/03-planning-artifacts.md`](codex1-rebuild-handoff/03-planning-artifacts.md) for the artifact contracts.
+
+## Files
+
+### `OUTCOME.md`
+
+Clarified-destination truth. YAML frontmatter plus human-readable body. Populated by `$clarify`, ratified by `codex1 outcome ratify`. A fresh mission (`codex1 init`) writes it with `[codex1-fill:*]` markers; ratification fails until every marker is resolved.
+
+Required fields: `mission_id`, `status`, `title`, `original_user_goal`, `interpreted_destination`, `must_be_true`, `success_criteria`, `non_goals`, `constraints`, `definitions`, `quality_bar`, `proof_expectations`, `review_expectations`, `known_risks`, `resolved_questions`.
+
+The mission cannot enter `plan` phase until `OUTCOME.md` is ratified.
+
+### `PLAN.yaml`
+
+The route, architecture, task DAG, planning evidence, and mission-close criteria. Written by `$plan` via `codex1 plan scaffold` and edited by the main thread until it passes `codex1 plan check`. On successful `plan check`, the plan is locked (`STATE.json` records `plan.locked = true` and `plan.hash`).
+
+Required sections: `mission_id`, `planning_level: {requested, effective}`, `outcome_interpretation`, `architecture`, `planning_process.evidence`, `tasks`, `risks`, `mission_close.criteria`.
+
+Waves are **not** stored here. They are derived each time `codex1 plan waves` is called, from `tasks[].depends_on` and current task status.
+
+### `STATE.json`
+
+Current operational state. Owned by the CLI; never edited by hand. Mutated only through `state::mutate`, which:
+
+1. Acquires an exclusive `fs2` lock on `STATE.json.lock`.
+2. Parses the current `STATE.json`.
+3. Enforces `--expect-revision <N>` when provided.
+4. Runs the handler closure.
+5. Bumps `revision` and `events_cursor` by 1.
+6. Atomically writes `STATE.json` (temp-in-same-dir + rename).
+7. Appends one line to `EVENTS.jsonl`.
+8. Releases the lock.
+
+Fields (see `crates/codex1/src/state/schema.rs` for the authoritative definition): `mission_id`, `revision`, `schema_version`, `phase`, `loop`, `outcome`, `plan`, `tasks`, `reviews`, `replan`, `close`, `events_cursor`.
+
+### `EVENTS.jsonl`
+
+Append-only audit log. One JSON line per mutation. The `seq` of the latest line matches `state.events_cursor`. This file is audit history, not replay authority — it is not read back to reconstruct state.
+
+### `specs/T<id>/SPEC.md`
+
+Task-local spec: goal, allowed read/write paths, steps, acceptance criteria, proof commands, review expectations. Written during planning (`$plan` or `codex1 plan scaffold`). Static once the plan is locked — if a task's spec needs to change, replan adds a new task id.
+
+### `specs/T<id>/PROOF.md`
+
+Written by the worker (or main thread) when they call `codex1 task finish <id> --proof <path>`. Records commands run and their outcomes.
+
+### `reviews/*.md`
+
+Main-thread-recorded review findings. Reviewers never write here directly — they return findings text to the main thread, which records via `codex1 review record <id> --findings-file <path>` (or `--clean` if there were none).
+
+### `CLOSEOUT.md`
+
+Written by `codex1 close complete` when the mission reaches terminal. Contains the mission summary, final verdict, and links to proofs and reviews.
+
+## Phase transitions
+
+```
+clarify        --outcome.ratified=true---------->  plan
+plan           --plan.locked=true----------------> execute
+execute        --all tasks Complete/Superseded--> review_loop
+review_loop    --mission-close review passed----> mission_close
+mission_close  --close complete------------------> terminal
+```
+
+`codex1 status` reports the current phase alongside the derived `verdict`. The mapping from state to verdict is in `state::readiness::derive_verdict` and matches `cli-contract-schemas.md`.
+
+## Revision discipline
+
+Every mutation bumps `state.revision` by 1. Mutating commands accept `--expect-revision <N>` for strict-equality stale-writer protection. On mismatch, the CLI returns:
+
+```json
+{
+  "ok": false,
+  "code": "REVISION_CONFLICT",
+  "message": "Expected state revision 7 but current revision is 8.",
+  "retryable": true,
+  "context": { "expected": 7, "actual": 8 }
+}
+```
+
+`retryable: true` on this code is a signal to callers: re-read `STATE.json`, reconcile, and retry with the current revision.
+
+## Late-output vocabulary
+
+Review records are classified by the CLI according to when they arrive:
+
+- `accepted_current` — recorded before the review boundary closed. Only this category affects the consecutive-dirty counter.
+- `late_same_boundary` — arrived after current, still within the same boundary revision.
+- `stale_superseded` — belongs to a superseded task/review boundary.
+- `contaminated_after_terminal` — arrived after mission terminal.
+
+All four categories are appended to `EVENTS.jsonl`; only `accepted_current` mutates current truth. This is how the harness tolerates subagents that respond after their boundary has moved on.
+
+## Stop semantics
+
+Ralph, the stop hook, reads `codex1 status --json` and nothing else. `stop.allow` is true iff the loop is inactive / paused, or the verdict is in `{terminal_complete, mission_close_review_passed, needs_user}`. A mission can be paused for discussion via `$close` (`codex1 loop pause`), resumed via `codex1 loop resume`, and abandoned via `codex1 loop deactivate`.
+
+See [`cli-contract-schemas.md`](cli-contract-schemas.md) for the full verdict/`stop.allow` derivation rules and [`codex1-rebuild-handoff/01-product-flow.md`](codex1-rebuild-handoff/01-product-flow.md) for the user-facing workflow that these files drive.


### PR DESCRIPTION
## Summary

- Rewrite `README.md` as a skills-first product overview: quick start, six public skills, manual CLI flow, pointers to the new docs, stop-hook wiring, contract, layout, MIT license. ~125 lines; retains the "Phase B features land as their PRs merge" caveat.
- Add `docs/cli-reference.md`: per-command reference for every Foundation and Phase B command, lifted directly from the clap definitions in `crates/codex1/src/cli/`. Each section lists purpose, state-mutation flag, arguments, success envelope summary, canonical error codes, phase status (wired vs `NOT_IMPLEMENTED` with unit ownership), and a copy-paste example. Global flags table at the bottom.
- Add `docs/install-verification.md`: toolchain, build, PATH, the critical verify-from-`/tmp` recipe (runs against the installed binary, not `cargo run`), `make verify-contract` mapping, skill auto-discovery pointer, Ralph hook pointer, and troubleshooting for `MISSION_NOT_FOUND`, `REVISION_CONFLICT`, `NOT_IMPLEMENTED`, network-FS doctor warnings.
- Add `docs/mission-anatomy.md`: `PLANS/<mission-id>/` file-by-file (OUTCOME, PLAN, STATE, EVENTS, specs, reviews, CLOSEOUT), phase transitions, revision discipline with concrete `REVISION_CONFLICT` example, late-output vocabulary, stop semantics.

No Rust code changes. `cargo build --release` still clean.

## Accuracy notes

- Command surface was lifted from `crates/codex1/src/cli/*/mod.rs`, not from aspirational handoff prose. In particular:
  - `loop` subcommands are `pause|resume|deactivate` only (no `activate`).
  - `close` subcommands are `check|complete` only (no `record-review`).
  - `hook` has a single subcommand `snippet`.
  - Flag shapes (`task finish --proof`, `review record --clean|--findings-file`, `plan graph --format --out`, etc.) match clap exactly.
- Error codes in `docs/cli-reference.md` are drawn only from `CliError` in `crates/codex1/src/core/error.rs`.
- Foundation `status` currently emits a minimal projection with `"foundation_only": true`. The docs describe the full Phase B target shape and flag the Foundation projection as partial, citing Phase B Unit 11.

## Internal links

All internal links resolve inside the worktree except `scripts/README-hook.md` (owned by Phase B Unit 12 — task spec explicitly says to link it anyway).

## Test plan

- [x] `cargo build --release` clean.
- [x] Line counts: README 125 lines (< 200 target), cli-reference 478, install-verification 80, mission-anatomy 123.
- [x] Every link resolves to a file that exists (modulo Unit 12's `scripts/README-hook.md`, which is expected).
- [x] Command surface in `cli-reference.md` matches the actual clap enums, not aspirational prose.
- [x] Error codes in `cli-reference.md` are a subset of `CliError` variants.
- [ ] Reviewer skim: `docs/cli-reference.md` for any stale Phase B assumptions vs what actually lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)