### PR TITLE
Unit 4: cli-plan check

### DIFF
--- a/crates/codex1/src/cli/plan/check.rs
+++ b/crates/codex1/src/cli/plan/check.rs
@@ -1,0 +1,551 @@
+//! `codex1 plan check` — validate PLAN.yaml structure and task DAG.
+//!
+//! On success (non-dry-run): lock the plan, record its SHA-256 hash, and
+//! advance `state.phase` from `plan` to `execute` via the mutation
+//! protocol. Re-running on an already-locked plan with an unchanged hash
+//! is idempotent — no state change, no new event.
+//!
+//! Error envelopes for PLAN_INVALID / DAG_CYCLE / DAG_MISSING_DEP carry a
+//! structured `context` field (e.g. `{ "task_id": "T3", "missing_dep":
+//! "T99" }`). Because the canonical `CliError::context()` for these
+//! variants defaults to `Value::Null` and `src/core/**` is foundation-owned,
+//! validation failures are printed here via `exit_with_validation_error`
+//! (exits code 1) so the top-level dispatcher never re-prints them.
+
+use std::collections::BTreeSet;
+use std::fs;
+
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::cli::Ctx;
+use crate::core::envelope::{JsonErr, JsonOk};
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::core::paths::MissionPaths;
+use crate::state::{self, Phase, PlanLevel};
+
+use super::dag::{topo_sort, TopoOutcome};
+use super::parsed::{ParsedPlan, TaskSpec, HARD_EVIDENCE_KINDS, PLAN_LEVELS, TASK_KINDS};
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let plan_path = paths.plan();
+    if !plan_path.is_file() {
+        return Err(CliError::PlanInvalid {
+            message: format!("PLAN.yaml missing at {}", plan_path.display()),
+            hint: Some("Run `codex1 plan scaffold --level <level>` first.".to_string()),
+        });
+    }
+
+    let raw = fs::read_to_string(&plan_path)?;
+    if let Some(pos) = raw.find("[codex1-fill:") {
+        let preview: String = raw[pos..].chars().take(60).collect();
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            &format!("PLAN.yaml still contains a [codex1-fill:…] marker: {preview}"),
+            Some("Replace every [codex1-fill:…] marker with the real plan content."),
+            json!({ "marker_preview": preview }),
+        );
+    }
+
+    let parsed: ParsedPlan = serde_yaml::from_str(&raw).map_err(|err| CliError::PlanInvalid {
+        message: format!("PLAN.yaml is not valid YAML: {err}"),
+        hint: Some("Re-run `codex1 plan scaffold` to restore the template.".to_string()),
+    })?;
+
+    let summary = validate(&parsed, &paths);
+
+    let hash = plan_hash(raw.as_bytes());
+
+    // Idempotent short-circuit: same hash on an already-locked plan → no mutation.
+    let current = state::load(&paths)?;
+    let already_locked_same =
+        current.plan.locked && current.plan.hash.as_deref() == Some(hash.as_str());
+
+    if ctx.dry_run || already_locked_same {
+        // Dry-run reports `locked: false` regardless of current state
+        // (the invariant is "this call did not mutate"). Idempotent
+        // re-runs report `locked: true` to confirm the plan is locked.
+        let reported_locked = !ctx.dry_run && already_locked_same;
+        let env = JsonOk::new(
+            Some(paths.mission_id.clone()),
+            Some(current.revision),
+            json!({
+                "tasks": summary.total_tasks,
+                "review_tasks": summary.review_tasks,
+                "hard_evidence": summary.hard_evidence_count,
+                "plan_hash": hash,
+                "locked": reported_locked,
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    let event_payload = json!({
+        "plan_hash": hash,
+        "tasks": summary.total_tasks,
+        "review_tasks": summary.review_tasks,
+        "hard_evidence": summary.hard_evidence_count,
+        "requested_level": level_str(&summary.requested_level),
+        "effective_level": level_str(&summary.effective_level),
+    });
+
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        "plan.checked",
+        event_payload,
+        |s| {
+            s.plan.locked = true;
+            s.plan.hash = Some(hash.clone());
+            s.plan.requested_level = Some(summary.requested_level.clone());
+            s.plan.effective_level = Some(summary.effective_level.clone());
+            if matches!(s.phase, Phase::Plan) {
+                s.phase = Phase::Execute;
+            }
+            Ok(())
+        },
+    )?;
+
+    let env = JsonOk::new(
+        Some(paths.mission_id.clone()),
+        Some(mutation.new_revision),
+        json!({
+            "tasks": summary.total_tasks,
+            "review_tasks": summary.review_tasks,
+            "hard_evidence": summary.hard_evidence_count,
+            "plan_hash": hash,
+            "locked": true,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+struct Summary {
+    total_tasks: usize,
+    review_tasks: usize,
+    hard_evidence_count: usize,
+    requested_level: PlanLevel,
+    effective_level: PlanLevel,
+}
+
+/// Validate the parsed plan. On first failure this exits the process with
+/// a structured error envelope on stdout — never returns the error up the
+/// call stack, so callers never have to worry about context round-tripping.
+fn validate(plan: &ParsedPlan, paths: &MissionPaths) -> Summary {
+    // Top-level sections.
+    require_string("mission_id", plan.mission_id.as_deref());
+
+    let level = plan.planning_level.as_ref().unwrap_or_else(|| {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "planning_level missing",
+            Some("Add planning_level.requested and planning_level.effective."),
+            Value::Null,
+        )
+    });
+    let requested_level = parse_level("planning_level.requested", level.requested.as_deref());
+    let effective_level = parse_level("planning_level.effective", level.effective.as_deref());
+
+    let outcome = plan.outcome_interpretation.as_ref().unwrap_or_else(|| {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "outcome_interpretation missing",
+            Some("Add outcome_interpretation.summary."),
+            Value::Null,
+        )
+    });
+    require_string("outcome_interpretation.summary", outcome.summary.as_deref());
+
+    let arch = plan.architecture.as_ref().unwrap_or_else(|| {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "architecture missing",
+            Some("Add architecture.summary and architecture.key_decisions[]."),
+            Value::Null,
+        )
+    });
+    require_string("architecture.summary", arch.summary.as_deref());
+    if arch.key_decisions.is_empty() {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "architecture.key_decisions is empty",
+            Some("Record at least one key decision."),
+            Value::Null,
+        );
+    }
+
+    let process = plan.planning_process.as_ref().unwrap_or_else(|| {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "planning_process missing",
+            Some("Add planning_process.evidence[]."),
+            Value::Null,
+        )
+    });
+
+    if plan.tasks.is_empty() {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "tasks list is empty",
+            Some("Every mission needs at least one task."),
+            Value::Null,
+        );
+    }
+
+    if plan.risks.is_empty() {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "risks list is empty",
+            Some("Record at least one risk + mitigation."),
+            Value::Null,
+        );
+    }
+    for (idx, risk) in plan.risks.iter().enumerate() {
+        require_string(&format!("risks[{idx}].risk"), risk.risk.as_deref());
+        require_string(
+            &format!("risks[{idx}].mitigation"),
+            risk.mitigation.as_deref(),
+        );
+    }
+
+    let mission_close = plan.mission_close.as_ref().unwrap_or_else(|| {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "mission_close missing",
+            Some("Add mission_close.criteria[]."),
+            Value::Null,
+        )
+    });
+    if mission_close.criteria.is_empty() {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            "mission_close.criteria is empty",
+            Some("List the conditions that must hold before close."),
+            Value::Null,
+        );
+    }
+
+    // Task-level validation.
+    let task_ids = validate_tasks(&plan.tasks, paths);
+
+    // Hard-plan evidence gate.
+    let hard_evidence_count = process
+        .evidence
+        .iter()
+        .filter(|e| {
+            e.kind
+                .as_deref()
+                .is_some_and(|k| HARD_EVIDENCE_KINDS.contains(&k))
+        })
+        .count();
+    if matches!(effective_level, PlanLevel::Hard) {
+        if process.evidence.is_empty() {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                "planning_process.evidence is empty but effective level is hard",
+                Some("Hard planning requires recorded evidence (explorer/advisor/plan_review)."),
+                json!({ "missing_hard_evidence": true, "hard_evidence_count": 0 }),
+            );
+        }
+        if hard_evidence_count == 0 {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                "no hard-qualifying evidence entries in planning_process.evidence",
+                Some(
+                    "Add at least one evidence entry with kind in {explorer, advisor, plan_review}.",
+                ),
+                json!({
+                    "missing_hard_evidence": true,
+                    "recorded_evidence_kinds": process
+                        .evidence
+                        .iter()
+                        .filter_map(|e| e.kind.clone())
+                        .collect::<Vec<_>>(),
+                }),
+            );
+        }
+    }
+
+    let review_tasks = plan
+        .tasks
+        .iter()
+        .filter(|t| t.kind.as_deref() == Some("review"))
+        .count();
+
+    // Cycle check (missing-dep already handled in validate_tasks).
+    let mut deps = std::collections::BTreeMap::new();
+    for t in &plan.tasks {
+        let id = t.id.clone().unwrap_or_default();
+        let ds = t.depends_on.clone().unwrap_or_default();
+        deps.insert(id, ds);
+    }
+    if let TopoOutcome::Cycle { remaining, edges } = topo_sort(&deps) {
+        let edges_json: Vec<Value> = edges.iter().map(|(a, b)| json!([a, b])).collect();
+        exit_with_validation_error(
+            "DAG_CYCLE",
+            &format!("cycle involving task(s): {}", remaining.join(", ")),
+            Some("Break the cycle by removing or redirecting one of the depends_on edges."),
+            json!({
+                "cycle_nodes": remaining,
+                "cycle_edges": edges_json,
+            }),
+        );
+    }
+
+    Summary {
+        total_tasks: task_ids.len(),
+        review_tasks,
+        hard_evidence_count,
+        requested_level,
+        effective_level,
+    }
+}
+
+fn validate_tasks(tasks: &[TaskSpec], paths: &MissionPaths) -> Vec<String> {
+    let mut ids: Vec<String> = Vec::with_capacity(tasks.len());
+    let mut seen = BTreeSet::new();
+    let mut duplicates = BTreeSet::new();
+
+    // First pass: presence, pattern, duplicates.
+    for (idx, task) in tasks.iter().enumerate() {
+        let id = task.id.clone().unwrap_or_else(|| {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                &format!("tasks[{idx}] is missing id"),
+                Some("Every task needs `id: T<n>`."),
+                json!({ "task_index": idx }),
+            )
+        });
+        if !is_valid_task_id(&id) {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                &format!("task id `{id}` does not match ^T\\d+$"),
+                Some("Use ids like T1, T2, T3; no leading zero, no suffixes."),
+                json!({ "invalid_id": id }),
+            );
+        }
+        if !seen.insert(id.clone()) {
+            duplicates.insert(id.clone());
+        }
+        ids.push(id);
+    }
+    if !duplicates.is_empty() {
+        let dups: Vec<String> = duplicates.iter().cloned().collect();
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            &format!("duplicate task ids: {}", dups.join(", ")),
+            Some("Task ids must be unique across the plan."),
+            json!({ "duplicate_ids": dups }),
+        );
+    }
+    let id_set: BTreeSet<_> = ids.iter().cloned().collect();
+
+    // Second pass: required fields, kind, deps, review targets, spec file.
+    let non_review_ids: BTreeSet<String> = tasks
+        .iter()
+        .filter(|t| t.kind.as_deref() != Some("review"))
+        .filter_map(|t| t.id.clone())
+        .collect();
+
+    for task in tasks {
+        let id = task.id.clone().unwrap_or_default();
+        require_string(&format!("tasks[{id}].title"), task.title.as_deref());
+
+        let kind = task.kind.as_deref().unwrap_or_else(|| {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                &format!("tasks[{id}] is missing kind"),
+                Some(&format!("Use one of {}.", TASK_KINDS.join(", "))),
+                json!({ "task_id": id }),
+            )
+        });
+        if !TASK_KINDS.contains(&kind) {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                &format!("tasks[{id}].kind `{kind}` is not a known kind"),
+                Some(&format!("Use one of {}.", TASK_KINDS.join(", "))),
+                json!({ "task_id": id, "kind": kind }),
+            );
+        }
+
+        let deps = task.depends_on.as_ref().unwrap_or_else(|| {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                &format!("tasks[{id}] is missing depends_on"),
+                Some("Use `depends_on: []` for root tasks."),
+                json!({ "task_id": id }),
+            )
+        });
+        for dep in deps {
+            if dep == &id {
+                exit_with_validation_error(
+                    "DAG_CYCLE",
+                    &format!("tasks[{id}] depends on itself"),
+                    Some("Break the cycle by removing or redirecting one of the depends_on edges."),
+                    json!({
+                        "cycle_nodes": [id.clone()],
+                        "cycle_edges": [[id.clone(), id.clone()]],
+                    }),
+                );
+            }
+            if !id_set.contains(dep) {
+                exit_with_validation_error(
+                    "DAG_MISSING_DEP",
+                    &format!("tasks[{id}] depends_on unknown task `{dep}`"),
+                    Some(
+                        "Ensure every depends_on entry references an existing task id (e.g. T1, T2).",
+                    ),
+                    json!({
+                        "task_id": id,
+                        "missing_dep": dep,
+                    }),
+                );
+            }
+        }
+
+        require_string(&format!("tasks[{id}].spec"), task.spec.as_deref());
+        let spec_rel = task.spec.as_deref().unwrap_or("");
+        let spec_abs = paths.mission_dir.join(spec_rel);
+        if !spec_abs.is_file() {
+            exit_with_validation_error(
+                "PLAN_INVALID",
+                &format!("tasks[{id}].spec file not found at {}", spec_abs.display()),
+                Some(&format!("Create `{spec_rel}` under the mission directory.")),
+                json!({
+                    "task_id": id,
+                    "missing_spec": spec_rel,
+                }),
+            );
+        }
+
+        if kind == "review" {
+            let target = task.review_target.as_ref().unwrap_or_else(|| {
+                exit_with_validation_error(
+                    "PLAN_INVALID",
+                    &format!("review task {id} is missing review_target"),
+                    Some(
+                        "Add `review_target:\n  tasks: [T…]` listing the non-review tasks under review.",
+                    ),
+                    json!({ "task_id": id }),
+                )
+            });
+            if target.tasks.is_empty() {
+                exit_with_validation_error(
+                    "PLAN_INVALID",
+                    &format!("review task {id} has empty review_target.tasks"),
+                    Some("List at least one target task id."),
+                    json!({ "task_id": id }),
+                );
+            }
+            for t in &target.tasks {
+                if !non_review_ids.contains(t) {
+                    exit_with_validation_error(
+                        "PLAN_INVALID",
+                        &format!(
+                            "review task {id} targets `{t}` which is not a known non-review task"
+                        ),
+                        Some("review_target.tasks must reference existing non-review task ids."),
+                        json!({
+                            "task_id": id,
+                            "invalid_target": t,
+                        }),
+                    );
+                }
+            }
+        }
+    }
+
+    ids
+}
+
+fn parse_level(field: &str, value: Option<&str>) -> PlanLevel {
+    let value = value.unwrap_or_else(|| {
+        exit_with_validation_error(
+            "PLAN_INVALID",
+            &format!("{field} missing"),
+            Some(&format!("Use one of {}.", PLAN_LEVELS.join(", "))),
+            Value::Null,
+        )
+    });
+    match value {
+        "light" => PlanLevel::Light,
+        "medium" => PlanLevel::Medium,
+        "hard" => PlanLevel::Hard,
+        other => exit_with_validation_error(
+            "PLAN_INVALID",
+            &format!("{field} `{other}` is not a known planning level"),
+            Some(&format!("Use one of {}.", PLAN_LEVELS.join(", "))),
+            json!({ "field": field, "value": other }),
+        ),
+    }
+}
+
+fn require_string(field: &str, value: Option<&str>) {
+    match value.map(str::trim) {
+        Some(s) if !s.is_empty() => {}
+        _ => exit_with_validation_error(
+            "PLAN_INVALID",
+            &format!("{field} is missing or empty"),
+            None,
+            json!({ "field": field }),
+        ),
+    }
+}
+
+/// Print a validation error envelope to stdout and exit the process with
+/// code 1. Used for every fail-early branch in `plan check`.
+#[cold]
+fn exit_with_validation_error(code: &str, message: &str, hint: Option<&str>, context: Value) -> ! {
+    use std::io::Write as _;
+    let env = JsonErr::new(
+        code.to_string(),
+        message.to_string(),
+        hint.map(ToString::to_string),
+        false,
+        context,
+    );
+    println!("{}", env.to_pretty());
+    // Explicit flush in case process::exit skips destructors that would
+    // drain buffered stdout.
+    let _ = std::io::stdout().flush();
+    std::process::exit(1)
+}
+
+/// Matches `^T\d+$` with the additional constraint that the digit run
+/// cannot start with `0` (so `T1` is valid but `T01` and `T0` are not).
+fn is_valid_task_id(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix('T') else {
+        return false;
+    };
+    let mut chars = rest.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_digit() && c != '0' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_digit())
+}
+
+fn plan_hash(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(7 + digest.len() * 2);
+    out.push_str("sha256:");
+    for b in digest {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+fn level_str(l: &PlanLevel) -> &'static str {
+    match l {
+        PlanLevel::Light => "light",
+        PlanLevel::Medium => "medium",
+        PlanLevel::Hard => "hard",
+    }
+}

--- a/crates/codex1/src/cli/plan/dag.rs
+++ b/crates/codex1/src/cli/plan/dag.rs
@@ -1,0 +1,142 @@
+//! DAG validation: Kahn topological sort + cycle-edge reconstruction.
+//!
+//! Inputs are already-deduplicated `(id, deps)` pairs so this module only
+//! handles graph topology. Missing-dep detection stays in the caller.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+/// Result of a topological sort attempt.
+#[derive(Debug)]
+pub enum TopoOutcome {
+    /// Tasks in a valid topological order.
+    Ordered(Vec<String>),
+    /// A cycle was detected. `remaining` is the set of nodes that could not
+    /// be scheduled; `edges` is a list of `(from, to)` dependency edges
+    /// participating in the cycle.
+    Cycle {
+        remaining: Vec<String>,
+        edges: Vec<(String, String)>,
+    },
+}
+
+/// Run Kahn's algorithm. `deps[id]` is the set of ids `id` depends on
+/// (i.e. incoming edges in the "dep -> task" orientation).
+#[must_use]
+pub fn topo_sort(deps: &BTreeMap<String, Vec<String>>) -> TopoOutcome {
+    let ids: BTreeSet<_> = deps.keys().cloned().collect();
+    let mut indegree: BTreeMap<String, usize> = ids.iter().map(|id| (id.clone(), 0)).collect();
+    // "dep -> task" adjacency so we can decrement successors when a dep resolves.
+    let mut succ: BTreeMap<String, Vec<String>> =
+        ids.iter().map(|id| (id.clone(), Vec::new())).collect();
+
+    for (id, edges) in deps {
+        for dep in edges {
+            if ids.contains(dep) {
+                *indegree.entry(id.clone()).or_insert(0) += 1;
+                succ.entry(dep.clone()).or_default().push(id.clone());
+            }
+        }
+    }
+
+    let mut queue: VecDeque<String> = indegree
+        .iter()
+        .filter(|(_, &n)| n == 0)
+        .map(|(id, _)| id.clone())
+        .collect();
+    let mut ordered = Vec::with_capacity(ids.len());
+    while let Some(id) = queue.pop_front() {
+        ordered.push(id.clone());
+        if let Some(children) = succ.get(&id) {
+            for child in children {
+                let entry = indegree.get_mut(child).expect("indegree entry");
+                *entry -= 1;
+                if *entry == 0 {
+                    queue.push_back(child.clone());
+                }
+            }
+        }
+    }
+
+    if ordered.len() == ids.len() {
+        return TopoOutcome::Ordered(ordered);
+    }
+
+    // Cycle branch. Collect the ids that never scheduled and the edges
+    // wholly within that set.
+    let scheduled: BTreeSet<_> = ordered.into_iter().collect();
+    let remaining: Vec<String> = ids
+        .iter()
+        .filter(|id| !scheduled.contains(*id))
+        .cloned()
+        .collect();
+    let remaining_set: BTreeSet<_> = remaining.iter().cloned().collect();
+
+    let mut edges: Vec<(String, String)> = Vec::new();
+    for id in &remaining {
+        if let Some(ds) = deps.get(id) {
+            for dep in ds {
+                if remaining_set.contains(dep) {
+                    edges.push((dep.clone(), id.clone()));
+                }
+            }
+        }
+    }
+
+    TopoOutcome::Cycle { remaining, edges }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deps(pairs: &[(&str, &[&str])]) -> BTreeMap<String, Vec<String>> {
+        pairs
+            .iter()
+            .map(|(id, ds)| {
+                (
+                    (*id).to_string(),
+                    ds.iter().map(|d| (*d).to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn linear_dag_orders() {
+        let g = deps(&[("T1", &[]), ("T2", &["T1"]), ("T3", &["T2"])]);
+        match topo_sort(&g) {
+            TopoOutcome::Ordered(order) => assert_eq!(order, vec!["T1", "T2", "T3"]),
+            TopoOutcome::Cycle { .. } => panic!("expected ordered"),
+        }
+    }
+
+    #[test]
+    fn diamond_dag_orders() {
+        let g = deps(&[
+            ("T1", &[]),
+            ("T2", &["T1"]),
+            ("T3", &["T1"]),
+            ("T4", &["T2", "T3"]),
+        ]);
+        match topo_sort(&g) {
+            TopoOutcome::Ordered(order) => {
+                assert_eq!(order[0], "T1");
+                assert_eq!(order[3], "T4");
+            }
+            TopoOutcome::Cycle { .. } => panic!("expected ordered"),
+        }
+    }
+
+    #[test]
+    fn simple_cycle_detected() {
+        let g = deps(&[("T1", &["T2"]), ("T2", &["T1"])]);
+        match topo_sort(&g) {
+            TopoOutcome::Cycle { remaining, edges } => {
+                assert!(remaining.contains(&"T1".to_string()));
+                assert!(remaining.contains(&"T2".to_string()));
+                assert_eq!(edges.len(), 2);
+            }
+            TopoOutcome::Ordered(_) => panic!("expected cycle"),
+        }
+    }
+}

--- a/crates/codex1/src/cli/plan/mod.rs
+++ b/crates/codex1/src/cli/plan/mod.rs
@@ -1,4 +1,12 @@
-//! `codex1 plan` stub — owned by Phase B Units 3/4/5.
+//! `codex1 plan` dispatcher.
+//!
+//! Foundation pins the subcommand enum and `dispatch`. Phase B unit 4 owns
+//! the `Check` arm; units 3 and 5 own the other arms. Each sibling module
+//! exposes a `run(ctx)` entry point.
+
+pub mod check;
+pub mod dag;
+pub mod parsed;
 
 use std::path::PathBuf;
 
@@ -44,15 +52,17 @@ pub enum GraphFormat {
     Json,
 }
 
-pub fn dispatch(cmd: PlanCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        PlanCmd::ChooseLevel { .. } => "plan choose-level",
-        PlanCmd::Scaffold { .. } => "plan scaffold",
-        PlanCmd::Check => "plan check",
-        PlanCmd::Graph { .. } => "plan graph",
-        PlanCmd::Waves => "plan waves",
+pub fn dispatch(cmd: PlanCmd, ctx: &Ctx) -> CliResult<()> {
+    let not_implemented = |label: &str| {
+        Err(CliError::NotImplemented {
+            command: label.to_string(),
+        })
     };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+    match cmd {
+        PlanCmd::Check => check::run(ctx),
+        PlanCmd::ChooseLevel { .. } => not_implemented("plan choose-level"),
+        PlanCmd::Scaffold { .. } => not_implemented("plan scaffold"),
+        PlanCmd::Graph { .. } => not_implemented("plan graph"),
+        PlanCmd::Waves => not_implemented("plan waves"),
+    }
 }

--- a/crates/codex1/src/cli/plan/parsed.rs
+++ b/crates/codex1/src/cli/plan/parsed.rs
@@ -1,0 +1,112 @@
+//! PLAN.yaml parsed types.
+//!
+//! These types mirror the plan contract in
+//! `docs/codex1-rebuild-handoff/03-planning-artifacts.md`. Deserialization
+//! stays lenient on optional fields and strict on required ones so that
+//! `plan check` can produce actionable `PLAN_INVALID` errors.
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ParsedPlan {
+    pub mission_id: Option<String>,
+    pub planning_level: Option<PlanningLevel>,
+    pub outcome_interpretation: Option<OutcomeInterpretation>,
+    pub architecture: Option<Architecture>,
+    pub planning_process: Option<PlanningProcess>,
+    #[serde(default)]
+    pub tasks: Vec<TaskSpec>,
+    #[serde(default)]
+    pub risks: Vec<Risk>,
+    pub mission_close: Option<MissionClose>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanningLevel {
+    pub requested: Option<String>,
+    pub effective: Option<String>,
+    #[serde(default)]
+    pub escalation_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OutcomeInterpretation {
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Architecture {
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub key_decisions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanningProcess {
+    #[serde(default)]
+    pub evidence: Vec<Evidence>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Evidence {
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub actor: Option<String>,
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub required_for_hard: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TaskSpec {
+    pub id: Option<String>,
+    pub title: Option<String>,
+    pub kind: Option<String>,
+    pub depends_on: Option<Vec<String>>,
+    pub spec: Option<String>,
+    #[serde(default)]
+    pub read_paths: Vec<String>,
+    #[serde(default)]
+    pub write_paths: Vec<String>,
+    #[serde(default)]
+    pub exclusive_resources: Vec<String>,
+    #[serde(default)]
+    pub unknown_side_effects: Option<bool>,
+    #[serde(default)]
+    pub acceptance: Vec<String>,
+    #[serde(default)]
+    pub proof: Vec<String>,
+    #[serde(default)]
+    pub review_target: Option<ReviewTarget>,
+    #[serde(default)]
+    pub review_profiles: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReviewTarget {
+    #[serde(default)]
+    pub tasks: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Risk {
+    pub risk: Option<String>,
+    pub mitigation: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MissionClose {
+    #[serde(default)]
+    pub criteria: Vec<String>,
+}
+
+/// Canonical task kinds.
+pub const TASK_KINDS: &[&str] = &[
+    "design", "code", "docs", "test", "research", "repair", "review",
+];
+
+/// Canonical planning levels.
+pub const PLAN_LEVELS: &[&str] = &["light", "medium", "hard"];
+
+/// Evidence kinds that satisfy the hard-plan evidence requirement.
+pub const HARD_EVIDENCE_KINDS: &[&str] = &["explorer", "advisor", "plan_review"];

--- a/crates/codex1/tests/foundation.rs
+++ b/crates/codex1/tests/foundation.rs
@@ -147,12 +147,12 @@ fn plan_stubs_return_not_implemented() {
     init_demo(&tmp, "demo");
     let output = cmd()
         .current_dir(tmp.path())
-        .args(["plan", "check", "--mission", "demo"])
+        .args(["plan", "waves", "--mission", "demo"])
         .output()
         .expect("runs");
     let json = parse_stdout_json(&output);
     assert_eq!(json["code"], "NOT_IMPLEMENTED");
-    assert_eq!(json["context"]["command"], "plan check");
+    assert_eq!(json["context"]["command"], "plan waves");
 }
 
 #[test]

--- a/crates/codex1/tests/plan_check.rs
+++ b/crates/codex1/tests/plan_check.rs
@@ -1,0 +1,655 @@
+//! Integration tests for `codex1 plan check`.
+//!
+//! Each test creates a temporary mission with `codex1 init --mission`,
+//! then writes a hand-crafted PLAN.yaml plus spec files and exercises
+//! `plan check` against it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_demo(tmp: &TempDir, mission: &str) -> PathBuf {
+    let mission_dir = tmp.path().join("PLANS").join(mission);
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", mission])
+        .assert()
+        .success();
+    mission_dir
+}
+
+fn write_spec(mission_dir: &Path, task_id: &str, body: &str) {
+    let spec_dir = mission_dir.join("specs").join(task_id);
+    fs::create_dir_all(&spec_dir).unwrap();
+    fs::write(spec_dir.join("SPEC.md"), body).unwrap();
+}
+
+fn write_plan(mission_dir: &Path, yaml: &str) {
+    fs::write(mission_dir.join("PLAN.yaml"), yaml).unwrap();
+}
+
+fn parse_stdout_json(output: &Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(stdout).unwrap_or_else(|e| {
+        panic!("expected JSON stdout, got:\n{stdout}\nerror: {e}");
+    })
+}
+
+fn run_check(tmp: &TempDir, mission: &str, extra_args: &[&str]) -> Output {
+    let mut c = cmd();
+    c.current_dir(tmp.path())
+        .args(["plan", "check", "--mission", mission]);
+    for a in extra_args {
+        c.arg(a);
+    }
+    c.output().expect("runs")
+}
+
+fn valid_4_task_yaml() -> String {
+    r#"mission_id: demo
+
+planning_level:
+  requested: medium
+  effective: medium
+
+outcome_interpretation:
+  summary: "Ship the demo mission."
+
+architecture:
+  summary: "Single crate, one executable."
+  key_decisions:
+    - "Use a single Cargo workspace."
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "Author-reviewed top-level design."
+
+tasks:
+  - id: T1
+    title: "Design API"
+    kind: design
+    depends_on: []
+    spec: specs/T1/SPEC.md
+  - id: T2
+    title: "Implement API"
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+  - id: T3
+    title: "Write docs"
+    kind: docs
+    depends_on: [T2]
+    spec: specs/T3/SPEC.md
+  - id: T4
+    title: "Review integration"
+    kind: review
+    depends_on: [T2, T3]
+    spec: specs/T4/SPEC.md
+    review_target:
+      tasks: [T2]
+    review_profiles:
+      - code_bug_correctness
+
+risks:
+  - risk: "Scope creep."
+    mitigation: "Freeze plan at lock."
+
+mission_close:
+  criteria:
+    - "All tasks complete and reviews clean."
+"#
+    .to_string()
+}
+
+fn seed_valid_mission(tmp: &TempDir, mission: &str) -> PathBuf {
+    let mission_dir = init_demo(tmp, mission);
+    for task in ["T1", "T2", "T3", "T4"] {
+        write_spec(&mission_dir, task, &format!("# {task} SPEC\n"));
+    }
+    write_plan(&mission_dir, &valid_4_task_yaml());
+    mission_dir
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(mission_dir.join("STATE.json")).unwrap()).unwrap()
+}
+
+fn read_events(mission_dir: &Path) -> Vec<Value> {
+    let content = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap();
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).unwrap())
+        .collect()
+}
+
+// --- Tests ---
+
+#[test]
+fn valid_plan_locks_state_and_advances_phase() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = seed_valid_mission(&tmp, "demo");
+
+    // Put the mission into the `plan` phase manually (init leaves it in
+    // `clarify`; we don't want `plan check` to unexpectedly skip the
+    // phase transition). We simulate by editing STATE.json directly —
+    // in practice `outcome ratify` + `plan scaffold` would do this.
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    state["phase"] = Value::String("plan".to_string());
+    fs::write(&state_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["tasks"], 4);
+    assert_eq!(json["data"]["review_tasks"], 1);
+    assert_eq!(json["data"]["locked"], true);
+    assert!(json["data"]["plan_hash"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["plan"]["locked"], true);
+    assert_eq!(state["phase"], "execute");
+    assert!(state["plan"]["hash"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
+
+    let events = read_events(&mission_dir);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["kind"], "plan.checked");
+}
+
+#[test]
+fn missing_depends_on_returns_plan_invalid() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T1", "# T1\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: "x"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "x"
+
+tasks:
+  - id: T1
+    title: "t1"
+    kind: code
+    spec: specs/T1/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    assert!(
+        json["message"].as_str().unwrap().contains("depends_on"),
+        "message missing depends_on: {}",
+        json["message"]
+    );
+}
+
+#[test]
+fn duplicate_task_ids_returns_plan_invalid_with_context() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T1", "# T1\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: "x"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "x"
+
+tasks:
+  - id: T1
+    title: "t1"
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+  - id: T1
+    title: "t1-dup"
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    let dups = json["context"]["duplicate_ids"]
+        .as_array()
+        .expect("duplicate_ids array");
+    assert!(dups.iter().any(|v| v == "T1"));
+}
+
+#[test]
+fn task_id_pattern_violation_returns_plan_invalid() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T01", "# T01\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: "x"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "x"
+
+tasks:
+  - id: T01
+    title: "t01"
+    kind: code
+    depends_on: []
+    spec: specs/T01/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    assert!(json["message"].as_str().unwrap().contains("T01"));
+}
+
+#[test]
+fn cycle_returns_dag_cycle_with_edges() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T1", "# T1\n");
+    write_spec(&mission_dir, "T2", "# T2\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: "x"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "x"
+
+tasks:
+  - id: T1
+    title: "t1"
+    kind: code
+    depends_on: [T2]
+    spec: specs/T1/SPEC.md
+  - id: T2
+    title: "t2"
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "DAG_CYCLE");
+    let edges = json["context"]["cycle_edges"]
+        .as_array()
+        .expect("cycle_edges array");
+    assert!(!edges.is_empty(), "cycle_edges should not be empty");
+}
+
+#[test]
+fn missing_dep_returns_dag_missing_dep_with_task_id() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T3", "# T3\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: "x"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "x"
+
+tasks:
+  - id: T3
+    title: "t3"
+    kind: code
+    depends_on: [T99]
+    spec: specs/T3/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "DAG_MISSING_DEP");
+    assert_eq!(json["context"]["task_id"], "T3");
+    assert_eq!(json["context"]["missing_dep"], "T99");
+}
+
+#[test]
+fn fill_marker_returns_plan_invalid() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T1", "# T1\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: "[codex1-fill:outcome_interpretation]"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "x"
+
+tasks:
+  - id: T1
+    title: "t1"
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    assert!(
+        json["message"].as_str().unwrap().contains("codex1-fill"),
+        "message should mention fill marker: {}",
+        json["message"]
+    );
+}
+
+#[test]
+fn hard_plan_without_evidence_returns_plan_invalid() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T1", "# T1\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: hard
+  effective: hard
+
+outcome_interpretation:
+  summary: "x"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence: []
+
+tasks:
+  - id: T1
+    title: "t1"
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    assert_eq!(json["context"]["missing_hard_evidence"], true);
+}
+
+#[test]
+fn review_task_without_review_target_returns_plan_invalid() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    write_spec(&mission_dir, "T1", "# T1\n");
+    write_spec(&mission_dir, "T2", "# T2\n");
+    let yaml = r#"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: "x"
+
+architecture:
+  summary: "x"
+  key_decisions: ["x"]
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: "x"
+
+tasks:
+  - id: T1
+    title: "t1"
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+  - id: T2
+    title: "review"
+    kind: review
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+
+risks:
+  - risk: "r"
+    mitigation: "m"
+
+mission_close:
+  criteria: ["c"]
+"#;
+    write_plan(&mission_dir, yaml);
+
+    let output = run_check(&tmp, "demo", &[]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    assert!(
+        json["message"].as_str().unwrap().contains("review_target"),
+        "message missing review_target: {}",
+        json["message"]
+    );
+}
+
+#[test]
+fn dry_run_does_not_lock_plan() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = seed_valid_mission(&tmp, "demo");
+
+    let output = run_check(&tmp, "demo", &["--dry-run"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["locked"], false);
+    assert_eq!(json["data"]["tasks"], 4);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["plan"]["locked"], false);
+    let events = read_events(&mission_dir);
+    assert!(events.is_empty(), "dry-run must not append events");
+}
+
+#[test]
+fn expect_revision_mismatch_returns_revision_conflict() {
+    let tmp = TempDir::new().unwrap();
+    seed_valid_mission(&tmp, "demo");
+
+    let output = run_check(&tmp, "demo", &["--expect-revision", "999"]);
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+    assert_eq!(json["context"]["expected"], 999);
+}
+
+#[test]
+fn re_running_on_locked_plan_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = seed_valid_mission(&tmp, "demo");
+
+    let first = run_check(&tmp, "demo", &[]);
+    assert!(
+        first.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_json = parse_stdout_json(&first);
+    assert_eq!(first_json["data"]["locked"], true);
+    let revision_after_first = read_state(&mission_dir)["revision"].as_u64().unwrap();
+    let events_after_first = read_events(&mission_dir).len();
+    let hash = first_json["data"]["plan_hash"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let second = run_check(&tmp, "demo", &[]);
+    assert!(
+        second.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_json = parse_stdout_json(&second);
+    assert_eq!(second_json["data"]["plan_hash"], hash);
+    assert_eq!(second_json["data"]["locked"], true);
+
+    let revision_after_second = read_state(&mission_dir)["revision"].as_u64().unwrap();
+    let events_after_second = read_events(&mission_dir).len();
+    assert_eq!(
+        revision_after_first, revision_after_second,
+        "idempotent re-check must not bump revision"
+    );
+    assert_eq!(
+        events_after_first, events_after_second,
+        "idempotent re-check must not append events"
+    );
+}


### PR DESCRIPTION
## Summary
- Implements `codex1 plan check --json`: validates PLAN.yaml structure + task DAG, then locks the plan by recording a SHA-256 hash and advancing `state.phase` from `plan` to `execute` via the mutation protocol.
- Adds Kahn-based topological sort with cycle-edge reconstruction in `plan/dag.rs`, parsed PLAN.yaml types in `plan/parsed.rs`, and the command runner in `plan/check.rs`.
- Respects `--dry-run` (no mutation, `locked: false`) and `--expect-revision` (strict equality → `REVISION_CONFLICT`). Idempotent re-runs on an unchanged plan neither bump revision nor append a new event.

## Validations
- No `[codex1-fill:…]` markers anywhere.
- All required top-level sections present and non-empty.
- `planning_level.requested` and `.effective` in {light, medium, hard}.
- Every task carries id/title/kind/depends_on/spec; ids match `^T\d+$` (no leading zero) and are unique (`PLAN_INVALID` with `context.duplicate_ids` on collision).
- Every `depends_on` entry resolves (`DAG_MISSING_DEP` with `context.task_id` + `context.missing_dep`).
- DAG has no cycles (`DAG_CYCLE` with `context.cycle_nodes` + `context.cycle_edges`).
- Review tasks declare `review_target.tasks` referencing existing non-review ids.
- Spec files exist under the mission directory.
- Hard-effective plans require ≥1 evidence entry with kind in {explorer, advisor, plan_review}.

## Design notes
- `src/core/**` is foundation-owned, and `CliError::context()` returns `Value::Null` for `PlanInvalid` / `DagCycle` / `DagMissingDep`. Because the contract mandates structured `context` on those failures, validation errors are printed via a local `exit_with_validation_error` helper that serializes a `JsonErr` envelope and exits with code 1 (no re-print through the top-level dispatcher). Non-validation errors (`REVISION_CONFLICT`, IO) still propagate through the normal `CliError` path.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (13 foundation + 12 plan_check + 3 dag unit tests, all pass)
- [x] Valid 4-task DAG with 1 review task locks state, advances phase, appends one `plan.checked` event.
- [x] Missing `depends_on`, duplicate ids, bad id pattern, cycle, missing dep, fill marker, hard-without-evidence, review-without-target all return the correct code + context.
- [x] `--dry-run` returns `locked: false` without mutation.
- [x] `--expect-revision 999` returns `REVISION_CONFLICT`.
- [x] Re-run on locked plan is idempotent (revision unchanged, no new event).