### PR TITLE
Unit 2: cli-outcome

### DIFF
--- a/crates/codex1/src/cli/outcome/check.rs
+++ b/crates/codex1/src/cli/outcome/check.rs
@@ -1,0 +1,43 @@
+//! `codex1 outcome check` — read-only OUTCOME.md validation.
+//!
+//! Reads `PLANS/<mission>/OUTCOME.md`, parses its YAML frontmatter,
+//! and reports whether it is ready to ratify. Never mutates state.
+
+use serde_json::json;
+
+use crate::cli::outcome::emit::emit_outcome_incomplete;
+use crate::cli::outcome::validate::validate_outcome;
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::CliResult;
+use crate::core::mission::resolve_mission;
+use crate::state;
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let report = validate_outcome(&paths.outcome())?;
+
+    if !report.ratifiable {
+        // Print the OUTCOME_INCOMPLETE envelope (with context) and exit(1).
+        // Returning a plain CliError would cause dispatch to re-print a
+        // context-less envelope, so we emit-and-exit here instead.
+        emit_outcome_incomplete(
+            &state.mission_id,
+            report.missing_fields,
+            report.placeholders,
+        );
+    }
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        json!({
+            "ratifiable": true,
+            "missing_fields": report.missing_fields,
+            "placeholders": report.placeholders,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/outcome/emit.rs
+++ b/crates/codex1/src/cli/outcome/emit.rs
@@ -1,0 +1,60 @@
+//! Envelope emitters for the `outcome` commands.
+//!
+//! Foundation's `cli::dispatch` always prints the error envelope produced
+//! by `CliError::to_envelope()`, and the `OutcomeIncomplete` variant has
+//! no fields for `missing_fields` / `placeholders`. To honour the CLI
+//! contract's `context.missing_fields` / `context.placeholders` promise
+//! without touching Foundation files, the `check` and `ratify` handlers
+//! assemble the enriched envelope themselves, print it, and exit with
+//! the handled-error exit code before control returns to dispatch.
+
+use serde_json::json;
+
+use crate::core::envelope::JsonErr;
+use crate::core::error::CliError;
+
+/// Print the `OUTCOME_INCOMPLETE` envelope with `context.missing_fields`
+/// and `context.placeholders` filled in, then exit with status 1.
+///
+/// Using `process::exit(1)` here is a deliberate escape hatch: it matches
+/// the `ExitKind::HandledError` mapping for `OutcomeIncomplete` in
+/// `lib::run`, and it prevents `cli::dispatch` from double-printing a
+/// context-less envelope on top of ours.
+pub fn emit_outcome_incomplete(
+    mission_id: &str,
+    missing_fields: Vec<String>,
+    placeholders: Vec<String>,
+) -> ! {
+    let err = CliError::OutcomeIncomplete {
+        message: build_message(&missing_fields, &placeholders),
+        hint: Some(
+            "Fill every required field and remove all `[codex1-fill:...]` markers, \
+            TODO/TBD values, and vague 'works well' style entries."
+                .to_string(),
+        ),
+    };
+    let base = err.to_envelope();
+    let context = json!({
+        "mission_id": mission_id,
+        "missing_fields": missing_fields,
+        "placeholders": placeholders,
+    });
+    let enriched = JsonErr {
+        ok: false,
+        code: base.code,
+        message: base.message,
+        hint: base.hint,
+        retryable: base.retryable,
+        context,
+    };
+    println!("{}", enriched.to_pretty());
+    std::process::exit(1);
+}
+
+fn build_message(missing: &[String], placeholders: &[String]) -> String {
+    match (missing.len(), placeholders.len()) {
+        (0, p) => format!("{p} placeholder(s) remain."),
+        (m, 0) => format!("{m} required field(s) missing."),
+        (m, p) => format!("{m} required field(s) missing and {p} placeholder(s) remain."),
+    }
+}

--- a/crates/codex1/src/cli/outcome/mod.rs
+++ b/crates/codex1/src/cli/outcome/mod.rs
@@ -1,14 +1,23 @@
-//! `codex1 outcome` stub — owned by Phase B Unit 2 (`cli-outcome`).
+//! `codex1 outcome` — OUTCOME.md validation and ratification.
 //!
-//! Foundation pins the subcommand variants so `cli::mod` can reference
-//! them by path. Phase B replaces the `dispatch` body with real
-//! `check` / `ratify` implementations and adds any needed helpers in
-//! sibling files under this directory.
+//! `outcome check` is a read-only validator that reports every missing
+//! required field and every `[codex1-fill:…]` / boilerplate placeholder.
+//!
+//! `outcome ratify` re-runs the same validation, then (on success)
+//! mutates STATE.json via `state::mutate` to set
+//! `outcome.ratified = true`, records `outcome.ratified_at`, advances
+//! `phase` from `Clarify` to `Plan`, and flips
+//! `status: draft` → `status: ratified` inside OUTCOME.md itself.
 
 use clap::Subcommand;
 
 use crate::cli::Ctx;
-use crate::core::error::{CliError, CliResult};
+use crate::core::error::CliResult;
+
+mod check;
+mod emit;
+mod ratify;
+mod validate;
 
 #[derive(Debug, Subcommand)]
 pub enum OutcomeCmd {
@@ -18,12 +27,9 @@ pub enum OutcomeCmd {
     Ratify,
 }
 
-pub fn dispatch(cmd: OutcomeCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        OutcomeCmd::Check => "outcome check",
-        OutcomeCmd::Ratify => "outcome ratify",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: OutcomeCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        OutcomeCmd::Check => check::run(ctx),
+        OutcomeCmd::Ratify => ratify::run(ctx),
+    }
 }

--- a/crates/codex1/src/cli/outcome/ratify.rs
+++ b/crates/codex1/src/cli/outcome/ratify.rs
@@ -1,0 +1,175 @@
+//! `codex1 outcome ratify` — validate OUTCOME.md, flip it to `ratified`,
+//! and advance the mission phase to `plan`.
+
+use serde_json::json;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::cli::outcome::emit::emit_outcome_incomplete;
+use crate::cli::outcome::validate::validate_outcome;
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::{self, fs_atomic::atomic_write, Phase};
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let report = validate_outcome(&paths.outcome())?;
+
+    if !report.ratifiable {
+        emit_outcome_incomplete(
+            &state.mission_id,
+            report.missing_fields,
+            report.placeholders,
+        );
+    }
+
+    let ratified_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    if ctx.dry_run {
+        let would_phase = advance_phase(&state.phase);
+        let env = JsonOk::new(
+            Some(state.mission_id.clone()),
+            Some(state.revision),
+            json!({
+                "dry_run": true,
+                "would_ratified_at": ratified_at,
+                "mission_id": state.mission_id,
+                "phase": would_phase,
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    let outcome_path = paths.outcome();
+    let rewritten_outcome = rewrite_status_to_ratified(&report.frontmatter_raw, &report.body)?;
+
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        "outcome.ratified",
+        json!({
+            "mission_id": state.mission_id,
+            "ratified_at": ratified_at,
+        }),
+        |state_mut| {
+            state_mut.outcome.ratified = true;
+            state_mut.outcome.ratified_at = Some(ratified_at.clone());
+            state_mut.phase = advance_phase(&state_mut.phase);
+            atomic_write(&outcome_path, rewritten_outcome.as_bytes())?;
+            Ok(())
+        },
+    )?;
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(mutation.new_revision),
+        json!({
+            "ratified_at": ratified_at,
+            "mission_id": state.mission_id,
+            "phase": mutation.state.phase,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+/// Advance `Clarify` to `Plan`; leave every other phase alone. Shared by
+/// the dry-run projection and the real mutation so they cannot drift.
+fn advance_phase(current: &Phase) -> Phase {
+    match current {
+        Phase::Clarify => Phase::Plan,
+        other => other.clone(),
+    }
+}
+
+/// Rewrite OUTCOME.md's frontmatter so `status: draft` (or any other
+/// value) becomes `status: ratified`. Only the first `status:` line
+/// inside the frontmatter is touched; the body is preserved byte-for-byte.
+///
+/// We avoid a `serde_yaml` round-trip to preserve field order, comments,
+/// quoting style, and whitespace authored by `$clarify`.
+fn rewrite_status_to_ratified(frontmatter: &str, body: &str) -> Result<String, CliError> {
+    let mut new_front = String::with_capacity(frontmatter.len() + 16);
+    let mut rewrote = false;
+    for line in frontmatter.split_inclusive('\n') {
+        if !rewrote && is_top_level_status_line(line) {
+            let indent_end = line.find("status:").unwrap_or(0);
+            let indent = &line[..indent_end];
+            let line_ending = if line.ends_with("\r\n") {
+                "\r\n"
+            } else if line.ends_with('\n') {
+                "\n"
+            } else {
+                ""
+            };
+            new_front.push_str(indent);
+            new_front.push_str("status: ratified");
+            new_front.push_str(line_ending);
+            rewrote = true;
+        } else {
+            new_front.push_str(line);
+        }
+    }
+    if !rewrote {
+        // Validation guarantees the field exists, but be explicit if the
+        // line couldn't be located via the simple scan.
+        return Err(CliError::OutcomeIncomplete {
+            message: "Could not locate `status:` line in OUTCOME.md frontmatter".to_string(),
+            hint: Some("Add a `status:` field at the top level of the YAML block.".to_string()),
+        });
+    }
+    let mut out = String::with_capacity(frontmatter.len() + body.len() + 8);
+    out.push_str("---\n");
+    out.push_str(&new_front);
+    out.push_str("---");
+    // Preserve the exact body, including any leading newline that was
+    // part of the file (split_frontmatter leaves `\n# Body…` in `body`).
+    out.push_str(body);
+    Ok(out)
+}
+
+fn is_top_level_status_line(line: &str) -> bool {
+    // Top-level keys have no leading whitespace in YAML frontmatter.
+    // We require the line to start with `status:` followed by a space,
+    // tab, newline, or end-of-string.
+    let trimmed_end = line.trim_end_matches(['\r', '\n']);
+    trimmed_end
+        .strip_prefix("status:")
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with(' ') || rest.starts_with('\t'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_status_line_preserving_body() {
+        let front = "mission_id: demo\nstatus: draft\ntitle: Thing\n";
+        let body = "\n# OUTCOME\nsome text with status: in prose\n";
+        let got = rewrite_status_to_ratified(front, body).unwrap();
+        assert!(got.contains("status: ratified"));
+        assert!(got.contains("status: in prose"));
+        assert!(!got.contains("status: draft"));
+    }
+
+    #[test]
+    fn rewrites_only_first_status_line() {
+        let front = "status: draft\nstatus: stale\n";
+        let got = rewrite_status_to_ratified(front, "").unwrap();
+        // Only the first `status:` is rewritten; the second survives as
+        // documentation of the original YAML shape.
+        assert!(got.contains("status: ratified\nstatus: stale"));
+    }
+
+    #[test]
+    fn errors_when_status_missing() {
+        let err = rewrite_status_to_ratified("mission_id: demo\n", "").unwrap_err();
+        assert!(matches!(err, CliError::OutcomeIncomplete { .. }));
+    }
+}

--- a/crates/codex1/src/cli/outcome/validate.rs
+++ b/crates/codex1/src/cli/outcome/validate.rs
@@ -1,0 +1,377 @@
+//! OUTCOME.md validation shared by `outcome check` and `outcome ratify`.
+//!
+//! Parses YAML frontmatter, checks required fields, rejects boilerplate,
+//! and flags any `[codex1-fill:…]` markers anywhere in the file.
+
+use std::path::Path;
+
+use serde_yaml::{Mapping, Value};
+
+use crate::core::error::CliError;
+
+/// Result of validating OUTCOME.md. `ratifiable` is true iff both
+/// `missing_fields` and `placeholders` are empty.
+#[derive(Debug, Clone)]
+pub struct ValidationReport {
+    pub ratifiable: bool,
+    pub missing_fields: Vec<String>,
+    pub placeholders: Vec<String>,
+    pub frontmatter_raw: String,
+    pub body: String,
+}
+
+/// Load and validate OUTCOME.md at `path`. Returns a structured report
+/// even when invalid — the caller decides whether to error.
+pub fn validate_outcome(path: &Path) -> Result<ValidationReport, CliError> {
+    if !path.is_file() {
+        return Err(CliError::OutcomeIncomplete {
+            message: format!("OUTCOME.md not found at {}", path.display()),
+            hint: Some("Run `codex1 init --mission <id>` first.".to_string()),
+        });
+    }
+    let raw = std::fs::read_to_string(path)?;
+    let (frontmatter_raw, body) =
+        split_frontmatter(&raw).ok_or_else(|| CliError::OutcomeIncomplete {
+            message: "OUTCOME.md is missing YAML frontmatter (expected `---` fences)".to_string(),
+            hint: Some("Start the file with `---`, a YAML block, and a closing `---`.".to_string()),
+        })?;
+
+    let mapping: Mapping = match serde_yaml::from_str::<Value>(&frontmatter_raw) {
+        Ok(Value::Mapping(m)) => m,
+        Ok(_) => {
+            return Err(CliError::OutcomeIncomplete {
+                message: "OUTCOME.md frontmatter must be a YAML mapping".to_string(),
+                hint: None,
+            });
+        }
+        Err(err) => {
+            return Err(CliError::OutcomeIncomplete {
+                message: format!("Failed to parse OUTCOME.md frontmatter: {err}"),
+                hint: Some(
+                    "Ensure the YAML between `---` fences is syntactically valid.".to_string(),
+                ),
+            });
+        }
+    };
+
+    let mut missing_fields = Vec::new();
+    let mut placeholders = Vec::new();
+
+    check_scalar(
+        &mapping,
+        "mission_id",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_scalar(&mapping, "status", &mut missing_fields, &mut placeholders);
+    check_scalar(&mapping, "title", &mut missing_fields, &mut placeholders);
+    check_scalar(
+        &mapping,
+        "original_user_goal",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_scalar(
+        &mapping,
+        "interpreted_destination",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+
+    check_non_empty_list(
+        &mapping,
+        "must_be_true",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_non_empty_list(
+        &mapping,
+        "success_criteria",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+
+    check_list_present(
+        &mapping,
+        "non_goals",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_list_present(
+        &mapping,
+        "constraints",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_list_present(
+        &mapping,
+        "quality_bar",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_list_present(
+        &mapping,
+        "proof_expectations",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_list_present(
+        &mapping,
+        "review_expectations",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+    check_list_present(
+        &mapping,
+        "known_risks",
+        &mut missing_fields,
+        &mut placeholders,
+    );
+
+    // Stricter rejection: success_criteria entries must not be pure
+    // outcome-grade boilerplate ("works well", "reliable", …).
+    reject_success_criteria_boilerplate(&mapping, &mut placeholders);
+
+    // Sweep the whole file for remaining fill markers, including ones
+    // hiding in the body text.
+    collect_fill_markers(&raw, &mut placeholders);
+
+    // De-duplicate while preserving order.
+    dedup_in_place(&mut missing_fields);
+    dedup_in_place(&mut placeholders);
+
+    Ok(ValidationReport {
+        ratifiable: missing_fields.is_empty() && placeholders.is_empty(),
+        missing_fields,
+        placeholders,
+        frontmatter_raw,
+        body,
+    })
+}
+
+/// Split OUTCOME.md into `(frontmatter_body, markdown_body)`. Returns
+/// `None` if the file lacks the standard `---…---` fences.
+pub fn split_frontmatter(raw: &str) -> Option<(String, String)> {
+    let trimmed = raw.trim_start_matches('\u{feff}');
+    let rest = trimmed.strip_prefix("---")?;
+    let rest = rest
+        .strip_prefix('\n')
+        .or_else(|| rest.strip_prefix("\r\n"))?;
+    // Find the next line that is exactly `---` (trailing whitespace ok).
+    let mut offset = 0usize;
+    for line in rest.split_inclusive('\n') {
+        let line_end = offset + line.len();
+        let stripped = line.trim_end_matches(['\n', '\r']);
+        if stripped.trim_end() == "---" {
+            let frontmatter = rest[..offset].to_string();
+            let body_start = line_end;
+            let body = rest.get(body_start..).unwrap_or("").to_string();
+            return Some((frontmatter, body));
+        }
+        offset = line_end;
+    }
+    None
+}
+
+fn check_scalar(
+    m: &Mapping,
+    field: &str,
+    missing: &mut Vec<String>,
+    placeholders: &mut Vec<String>,
+) {
+    match m.get(Value::String(field.to_string())) {
+        None | Some(Value::Null) => missing.push(field.to_string()),
+        Some(Value::String(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                missing.push(field.to_string());
+            } else if is_placeholder_value(trimmed) {
+                placeholders.push(format!("{field}: {}", summarize(trimmed)));
+            } else if let Some(marker) = find_fill_marker(trimmed) {
+                placeholders.push(format!("{field}: {marker}"));
+            }
+        }
+        Some(_) => {
+            // status must be a string per contract; treat non-string scalars
+            // as a missing-field problem.
+            missing.push(format!("{field} (not a string)"));
+        }
+    }
+}
+
+fn check_non_empty_list(
+    m: &Mapping,
+    field: &str,
+    missing: &mut Vec<String>,
+    placeholders: &mut Vec<String>,
+) {
+    match m.get(Value::String(field.to_string())) {
+        None => missing.push(field.to_string()),
+        Some(Value::Sequence(seq)) => {
+            if seq.is_empty() {
+                missing.push(format!("{field} (empty list)"));
+            } else {
+                scan_list_entries(field, seq, placeholders);
+            }
+        }
+        Some(Value::Null) => missing.push(field.to_string()),
+        Some(_) => missing.push(format!("{field} (not a list)")),
+    }
+}
+
+fn check_list_present(
+    m: &Mapping,
+    field: &str,
+    missing: &mut Vec<String>,
+    placeholders: &mut Vec<String>,
+) {
+    match m.get(Value::String(field.to_string())) {
+        None => missing.push(format!("{field} (missing; use [] if truly empty)")),
+        Some(Value::Sequence(seq)) => scan_list_entries(field, seq, placeholders),
+        Some(Value::Null) => missing.push(format!("{field} (null; use [] if truly empty)")),
+        Some(_) => missing.push(format!("{field} (not a list)")),
+    }
+}
+
+fn scan_list_entries(field: &str, seq: &[Value], placeholders: &mut Vec<String>) {
+    for (idx, entry) in seq.iter().enumerate() {
+        let Value::String(s) = entry else {
+            // Non-string entries in these fields are suspicious but we only
+            // flag placeholder text; leave structural validation to a richer
+            // downstream unit.
+            continue;
+        };
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            placeholders.push(format!("{field}[{idx}]: <empty>"));
+            continue;
+        }
+        if is_placeholder_value(trimmed) {
+            placeholders.push(format!("{field}[{idx}]: {}", summarize(trimmed)));
+        } else if let Some(marker) = find_fill_marker(trimmed) {
+            placeholders.push(format!("{field}[{idx}]: {marker}"));
+        }
+    }
+}
+
+fn reject_success_criteria_boilerplate(m: &Mapping, placeholders: &mut Vec<String>) {
+    let Some(Value::Sequence(seq)) = m.get(Value::String("success_criteria".to_string())) else {
+        return;
+    };
+    for (idx, entry) in seq.iter().enumerate() {
+        let Value::String(s) = entry else { continue };
+        let lower = s.trim().to_lowercase();
+        if is_success_boilerplate(&lower) {
+            placeholders.push(format!("success_criteria[{idx}]: {}", summarize(s.trim())));
+        }
+    }
+}
+
+fn is_success_boilerplate(lower: &str) -> bool {
+    matches!(
+        lower,
+        "works well"
+            | "is reliable"
+            | "reliable"
+            | "is done"
+            | "done"
+            | "succeeds"
+            | "success"
+            | "overall"
+            | "codex1 works well."
+            | "codex1 works well"
+    )
+}
+
+/// Return true for generic placeholder scalars that should block ratification.
+fn is_placeholder_value(value: &str) -> bool {
+    let lower = value.to_lowercase();
+    matches!(
+        lower.as_str(),
+        "todo"
+            | "tbd"
+            | "..."
+            | "\"works well\""
+            | "works well"
+            | "reliable"
+            | "overall"
+            | "codex1 works well."
+            | "codex1 works well"
+    )
+}
+
+fn find_fill_marker(value: &str) -> Option<String> {
+    let needle = "[codex1-fill:";
+    let start = value.find(needle)?;
+    let rest = &value[start..];
+    let end = rest.find(']')?;
+    Some(rest[..=end].to_string())
+}
+
+fn collect_fill_markers(raw: &str, placeholders: &mut Vec<String>) {
+    let mut cursor = 0;
+    while let Some(rel) = raw[cursor..].find("[codex1-fill:") {
+        let start = cursor + rel;
+        if let Some(rel_end) = raw[start..].find(']') {
+            let marker = &raw[start..=start + rel_end];
+            placeholders.push(marker.to_string());
+            cursor = start + rel_end + 1;
+        } else {
+            // Unterminated marker — record what we can and stop.
+            placeholders.push(raw[start..].to_string());
+            break;
+        }
+    }
+}
+
+fn dedup_in_place(items: &mut Vec<String>) {
+    let mut seen = std::collections::HashSet::new();
+    items.retain(|s| seen.insert(s.clone()));
+}
+
+fn summarize(value: &str) -> String {
+    const MAX: usize = 80;
+    if value.chars().count() > MAX {
+        let truncated: String = value.chars().take(MAX).collect();
+        format!("{truncated}…")
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_frontmatter_basic() {
+        let raw = "---\nmission_id: demo\n---\n\n# Body\n";
+        let (front, body) = split_frontmatter(raw).unwrap();
+        assert_eq!(front, "mission_id: demo\n");
+        assert_eq!(body, "\n# Body\n");
+    }
+
+    #[test]
+    fn split_frontmatter_missing_fences_returns_none() {
+        let raw = "# just markdown\n";
+        assert!(split_frontmatter(raw).is_none());
+    }
+
+    #[test]
+    fn find_fill_marker_detects_codex1_fill() {
+        assert_eq!(
+            find_fill_marker("[codex1-fill:title]").as_deref(),
+            Some("[codex1-fill:title]")
+        );
+        assert!(find_fill_marker("no marker here").is_none());
+    }
+
+    #[test]
+    fn is_placeholder_detects_common_strings() {
+        assert!(is_placeholder_value("TODO"));
+        assert!(is_placeholder_value("TBD"));
+        assert!(is_placeholder_value("..."));
+        assert!(is_placeholder_value("works well"));
+        assert!(!is_placeholder_value("The system must validate inputs."));
+    }
+}

--- a/crates/codex1/tests/foundation.rs
+++ b/crates/codex1/tests/foundation.rs
@@ -125,21 +125,9 @@ fn status_without_mission_reports_needs_user() {
     assert_eq!(json["data"]["stop"]["allow"], true);
 }
 
-#[test]
-fn outcome_stubs_return_not_implemented() {
-    let tmp = TempDir::new().unwrap();
-    init_demo(&tmp, "demo");
-    let output = cmd()
-        .current_dir(tmp.path())
-        .args(["outcome", "check", "--mission", "demo"])
-        .output()
-        .expect("runs");
-    assert!(!output.status.success());
-    let json = parse_stdout_json(&output);
-    assert_eq!(json["ok"], Value::Bool(false));
-    assert_eq!(json["code"], "NOT_IMPLEMENTED");
-    assert_eq!(json["context"]["command"], "outcome check");
-}
+// `outcome_stubs_return_not_implemented` removed: Phase B Unit 2
+// (cli-outcome) has replaced the stub with the real implementation.
+// See `tests/outcome.rs` for the Phase B integration coverage.
 
 #[test]
 fn plan_stubs_return_not_implemented() {

--- a/crates/codex1/tests/outcome.rs
+++ b/crates/codex1/tests/outcome.rs
@@ -1,0 +1,408 @@
+//! Integration tests for `codex1 outcome check` and `codex1 outcome ratify`.
+//!
+//! Coverage:
+//!   1. Fresh init fails `check` with OUTCOME_INCOMPLETE + fill markers.
+//!   2. Filled OUTCOME.md passes `check` with ratifiable: true.
+//!   3. Boilerplate (`TODO`, `TBD`, …) is flagged by `check`.
+//!   4. `ratify` on invalid OUTCOME.md does not mutate STATE.json.
+//!   5. `ratify` on valid OUTCOME.md bumps revision, writes event, flips
+//!      frontmatter status, advances phase to `plan`.
+//!   6. `ratify --dry-run` validates but does not mutate.
+//!   7. `ratify --expect-revision 999` returns REVISION_CONFLICT.
+//!   8. `ratify` then `check` → still ratifiable (idempotent view).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_demo(tmp: &TempDir, mission: &str) -> PathBuf {
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", mission])
+        .assert()
+        .success();
+    tmp.path().join("PLANS").join(mission)
+}
+
+fn parse_json(output: &Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(stdout).unwrap_or_else(|e| {
+        panic!("expected JSON stdout, got:\n{stdout}\nerror: {e}");
+    })
+}
+
+/// Overwrite OUTCOME.md with a fully-filled, ratifiable template.
+fn seed_valid_outcome(mission_dir: &Path, mission_id: &str) {
+    let body = format!(
+        r"---
+mission_id: {mission_id}
+status: draft
+title: Demo mission for outcome tests
+
+original_user_goal: |
+  The user wants to exercise the outcome ratification flow end to end,
+  validating that every required field is present and free of placeholders.
+
+interpreted_destination: |
+  Codex1 correctly treats a fully-filled OUTCOME.md as ratifiable, flips
+  the frontmatter status to ratified, and advances the mission phase.
+
+must_be_true:
+  - The mission has a single clarified destination captured in OUTCOME.md.
+  - Every required field contains concrete content, not fill markers.
+
+success_criteria:
+  - codex1 outcome check returns ratifiable true for this fixture.
+  - codex1 outcome ratify flips phase from clarify to plan and records ratified_at.
+
+non_goals:
+  - Do not implement planning logic in this unit.
+  - Do not change Foundation files.
+
+constraints:
+  - Tests must use tempfile-backed mission directories only.
+  - OUTCOME.md rewrite must preserve the markdown body byte-for-byte.
+
+quality_bar:
+  - The check command is idempotent and side-effect free.
+
+proof_expectations:
+  - cargo test outcome passes for this unit.
+
+review_expectations:
+  - The main thread reviews outcome validation before plan scaffolding.
+
+known_risks:
+  - YAML frontmatter reordering on rewrite could silently corrupt missions.
+
+resolved_questions:
+  - question: Should status ratification rewrite the file?
+    answer: Yes, atomically, only the status line inside the frontmatter.
+---
+
+# OUTCOME
+
+Body paragraph for the test fixture.
+"
+    );
+    let outcome_path = mission_dir.join("OUTCOME.md");
+    fs::write(&outcome_path, body).expect("write OUTCOME.md");
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    let raw = fs::read_to_string(mission_dir.join("STATE.json")).expect("read state");
+    serde_json::from_str(&raw).expect("parse state")
+}
+
+fn read_events(mission_dir: &Path) -> Vec<Value> {
+    let raw = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap_or_default();
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("parse event line"))
+        .collect()
+}
+
+#[test]
+fn check_on_fresh_init_reports_fill_markers() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success(), "expected non-zero exit");
+    let json = parse_json(&output);
+    assert_eq!(json["ok"], Value::Bool(false));
+    assert_eq!(json["code"], "OUTCOME_INCOMPLETE");
+    let placeholders = json["context"]["placeholders"]
+        .as_array()
+        .expect("placeholders array");
+    assert!(
+        !placeholders.is_empty(),
+        "expected fill markers in context.placeholders, got: {json}"
+    );
+    let any_marker = placeholders
+        .iter()
+        .any(|p| p.as_str().unwrap_or("").contains("[codex1-fill:"));
+    assert!(
+        any_marker,
+        "expected at least one [codex1-fill:…] marker, got: {placeholders:?}"
+    );
+    assert_eq!(json["context"]["mission_id"], "demo");
+}
+
+#[test]
+fn check_on_valid_outcome_is_ratifiable() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_valid_outcome(&mission_dir, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success(), "expected success: {:?}", output);
+    let json = parse_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["ratifiable"], true);
+    assert_eq!(json["data"]["missing_fields"].as_array().unwrap().len(), 0);
+    assert_eq!(json["data"]["placeholders"].as_array().unwrap().len(), 0);
+    assert_eq!(json["mission_id"], "demo");
+}
+
+#[test]
+fn check_flags_boilerplate_placeholders() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    // Seed the mandatory fields but inject boilerplate in multiple places.
+    let body = r"---
+mission_id: demo
+status: draft
+title: TODO
+
+original_user_goal: |
+  TBD
+
+interpreted_destination: |
+  Codex1 works well.
+
+must_be_true:
+  - TODO
+
+success_criteria:
+  - works well
+  - reliable
+
+non_goals: []
+
+constraints: []
+
+quality_bar:
+  - TBD
+
+proof_expectations: []
+
+review_expectations: []
+
+known_risks: []
+
+resolved_questions: []
+---
+
+# OUTCOME
+";
+    fs::write(mission_dir.join("OUTCOME.md"), body).unwrap();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_json(&output);
+    assert_eq!(json["code"], "OUTCOME_INCOMPLETE");
+    let placeholders: Vec<String> = json["context"]["placeholders"]
+        .as_array()
+        .expect("placeholders array")
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_string())
+        .collect();
+    // Every injected boilerplate should surface somewhere in the list.
+    let joined = placeholders.join("\n");
+    assert!(
+        joined.to_lowercase().contains("todo"),
+        "missing TODO detection in: {joined}"
+    );
+    assert!(
+        joined.to_lowercase().contains("tbd"),
+        "missing TBD detection in: {joined}"
+    );
+    assert!(
+        joined.to_lowercase().contains("works well")
+            || joined.to_lowercase().contains("codex1 works well"),
+        "missing 'works well' detection in: {joined}"
+    );
+    assert!(
+        joined.to_lowercase().contains("reliable"),
+        "missing 'reliable' detection in: {joined}"
+    );
+}
+
+#[test]
+fn ratify_on_invalid_outcome_does_not_mutate_state() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state_before = read_state(&mission_dir);
+    let outcome_before = fs::read_to_string(mission_dir.join("OUTCOME.md")).unwrap();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "ratify", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_json(&output);
+    assert_eq!(json["code"], "OUTCOME_INCOMPLETE");
+
+    let state_after = read_state(&mission_dir);
+    assert_eq!(state_before["revision"], state_after["revision"]);
+    assert_eq!(state_before["phase"], state_after["phase"]);
+    assert_eq!(state_after["outcome"]["ratified"], false);
+    let events = read_events(&mission_dir);
+    assert!(
+        events.is_empty(),
+        "failed ratify must not append events; got {events:?}"
+    );
+    // OUTCOME.md untouched.
+    let outcome_after = fs::read_to_string(mission_dir.join("OUTCOME.md")).unwrap();
+    assert_eq!(outcome_before, outcome_after);
+}
+
+#[test]
+fn ratify_on_valid_outcome_bumps_state_and_rewrites_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_valid_outcome(&mission_dir, "demo");
+    let rev_before = read_state(&mission_dir)["revision"].as_u64().unwrap();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "ratify", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success(), "ratify failed: {:?}", output);
+    let json = parse_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["mission_id"], "demo");
+    assert_eq!(json["data"]["phase"], "plan");
+    assert!(
+        json["data"]["ratified_at"].is_string(),
+        "ratified_at missing: {json}"
+    );
+    assert_eq!(json["revision"], rev_before + 1);
+
+    // State mutated.
+    let state_after = read_state(&mission_dir);
+    assert_eq!(state_after["revision"], rev_before + 1);
+    assert_eq!(state_after["phase"], "plan");
+    assert_eq!(state_after["outcome"]["ratified"], true);
+    assert!(state_after["outcome"]["ratified_at"].is_string());
+
+    // Event appended.
+    let events = read_events(&mission_dir);
+    assert_eq!(events.len(), 1, "expected one event, got {events:?}");
+    assert_eq!(events[0]["kind"], "outcome.ratified");
+    assert_eq!(events[0]["payload"]["mission_id"], "demo");
+
+    // OUTCOME.md frontmatter flipped.
+    let outcome = fs::read_to_string(mission_dir.join("OUTCOME.md")).unwrap();
+    assert!(
+        outcome.contains("status: ratified"),
+        "frontmatter not flipped: {outcome}"
+    );
+    assert!(
+        !outcome.contains("status: draft"),
+        "old status: draft still present: {outcome}"
+    );
+    // Body preserved.
+    assert!(outcome.contains("# OUTCOME"));
+    assert!(outcome.contains("Body paragraph for the test fixture."));
+}
+
+#[test]
+fn ratify_dry_run_does_not_mutate() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_valid_outcome(&mission_dir, "demo");
+    let state_before = read_state(&mission_dir);
+    let outcome_before = fs::read_to_string(mission_dir.join("OUTCOME.md")).unwrap();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "ratify", "--mission", "demo", "--dry-run"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success(), "dry-run failed: {:?}", output);
+    let json = parse_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["phase"], "plan");
+
+    let state_after = read_state(&mission_dir);
+    assert_eq!(state_before["revision"], state_after["revision"]);
+    assert_eq!(state_before["phase"], state_after["phase"]);
+    assert_eq!(state_after["outcome"]["ratified"], false);
+    let events = read_events(&mission_dir);
+    assert!(events.is_empty());
+    let outcome_after = fs::read_to_string(mission_dir.join("OUTCOME.md")).unwrap();
+    assert_eq!(outcome_before, outcome_after);
+}
+
+#[test]
+fn ratify_rejects_stale_expect_revision() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_valid_outcome(&mission_dir, "demo");
+    let rev_before = read_state(&mission_dir)["revision"].as_u64().unwrap();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "outcome",
+            "ratify",
+            "--mission",
+            "demo",
+            "--expect-revision",
+            "999",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_json(&output);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+    assert_eq!(json["retryable"], true);
+    assert_eq!(json["context"]["expected"], 999);
+    assert_eq!(json["context"]["actual"], rev_before);
+
+    // State unchanged after rejected mutation.
+    let state_after = read_state(&mission_dir);
+    assert_eq!(state_after["revision"], rev_before);
+    assert_eq!(state_after["outcome"]["ratified"], false);
+}
+
+#[test]
+fn check_after_ratify_still_ratifiable() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_valid_outcome(&mission_dir, "demo");
+
+    let ratify = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "ratify", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(ratify.status.success());
+
+    let check = cmd()
+        .current_dir(tmp.path())
+        .args(["outcome", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(
+        check.status.success(),
+        "check after ratify failed: {:?}",
+        check
+    );
+    let json = parse_json(&check);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["ratifiable"], true);
+}


### PR DESCRIPTION
Implements `codex1 outcome check` + `codex1 outcome ratify` per `docs/cli-contract-schemas.md`.

## Summary
- `outcome check` validates OUTCOME.md (YAML frontmatter + body sweep), reporting every missing required field and every `[codex1-fill:...]` / boilerplate placeholder.
- `outcome ratify` revalidates, then flips `state.outcome.ratified`, stamps `ratified_at`, advances `phase: clarify -> plan`, and atomically rewrites OUTCOME.md `status: draft -> status: ratified` inside the `state::mutate` closure so state + file stay coherent.
- Honours the contract's `context.missing_fields` / `context.placeholders` promise by assembling the enriched `OUTCOME_INCOMPLETE` envelope and `exit(1)` before `cli::dispatch` reprints — the only way to do this without touching Foundation files. Workaround is isolated to `cli/outcome/emit.rs`.
- Drops the now-stale `outcome_stubs_return_not_implemented` test in Foundation's test file; real coverage lives in `tests/outcome.rs`.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` and `cargo test --release` green (27 tests)
- [x] Smoke test from `/tmp`: `codex1 init` then `codex1 outcome check` returns `OUTCOME_INCOMPLETE` with every template marker surfaced in `context.placeholders`
- [x] Tests cover: fill-marker detection on fresh init, ratifiable-true on a filled OUTCOME.md, boilerplate rejection (TODO/TBD/`works well`/`reliable`), invalid ratify leaves state untouched, valid ratify bumps revision + writes event + flips frontmatter + advances phase, `--dry-run` is truly side-effect free, `--expect-revision 999` returns `REVISION_CONFLICT` (retryable), and `check` after `ratify` is still ratifiable (idempotent view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)