### PR TITLE
Unit 6: cli-task lifecycle + worker packet

### DIFF
--- a/crates/codex1/src/cli/task/finish.rs
+++ b/crates/codex1/src/cli/task/finish.rs
@@ -1,0 +1,126 @@
+//! `codex1 task finish` — transition InProgress task to Complete or
+//! AwaitingReview (depending on whether a review task targets it).
+
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::{self, schema::TaskStatus};
+
+use super::lifecycle::{ensure_task_record, load_plan, now_rfc3339, status_str};
+
+pub fn run(task_id: &str, proof: &Path, ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let plan = load_plan(&paths)?;
+
+    // Validate the task exists in PLAN.yaml.
+    if plan.get(task_id).is_none() {
+        return Err(CliError::TaskNotReady {
+            message: format!("Task `{task_id}` not found in PLAN.yaml"),
+        });
+    }
+
+    // Resolve proof path. Absolute paths are taken verbatim; relative
+    // paths are joined against mission_dir.
+    let proof_abs: PathBuf = if proof.is_absolute() {
+        proof.to_path_buf()
+    } else {
+        paths.mission_dir.join(proof)
+    };
+    if !proof_abs.is_file() {
+        return Err(CliError::ProofMissing {
+            path: proof_abs.clone(),
+        });
+    }
+
+    let current_status = state
+        .tasks
+        .get(task_id)
+        .map_or(TaskStatus::Pending, |r| r.status.clone());
+
+    if !matches!(current_status, TaskStatus::InProgress) {
+        return Err(CliError::TaskNotReady {
+            message: format!(
+                "Task `{task_id}` has status `{}`; only in_progress tasks can be finished",
+                status_str(&current_status)
+            ),
+        });
+    }
+
+    // Decide next status: AwaitingReview iff a review task targets this task.
+    let has_review = plan.review_task_targeting(task_id).is_some();
+    let next_status = if has_review {
+        TaskStatus::AwaitingReview
+    } else {
+        TaskStatus::Complete
+    };
+    let next_status_str = status_str(&next_status);
+
+    // Store proof path relative to mission dir when possible.
+    let proof_display = match proof_abs.strip_prefix(&paths.mission_dir) {
+        Ok(rel) => rel.display().to_string(),
+        Err(_) => proof_abs.display().to_string(),
+    };
+
+    if ctx.dry_run {
+        let env = JsonOk::new(
+            Some(state.mission_id.clone()),
+            Some(state.revision),
+            json!({
+                "dry_run": true,
+                "task_id": task_id,
+                "would_transition": {
+                    "from": status_str(&current_status),
+                    "to": next_status_str,
+                },
+                "proof_path": proof_display,
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    let finished_at = now_rfc3339();
+    let mutation = {
+        let task_id = task_id.to_string();
+        let finished_at = finished_at.clone();
+        let proof_display = proof_display.clone();
+        let next_status = next_status.clone();
+        state::mutate(
+            &paths,
+            ctx.expect_revision,
+            "task.finished",
+            json!({
+                "task_id": task_id,
+                "finished_at": finished_at,
+                "proof_path": proof_display,
+                "next_status": next_status_str,
+            }),
+            move |state| {
+                let rec = ensure_task_record(state, &task_id);
+                rec.status = next_status;
+                rec.finished_at = Some(finished_at);
+                rec.proof_path = Some(proof_display);
+                Ok(())
+            },
+        )?
+    };
+
+    let env = JsonOk::new(
+        Some(mutation.state.mission_id.clone()),
+        Some(mutation.new_revision),
+        json!({
+            "task_id": task_id,
+            "status": next_status_str,
+            "finished_at": finished_at,
+            "proof_path": proof_display,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/task/lifecycle.rs
+++ b/crates/codex1/src/cli/task/lifecycle.rs
@@ -1,0 +1,271 @@
+//! Task lifecycle helpers: plan parsing, dependency resolution, wave derivation.
+//!
+//! Kept private to the `task` module. Other units derive their own views
+//! from PLAN.yaml + STATE.json rather than importing this.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+
+use serde::Deserialize;
+use serde_yaml::Value;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::core::error::CliError;
+use crate::core::paths::MissionPaths;
+use crate::state::schema::{MissionState, TaskId, TaskRecord, TaskStatus};
+
+/// Minimal view of a single task's fields we care about in the task
+/// lifecycle. Extra fields are ignored so we are tolerant of schema
+/// evolution by sibling units.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanTask {
+    pub id: TaskId,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default = "default_kind")]
+    pub kind: String,
+    #[serde(default)]
+    pub depends_on: Vec<TaskId>,
+    #[serde(default)]
+    pub spec: Option<String>,
+    #[serde(default)]
+    pub read_paths: Vec<String>,
+    #[serde(default)]
+    pub write_paths: Vec<String>,
+    #[serde(default)]
+    pub proof: Vec<String>,
+    #[serde(default)]
+    pub review_target: Option<ReviewTarget>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReviewTarget {
+    #[serde(default)]
+    pub tasks: Vec<TaskId>,
+}
+
+fn default_kind() -> String {
+    "code".to_string()
+}
+
+/// Parsed PLAN.yaml. Only the task list is required for this unit.
+#[derive(Debug, Clone)]
+pub struct ParsedPlan {
+    pub tasks: Vec<PlanTask>,
+    /// Index by id for O(1) lookup.
+    pub by_id: BTreeMap<TaskId, PlanTask>,
+}
+
+impl ParsedPlan {
+    pub fn get(&self, id: &str) -> Option<&PlanTask> {
+        self.by_id.get(id)
+    }
+
+    /// Find the review task (if any) whose `review_target.tasks` includes `id`.
+    pub fn review_task_targeting(&self, id: &str) -> Option<&PlanTask> {
+        self.tasks.iter().find(|t| {
+            t.kind == "review"
+                && t.review_target
+                    .as_ref()
+                    .is_some_and(|rt| rt.tasks.iter().any(|tid| tid == id))
+        })
+    }
+}
+
+/// Load and parse PLAN.yaml from disk. Returns `PlanInvalid` if the
+/// top-level shape is unreadable.
+pub fn load_plan(paths: &MissionPaths) -> Result<ParsedPlan, CliError> {
+    let plan_path = paths.plan();
+    let raw = fs::read_to_string(&plan_path).map_err(|err| CliError::PlanInvalid {
+        message: format!("Failed to read PLAN.yaml at {}: {err}", plan_path.display()),
+        hint: Some("Run `codex1 plan scaffold` to create a plan skeleton.".to_string()),
+    })?;
+    let doc: Value = serde_yaml::from_str(&raw).map_err(|err| CliError::PlanInvalid {
+        message: format!("PLAN.yaml is not valid YAML: {err}"),
+        hint: None,
+    })?;
+    let tasks_val = doc.get("tasks").cloned().unwrap_or(Value::Sequence(vec![]));
+    let tasks: Vec<PlanTask> =
+        serde_yaml::from_value(tasks_val).map_err(|err| CliError::PlanInvalid {
+            message: format!("PLAN.yaml `tasks` is malformed: {err}"),
+            hint: Some("Each task needs at least `id`, `depends_on`, and `kind`.".to_string()),
+        })?;
+    let mut by_id = BTreeMap::new();
+    for t in &tasks {
+        if by_id.insert(t.id.clone(), t.clone()).is_some() {
+            return Err(CliError::PlanInvalid {
+                message: format!("Duplicate task id `{}` in PLAN.yaml", t.id),
+                hint: None,
+            });
+        }
+    }
+    Ok(ParsedPlan { tasks, by_id })
+}
+
+/// A `TaskRecord` reconciled with on-demand readiness (so `Pending` may
+/// promote to `Ready` without mutating state).
+#[derive(Debug, Clone)]
+pub struct EffectiveTask {
+    pub id: TaskId,
+    pub kind: String,
+    pub status: TaskStatus,
+    pub depends_on: Vec<TaskId>,
+}
+
+/// Project a unified view of PLAN.yaml tasks joined against STATE.json.
+/// Tasks that are `Pending` in state but have all deps satisfied are
+/// reported as `Ready` here (the promotion is computed, not persisted).
+pub fn effective_tasks(plan: &ParsedPlan, state: &MissionState) -> Vec<EffectiveTask> {
+    plan.tasks
+        .iter()
+        .map(|t| {
+            let record = state.tasks.get(&t.id);
+            let raw_status = record.map_or(TaskStatus::Pending, |r| r.status.clone());
+            let status = if matches!(raw_status, TaskStatus::Pending) && deps_satisfied(t, state) {
+                TaskStatus::Ready
+            } else {
+                raw_status
+            };
+            EffectiveTask {
+                id: t.id.clone(),
+                kind: t.kind.clone(),
+                status,
+                depends_on: t.depends_on.clone(),
+            }
+        })
+        .collect()
+}
+
+/// True iff every dep of `task` is "satisfied enough" for `task` to be
+/// ready. A `review` task's deps are satisfied when the dep is in
+/// `AwaitingReview`, `Complete`, or `Superseded` (so the review can run
+/// against fresh work). All other kinds require `Complete`/`Superseded`.
+pub fn deps_satisfied(task: &PlanTask, state: &MissionState) -> bool {
+    let is_review = task.kind == "review";
+    task.depends_on.iter().all(|dep| {
+        let Some(r) = state.tasks.get(dep) else {
+            return false;
+        };
+        match &r.status {
+            TaskStatus::Complete | TaskStatus::Superseded => true,
+            TaskStatus::AwaitingReview if is_review => true,
+            _ => false,
+        }
+    })
+}
+
+/// Map each dep id to its current `TaskStatus` string (or `pending` if
+/// absent from state). Used by `task status`.
+pub fn deps_status_map(deps: &[TaskId], state: &MissionState) -> BTreeMap<String, String> {
+    deps.iter()
+        .map(|d| {
+            let s = state
+                .tasks
+                .get(d)
+                .map_or("pending", |r| status_str(&r.status))
+                .to_string();
+            (d.clone(), s)
+        })
+        .collect()
+}
+
+pub fn status_str(status: &TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Pending => "pending",
+        TaskStatus::Ready => "ready",
+        TaskStatus::InProgress => "in_progress",
+        TaskStatus::AwaitingReview => "awaiting_review",
+        TaskStatus::Complete => "complete",
+        TaskStatus::Superseded => "superseded",
+    }
+}
+
+/// The current ready wave: the set of tasks whose deps are all complete
+/// and whose effective status is `Ready`. Preserves PLAN.yaml order.
+pub fn ready_wave(effective: &[EffectiveTask]) -> Vec<EffectiveTask> {
+    effective
+        .iter()
+        .filter(|t| matches!(t.status, TaskStatus::Ready))
+        .cloned()
+        .collect()
+}
+
+/// Any task in `AwaitingReview` — we surface these so `task next` can
+/// route to the matching review task.
+pub fn awaiting_review_targets(effective: &[EffectiveTask]) -> Vec<TaskId> {
+    effective
+        .iter()
+        .filter(|t| matches!(t.status, TaskStatus::AwaitingReview))
+        .map(|t| t.id.clone())
+        .collect()
+}
+
+/// Find the first ready review task whose `review_target.tasks` includes
+/// at least one id from `awaiting`. Returns `(review_task, covered_targets)`.
+pub fn next_ready_review<'a>(
+    plan: &'a ParsedPlan,
+    effective: &[EffectiveTask],
+    awaiting: &[TaskId],
+) -> Option<(&'a PlanTask, Vec<TaskId>)> {
+    let awaiting_set: BTreeSet<&TaskId> = awaiting.iter().collect();
+    for et in effective {
+        if !matches!(et.status, TaskStatus::Ready) {
+            continue;
+        }
+        let Some(pt) = plan.get(&et.id) else { continue };
+        if pt.kind != "review" {
+            continue;
+        }
+        let Some(rt) = &pt.review_target else {
+            continue;
+        };
+        let covered: Vec<TaskId> = rt
+            .tasks
+            .iter()
+            .filter(|t| awaiting_set.contains(t))
+            .cloned()
+            .collect();
+        if !covered.is_empty() {
+            return Some((pt, covered));
+        }
+    }
+    None
+}
+
+/// RFC3339 timestamp for state transitions.
+pub fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+/// Record the effective status for a task, defaulting to pending if
+/// absent. Used when we want to merge in a fresh TaskRecord.
+pub fn ensure_task_record<'a>(state: &'a mut MissionState, id: &str) -> &'a mut TaskRecord {
+    state
+        .tasks
+        .entry(id.to_string())
+        .or_insert_with(|| TaskRecord {
+            id: id.to_string(),
+            status: TaskStatus::Pending,
+            started_at: None,
+            finished_at: None,
+            proof_path: None,
+            superseded_by: None,
+        })
+}
+
+/// True iff every task in the plan is currently Complete or Superseded
+/// (reads state directly since effective view would promote Pending→Ready).
+pub fn all_tasks_terminal(plan: &ParsedPlan, state: &MissionState) -> bool {
+    if plan.tasks.is_empty() {
+        return false;
+    }
+    plan.tasks.iter().all(|t| {
+        state
+            .tasks
+            .get(&t.id)
+            .is_some_and(|r| matches!(r.status, TaskStatus::Complete | TaskStatus::Superseded))
+    })
+}

--- a/crates/codex1/src/cli/task/mod.rs
+++ b/crates/codex1/src/cli/task/mod.rs
@@ -1,11 +1,23 @@
-//! `codex1 task` stub — owned by Phase B Unit 6.
+//! `codex1 task` — Phase B Unit 6 (task lifecycle + worker packet).
+//!
+//! Each subcommand is a thin wrapper over helpers in `lifecycle.rs` and
+//! `worker_packet.rs`. The `TaskCmd` variants are foundation-pinned so
+//! `cli::mod` compiles regardless of this unit's merge order.
 
 use std::path::PathBuf;
 
 use clap::Subcommand;
 
 use crate::cli::Ctx;
-use crate::core::error::{CliError, CliResult};
+use crate::core::error::CliResult;
+
+mod finish;
+mod lifecycle;
+mod next;
+mod packet;
+mod start;
+mod status_cmd;
+mod worker_packet;
 
 #[derive(Debug, Subcommand)]
 pub enum TaskCmd {
@@ -35,15 +47,12 @@ pub enum TaskCmd {
     },
 }
 
-pub fn dispatch(cmd: TaskCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        TaskCmd::Next => "task next",
-        TaskCmd::Start { .. } => "task start",
-        TaskCmd::Finish { .. } => "task finish",
-        TaskCmd::Status { .. } => "task status",
-        TaskCmd::Packet { .. } => "task packet",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: TaskCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        TaskCmd::Next => next::run(ctx),
+        TaskCmd::Start { task } => start::run(&task, ctx),
+        TaskCmd::Finish { task, proof } => finish::run(&task, &proof, ctx),
+        TaskCmd::Status { task } => status_cmd::run(&task, ctx),
+        TaskCmd::Packet { task } => packet::run(&task, ctx),
+    }
 }

--- a/crates/codex1/src/cli/task/next.rs
+++ b/crates/codex1/src/cli/task/next.rs
@@ -1,0 +1,138 @@
+//! `codex1 task next` — report the next ready task / wave / review / close.
+
+use serde_json::json;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::CliResult;
+use crate::core::mission::resolve_mission;
+use crate::state;
+
+use super::lifecycle::{
+    all_tasks_terminal, awaiting_review_targets, effective_tasks, load_plan, next_ready_review,
+    ready_wave,
+};
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+
+    let plan = load_plan(&paths)?;
+    let effective = effective_tasks(&plan, &state);
+
+    let next = if all_tasks_terminal(&plan, &state) {
+        json!({
+            "kind": "mission_close_review",
+            "reason": "all tasks complete or superseded",
+        })
+    } else {
+        let awaiting = awaiting_review_targets(&effective);
+        if let Some((review_task, covered)) = next_ready_review(&plan, &effective, &awaiting) {
+            json!({
+                "kind": "run_review",
+                "task_id": review_task.id,
+                "targets": covered,
+            })
+        } else {
+            let ready = ready_wave(&effective);
+            match ready.len() {
+                0 => json!({
+                    "kind": "blocked",
+                    "reason": blocker_reason(&state, &effective),
+                }),
+                1 => {
+                    let t = &ready[0];
+                    json!({
+                        "kind": "run_task",
+                        "task_id": t.id,
+                        "task_kind": t.kind,
+                    })
+                }
+                _ => {
+                    let ids: Vec<String> = ready.iter().map(|t| t.id.clone()).collect();
+                    json!({
+                        "kind": "run_wave",
+                        "wave_id": wave_id_for(&effective, &ready),
+                        "tasks": ids,
+                        "parallel_safe": true,
+                    })
+                }
+            }
+        }
+    };
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        json!({ "next": next }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+/// Assign a deterministic id to the current ready wave.
+/// Depth(T) = 1 if `depends_on` is empty, else 1 + max(Depth(d) for d in deps).
+/// All tasks in a ready wave share the same depth, so we take the min.
+fn wave_id_for(
+    effective: &[super::lifecycle::EffectiveTask],
+    ready: &[super::lifecycle::EffectiveTask],
+) -> String {
+    use std::collections::BTreeMap;
+    let mut depth_of: BTreeMap<String, usize> = BTreeMap::new();
+    for t in effective {
+        let d = if t.depends_on.is_empty() {
+            1
+        } else {
+            t.depends_on
+                .iter()
+                .map(|d| depth_of.get(d).copied().unwrap_or(1))
+                .max()
+                .unwrap_or(0)
+                + 1
+        };
+        depth_of.insert(t.id.clone(), d);
+    }
+    let ready_depth = ready
+        .iter()
+        .map(|t| depth_of.get(&t.id).copied().unwrap_or(1))
+        .min()
+        .unwrap_or(1);
+    format!("W{ready_depth}")
+}
+
+/// Human-readable reason when no ready wave and no ready review.
+fn blocker_reason(
+    state: &crate::state::schema::MissionState,
+    effective: &[super::lifecycle::EffectiveTask],
+) -> String {
+    use crate::state::schema::TaskStatus;
+    if !state.outcome.ratified {
+        return "OUTCOME.md is not ratified".to_string();
+    }
+    if !state.plan.locked {
+        return "PLAN.yaml is not locked".to_string();
+    }
+    if effective.is_empty() {
+        return "PLAN.yaml has no tasks".to_string();
+    }
+    let in_progress: Vec<&str> = effective
+        .iter()
+        .filter(|t| matches!(t.status, TaskStatus::InProgress))
+        .map(|t| t.id.as_str())
+        .collect();
+    if !in_progress.is_empty() {
+        return format!("tasks in progress: {}", in_progress.join(", "));
+    }
+    let awaiting: Vec<&str> = effective
+        .iter()
+        .filter(|t| matches!(t.status, TaskStatus::AwaitingReview))
+        .map(|t| t.id.as_str())
+        .collect();
+    if !awaiting.is_empty() {
+        return format!(
+            "tasks awaiting review without a ready review task: {}",
+            awaiting.join(", ")
+        );
+    }
+    "no ready tasks and no ready review task".to_string()
+}

--- a/crates/codex1/src/cli/task/packet.rs
+++ b/crates/codex1/src/cli/task/packet.rs
@@ -1,0 +1,27 @@
+//! `codex1 task packet <id>` — worker-subagent prompt packet.
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state;
+
+use super::lifecycle::load_plan;
+use super::worker_packet::build_packet;
+
+pub fn run(task_id: &str, ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let plan = load_plan(&paths)?;
+
+    let Some(plan_task) = plan.get(task_id) else {
+        return Err(CliError::TaskNotReady {
+            message: format!("Task `{task_id}` not found in PLAN.yaml"),
+        });
+    };
+
+    let data = build_packet(&paths, plan_task)?;
+    let env = JsonOk::new(Some(state.mission_id.clone()), Some(state.revision), data);
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/task/start.rs
+++ b/crates/codex1/src/cli/task/start.rs
@@ -1,0 +1,116 @@
+//! `codex1 task start` — transition a task to `InProgress`.
+//!
+//! - Idempotent on re-entry (no second event emitted).
+//! - Refuses if dependencies are not complete/superseded.
+//! - Respects `--dry-run` and `--expect-revision`.
+
+use serde_json::json;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::{self, schema::TaskStatus};
+
+use super::lifecycle::{deps_satisfied, ensure_task_record, load_plan, now_rfc3339, status_str};
+
+pub fn run(task_id: &str, ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let plan = load_plan(&paths)?;
+
+    let Some(plan_task) = plan.get(task_id) else {
+        return Err(CliError::TaskNotReady {
+            message: format!("Task `{task_id}` not found in PLAN.yaml"),
+        });
+    };
+
+    if !deps_satisfied(plan_task, &state) {
+        return Err(CliError::TaskNotReady {
+            message: format!(
+                "Task `{task_id}` has incomplete dependencies: {}",
+                plan_task.depends_on.join(", ")
+            ),
+        });
+    }
+
+    let record = state.tasks.get(task_id);
+    let current_status = record.map_or(TaskStatus::Pending, |r| r.status.clone());
+
+    // Idempotent: already in progress → no mutation.
+    if matches!(current_status, TaskStatus::InProgress) {
+        let started_at = record
+            .and_then(|r| r.started_at.clone())
+            .unwrap_or_default();
+        let env = JsonOk::new(
+            Some(state.mission_id.clone()),
+            Some(state.revision),
+            json!({
+                "task_id": task_id,
+                "status": "in_progress",
+                "started_at": started_at,
+                "idempotent": true,
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    // Only Pending or Ready may transition.
+    if !matches!(current_status, TaskStatus::Pending | TaskStatus::Ready) {
+        return Err(CliError::TaskNotReady {
+            message: format!(
+                "Task `{task_id}` has status `{}`; cannot start",
+                status_str(&current_status)
+            ),
+        });
+    }
+
+    if ctx.dry_run {
+        let env = JsonOk::new(
+            Some(state.mission_id.clone()),
+            Some(state.revision),
+            json!({
+                "dry_run": true,
+                "task_id": task_id,
+                "would_transition": {
+                    "from": status_str(&current_status),
+                    "to": "in_progress",
+                }
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    let started_at = now_rfc3339();
+    let mutation = {
+        let task_id = task_id.to_string();
+        let started_at = started_at.clone();
+        state::mutate(
+            &paths,
+            ctx.expect_revision,
+            "task.started",
+            json!({ "task_id": task_id, "started_at": started_at }),
+            move |state| {
+                let rec = ensure_task_record(state, &task_id);
+                rec.status = TaskStatus::InProgress;
+                rec.started_at = Some(started_at);
+                Ok(())
+            },
+        )?
+    };
+
+    let env = JsonOk::new(
+        Some(mutation.state.mission_id.clone()),
+        Some(mutation.new_revision),
+        json!({
+            "task_id": task_id,
+            "status": "in_progress",
+            "started_at": started_at,
+            "idempotent": false,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/task/status_cmd.rs
+++ b/crates/codex1/src/cli/task/status_cmd.rs
@@ -1,0 +1,60 @@
+//! `codex1 task status <id>` — read-only snapshot of a single task.
+
+use serde_json::json;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::{self, schema::TaskStatus};
+
+use super::lifecycle::{deps_satisfied, deps_status_map, load_plan, status_str};
+
+pub fn run(task_id: &str, ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let plan = load_plan(&paths)?;
+
+    let Some(plan_task) = plan.get(task_id) else {
+        return Err(CliError::TaskNotReady {
+            message: format!("Task `{task_id}` not found in PLAN.yaml"),
+        });
+    };
+
+    let record = state.tasks.get(task_id);
+    let raw_status = record.map_or(TaskStatus::Pending, |r| r.status.clone());
+    // Promote Pending→Ready on-demand when all deps are satisfied.
+    let effective_status =
+        if matches!(raw_status, TaskStatus::Pending) && deps_satisfied(plan_task, &state) {
+            TaskStatus::Ready
+        } else {
+            raw_status
+        };
+
+    let deps_status = deps_status_map(&plan_task.depends_on, &state);
+    let mut data = serde_json::Map::new();
+    data.insert("task_id".into(), json!(task_id));
+    data.insert("kind".into(), json!(plan_task.kind));
+    data.insert("status".into(), json!(status_str(&effective_status)));
+    data.insert("depends_on".into(), json!(plan_task.depends_on));
+    data.insert("deps_status".into(), json!(deps_status));
+    if let Some(r) = record {
+        if let Some(s) = &r.started_at {
+            data.insert("started_at".into(), json!(s));
+        }
+        if let Some(f) = &r.finished_at {
+            data.insert("finished_at".into(), json!(f));
+        }
+        if let Some(p) = &r.proof_path {
+            data.insert("proof_path".into(), json!(p));
+        }
+    }
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        serde_json::Value::Object(data),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/task/worker_packet.rs
+++ b/crates/codex1/src/cli/task/worker_packet.rs
@@ -1,0 +1,98 @@
+//! Worker-subagent packet assembly for `codex1 task packet`.
+
+use std::fs;
+
+use serde_json::{json, Value as JsonValue};
+
+use crate::core::error::CliError;
+use crate::core::paths::MissionPaths;
+
+use super::lifecycle::PlanTask;
+
+const SPEC_EXCERPT_MAX: usize = 2000;
+
+/// Standing worker-role instructions included in every packet.
+pub const WORKER_INSTRUCTIONS: &str = "You are a Codex1 worker for task <TASK_ID>.
+
+You may: edit files inside write_paths; run proof commands; read any file.
+You must not: modify OUTCOME.md, PLAN.yaml, STATE.json, EVENTS.jsonl, reviews, CLOSEOUT.md. Do not record review results. Do not replan. Do not mark missions complete.
+
+When done, report changed files, proof commands run, proof results, blockers, and assumptions.";
+
+/// Build the packet JSON object for a task. Reads SPEC.md and the
+/// OUTCOME.md frontmatter from disk. Missing files degrade gracefully
+/// (empty strings) so a worker still gets a usable envelope.
+pub fn build_packet(paths: &MissionPaths, plan_task: &PlanTask) -> Result<JsonValue, CliError> {
+    let spec_rel = plan_task
+        .spec
+        .clone()
+        .unwrap_or_else(|| format!("specs/{}/SPEC.md", plan_task.id));
+    let spec_abs = paths.mission_dir.join(&spec_rel);
+    let spec_body = fs::read_to_string(&spec_abs).unwrap_or_default();
+    let spec_excerpt = truncate_chars(&spec_body, SPEC_EXCERPT_MAX);
+
+    let mission_summary = read_interpreted_destination(paths).unwrap_or_default();
+    let spec_rel_under_plans = format!(
+        "PLANS/{}/{}",
+        paths.mission_id,
+        spec_rel.trim_start_matches("./")
+    );
+
+    let instructions = WORKER_INSTRUCTIONS.replace("<TASK_ID>", &plan_task.id);
+
+    Ok(json!({
+        "task_id": plan_task.id,
+        "title": plan_task.title,
+        "kind": plan_task.kind,
+        "spec_excerpt": spec_excerpt,
+        "spec_path": spec_rel_under_plans,
+        "read_paths": plan_task.read_paths,
+        "write_paths": plan_task.write_paths,
+        "proof_commands": plan_task.proof,
+        "mission_summary": mission_summary,
+        "mission_id": paths.mission_id,
+        "worker_instructions": instructions,
+    }))
+}
+
+/// Parse OUTCOME.md, return `interpreted_destination` from the YAML
+/// frontmatter (block delimited by leading `---` / trailing `---`).
+fn read_interpreted_destination(paths: &MissionPaths) -> Option<String> {
+    let raw = fs::read_to_string(paths.outcome()).ok()?;
+    let frontmatter = extract_frontmatter(&raw)?;
+    let doc: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
+    doc.get("interpreted_destination")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim().to_string())
+}
+
+/// Pull the YAML frontmatter out of a markdown file. Returns the inner
+/// block (without the `---` fences). If the whole file is YAML (no
+/// leading `---`), returns the file verbatim.
+fn extract_frontmatter(raw: &str) -> Option<&str> {
+    let trimmed = raw.trim_start_matches('\u{feff}');
+    if let Some(rest) = trimmed.strip_prefix("---\n") {
+        if let Some(end) = rest.find("\n---") {
+            return Some(&rest[..end]);
+        }
+    }
+    // Tolerate CRLF.
+    if let Some(rest) = trimmed.strip_prefix("---\r\n") {
+        if let Some(end) = rest.find("\r\n---") {
+            return Some(&rest[..end]);
+        }
+    }
+    Some(trimmed)
+}
+
+/// Char-safe truncate so we never split a multi-byte boundary.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.trim_end().to_string();
+    }
+    s.chars()
+        .take(max)
+        .collect::<String>()
+        .trim_end()
+        .to_string()
+}

--- a/crates/codex1/tests/foundation.rs
+++ b/crates/codex1/tests/foundation.rs
@@ -156,12 +156,14 @@ fn plan_stubs_return_not_implemented() {
 }
 
 #[test]
-fn task_stubs_return_not_implemented() {
+fn review_stubs_return_not_implemented() {
+    // The task stubs were replaced by Unit 6 (cli-task). Stand-in: any
+    // still-stubbed subcommand. Review stays stubbed until Unit 7 lands.
     let tmp = TempDir::new().unwrap();
     init_demo(&tmp, "demo");
     let output = cmd()
         .current_dir(tmp.path())
-        .args(["task", "next", "--mission", "demo"])
+        .args(["review", "status", "T1", "--mission", "demo"])
         .output()
         .expect("runs");
     let json = parse_stdout_json(&output);

--- a/crates/codex1/tests/task.rs
+++ b/crates/codex1/tests/task.rs
@@ -1,0 +1,621 @@
+//! Integration tests for `codex1 task` (Phase B Unit 6).
+//!
+//! Each test seeds a mission directory on disk (STATE.json, PLAN.yaml,
+//! specs/*) rather than going through `plan scaffold`/`outcome ratify`
+//! which are implemented by sibling units that may not have merged yet.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn parse_json(out: &std::process::Output) -> Value {
+    let s = std::str::from_utf8(&out.stdout).expect("utf-8 stdout");
+    serde_json::from_str(s).unwrap_or_else(|e| panic!("bad JSON:\n{s}\nerror: {e}"))
+}
+
+fn write(path: &Path, content: &str) {
+    if let Some(p) = path.parent() {
+        fs::create_dir_all(p).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+/// Seed a fresh mission directory with a ratified outcome, locked plan,
+/// and empty STATE.json at revision 0. Returns (tmp, mission_dir).
+fn seed_mission(plan_yaml: &str, specs: &[(&str, &str)]) -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = tmp.path().join("PLANS").join("demo");
+    fs::create_dir_all(mission_dir.join("specs")).unwrap();
+    fs::create_dir_all(mission_dir.join("reviews")).unwrap();
+
+    write(&mission_dir.join("OUTCOME.md"), OUTCOME_FIXTURE);
+    write(&mission_dir.join("PLAN.yaml"), plan_yaml);
+    write(
+        &mission_dir.join("STATE.json"),
+        r#"{
+  "mission_id": "demo",
+  "revision": 0,
+  "schema_version": 1,
+  "phase": "execute",
+  "loop": { "active": false, "paused": false, "mode": "none" },
+  "outcome": { "ratified": true, "ratified_at": "2026-04-20T00:00:00Z" },
+  "plan": { "locked": true, "requested_level": "medium", "effective_level": "medium", "hash": "abc" },
+  "tasks": {},
+  "reviews": {},
+  "replan": { "consecutive_dirty_by_target": {}, "triggered": false },
+  "close": { "review_state": "not_started" },
+  "events_cursor": 0
+}
+"#,
+    );
+    write(&mission_dir.join("EVENTS.jsonl"), "");
+
+    for (id, body) in specs {
+        write(&mission_dir.join("specs").join(id).join("SPEC.md"), body);
+    }
+
+    (tmp, mission_dir)
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    let raw = fs::read_to_string(mission_dir.join("STATE.json")).unwrap();
+    serde_json::from_str(&raw).unwrap()
+}
+
+fn events(mission_dir: &Path) -> Vec<Value> {
+    let raw = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap_or_default();
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+fn run(mission_dir_root: &Path, args: &[&str]) -> std::process::Output {
+    cmd()
+        .current_dir(mission_dir_root)
+        .args(args)
+        .output()
+        .expect("runs")
+}
+
+const OUTCOME_FIXTURE: &str = r#"---
+mission_id: demo
+status: ratified
+title: "Demo Mission"
+
+original_user_goal: |
+  do the thing
+
+interpreted_destination: |
+  A compact mission used to exercise `codex1 task` subcommands end to end.
+
+must_be_true:
+  - one
+
+success_criteria:
+  - two
+
+non_goals:
+  - three
+
+constraints:
+  - four
+
+definitions: {}
+
+quality_bar:
+  - five
+
+proof_expectations:
+  - six
+
+review_expectations:
+  - seven
+
+known_risks:
+  - eight
+
+resolved_questions: []
+---
+
+# OUTCOME
+"#;
+
+// --- Fixture plans ---
+
+const PLAN_LINEAR_NO_REVIEW: &str = r#"mission_id: demo
+
+planning_level:
+  requested: medium
+  effective: medium
+
+outcome_interpretation:
+  summary: "demo"
+
+architecture:
+  summary: "demo"
+  key_decisions: []
+
+planning_process:
+  evidence: []
+
+tasks:
+  - id: T1
+    title: "Root task"
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+    read_paths: []
+    write_paths: ["src/foo/**"]
+    proof:
+      - "cargo test foo"
+  - id: T2
+    title: "Dependent task"
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+    write_paths: ["src/bar/**"]
+    proof:
+      - "cargo test bar"
+
+risks: []
+mission_close:
+  criteria: []
+"#;
+
+const PLAN_WITH_REVIEW: &str = r#"mission_id: demo
+
+planning_level:
+  requested: medium
+  effective: medium
+
+outcome_interpretation:
+  summary: "demo"
+
+architecture:
+  summary: "demo"
+  key_decisions: []
+
+planning_process:
+  evidence: []
+
+tasks:
+  - id: T1
+    title: "Root"
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+    write_paths: ["src/foo/**"]
+    proof: ["cargo test foo"]
+  - id: T2
+    title: "Work to be reviewed"
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+    write_paths: ["src/bar/**"]
+    proof: ["cargo test bar"]
+  - id: T3
+    title: "Review of T2"
+    kind: review
+    depends_on: [T2]
+    spec: specs/T3/SPEC.md
+    review_target:
+      tasks: [T2]
+
+risks: []
+mission_close:
+  criteria: []
+"#;
+
+// --- Tests ---
+
+#[test]
+fn next_fresh_ratified_reports_single_ready_task() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(tmp.path(), &["task", "next", "--mission", "demo"]);
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    let json = parse_json(&out);
+    assert_eq!(json["ok"], json!(true));
+    assert_eq!(json["data"]["next"]["kind"], "run_task");
+    assert_eq!(json["data"]["next"]["task_id"], "T1");
+    assert_eq!(json["data"]["next"]["task_kind"], "code");
+}
+
+#[test]
+fn next_multi_ready_reports_wave() {
+    // T2 and T3 both depend only on T1; complete T1 to make them ready.
+    let plan = r"mission_id: demo
+
+planning_level: { requested: medium, effective: medium }
+outcome_interpretation: { summary: demo }
+architecture: { summary: demo, key_decisions: [] }
+planning_process: { evidence: [] }
+
+tasks:
+  - id: T1
+    title: Root
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+  - id: T2
+    title: Two
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+  - id: T3
+    title: Three
+    kind: code
+    depends_on: [T1]
+    spec: specs/T3/SPEC.md
+
+risks: []
+mission_close: { criteria: [] }
+";
+    let (tmp, dir) = seed_mission(plan, &[]);
+    // Mark T1 complete directly in STATE.
+    write(&dir.join("specs/T1/PROOF.md"), "proof");
+    let mut state = read_state(&dir);
+    state["tasks"] = json!({
+        "T1": {
+            "id": "T1",
+            "status": "complete",
+            "finished_at": "2026-04-20T00:00:00Z",
+            "proof_path": "specs/T1/PROOF.md"
+        }
+    });
+    write(
+        &dir.join("STATE.json"),
+        &serde_json::to_string_pretty(&state).unwrap(),
+    );
+
+    let out = run(tmp.path(), &["task", "next", "--mission", "demo"]);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["next"]["kind"], "run_wave");
+    assert_eq!(json["data"]["next"]["tasks"], json!(["T2", "T3"]));
+    assert_eq!(json["data"]["next"]["parallel_safe"], json!(true));
+}
+
+#[test]
+fn start_ready_task_transitions_to_in_progress() {
+    let (tmp, dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(tmp.path(), &["task", "start", "T1", "--mission", "demo"]);
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    let json = parse_json(&out);
+    assert_eq!(json["ok"], json!(true));
+    assert_eq!(json["data"]["status"], "in_progress");
+    assert_eq!(json["data"]["idempotent"], json!(false));
+    assert_eq!(json["revision"], json!(1));
+
+    let state = read_state(&dir);
+    assert_eq!(state["tasks"]["T1"]["status"], "in_progress");
+    assert!(state["tasks"]["T1"]["started_at"].is_string());
+    assert_eq!(state["revision"], 1);
+
+    let evs = events(&dir);
+    assert_eq!(evs.len(), 1);
+    assert_eq!(evs[0]["kind"], "task.started");
+    assert_eq!(evs[0]["payload"]["task_id"], "T1");
+}
+
+#[test]
+fn start_with_incomplete_deps_returns_task_not_ready() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(tmp.path(), &["task", "start", "T2", "--mission", "demo"]);
+    assert!(!out.status.success());
+    let json = parse_json(&out);
+    assert_eq!(json["ok"], json!(false));
+    assert_eq!(json["code"], "TASK_NOT_READY");
+}
+
+#[test]
+fn start_twice_is_idempotent() {
+    let (tmp, dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let first = run(tmp.path(), &["task", "start", "T1", "--mission", "demo"]);
+    assert!(first.status.success());
+    let rev_after_first = read_state(&dir)["revision"].as_u64().unwrap();
+    let evs_after_first = events(&dir).len();
+
+    let second = run(tmp.path(), &["task", "start", "T1", "--mission", "demo"]);
+    assert!(second.status.success());
+    let json = parse_json(&second);
+    assert_eq!(json["data"]["idempotent"], json!(true));
+    assert_eq!(
+        read_state(&dir)["revision"].as_u64().unwrap(),
+        rev_after_first
+    );
+    assert_eq!(events(&dir).len(), evs_after_first);
+}
+
+#[test]
+fn finish_no_review_target_transitions_to_complete() {
+    let (tmp, dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    // Start T1 first.
+    run(tmp.path(), &["task", "start", "T1", "--mission", "demo"]);
+    write(&dir.join("specs/T1/PROOF.md"), "ok");
+    let out = run(
+        tmp.path(),
+        &[
+            "task",
+            "finish",
+            "T1",
+            "--proof",
+            "specs/T1/PROOF.md",
+            "--mission",
+            "demo",
+        ],
+    );
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["status"], "complete");
+    assert_eq!(json["data"]["proof_path"], "specs/T1/PROOF.md");
+
+    let state = read_state(&dir);
+    assert_eq!(state["tasks"]["T1"]["status"], "complete");
+    assert!(state["tasks"]["T1"]["finished_at"].is_string());
+    let evs = events(&dir);
+    assert_eq!(evs.last().unwrap()["kind"], "task.finished");
+}
+
+#[test]
+fn finish_with_review_target_transitions_to_awaiting_review() {
+    let (tmp, dir) = seed_mission(PLAN_WITH_REVIEW, &[]);
+    // Complete T1, then start T2.
+    let mut state = read_state(&dir);
+    state["tasks"] = json!({
+        "T1": {
+            "id": "T1",
+            "status": "complete",
+            "finished_at": "2026-04-20T00:00:00Z",
+            "proof_path": "specs/T1/PROOF.md"
+        }
+    });
+    write(
+        &dir.join("STATE.json"),
+        &serde_json::to_string_pretty(&state).unwrap(),
+    );
+    run(tmp.path(), &["task", "start", "T2", "--mission", "demo"]);
+    write(&dir.join("specs/T2/PROOF.md"), "ok");
+
+    let out = run(
+        tmp.path(),
+        &[
+            "task",
+            "finish",
+            "T2",
+            "--proof",
+            "specs/T2/PROOF.md",
+            "--mission",
+            "demo",
+        ],
+    );
+    let json = parse_json(&out);
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    assert_eq!(json["data"]["status"], "awaiting_review");
+    assert_eq!(read_state(&dir)["tasks"]["T2"]["status"], "awaiting_review");
+}
+
+#[test]
+fn finish_with_missing_proof_file_errors() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    run(tmp.path(), &["task", "start", "T1", "--mission", "demo"]);
+    let out = run(
+        tmp.path(),
+        &[
+            "task",
+            "finish",
+            "T1",
+            "--proof",
+            "does/not/exist.md",
+            "--mission",
+            "demo",
+        ],
+    );
+    assert!(!out.status.success());
+    let json = parse_json(&out);
+    assert_eq!(json["code"], "PROOF_MISSING");
+    assert!(json["context"]["path"].is_string());
+}
+
+#[test]
+fn finish_without_proof_arg_is_clap_error() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(tmp.path(), &["task", "finish", "T1", "--mission", "demo"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--proof") || stderr.contains("required"),
+        "expected clap error about --proof, got: {stderr}"
+    );
+}
+
+#[test]
+fn status_returns_expected_envelope() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(tmp.path(), &["task", "status", "T1", "--mission", "demo"]);
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["task_id"], "T1");
+    assert_eq!(json["data"]["kind"], "code");
+    assert_eq!(json["data"]["status"], "ready");
+    assert_eq!(json["data"]["depends_on"], json!([]));
+    assert!(json["data"]["deps_status"].is_object());
+}
+
+#[test]
+fn status_reports_deps_status_map() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(tmp.path(), &["task", "status", "T2", "--mission", "demo"]);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["status"], "pending");
+    assert_eq!(json["data"]["depends_on"], json!(["T1"]));
+    assert_eq!(json["data"]["deps_status"]["T1"], "pending");
+}
+
+#[test]
+fn packet_returns_expected_fields() {
+    let spec = "# T2\n\nDo the bar work.\n\nReference the API per the spec.\n";
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[("T2", spec)]);
+    let out = run(tmp.path(), &["task", "packet", "T2", "--mission", "demo"]);
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["task_id"], "T2");
+    assert_eq!(json["data"]["kind"], "code");
+    assert!(json["data"]["spec_excerpt"]
+        .as_str()
+        .unwrap()
+        .contains("Do the bar work."));
+    assert_eq!(json["data"]["write_paths"], json!(["src/bar/**"]));
+    assert_eq!(json["data"]["proof_commands"], json!(["cargo test bar"]));
+    let instructions = json["data"]["worker_instructions"].as_str().unwrap();
+    assert!(instructions.contains("Codex1 worker"));
+    assert!(instructions.contains("T2"));
+    assert!(instructions.contains("must not"));
+    let summary = json["data"]["mission_summary"].as_str().unwrap();
+    assert!(
+        summary.contains("mission used to exercise"),
+        "expected interpreted_destination in mission_summary, got {summary:?}"
+    );
+}
+
+#[test]
+fn next_after_work_done_with_review_pending_runs_review() {
+    let (tmp, dir) = seed_mission(PLAN_WITH_REVIEW, &[]);
+    let mut state = read_state(&dir);
+    state["tasks"] = json!({
+        "T1": {
+            "id": "T1",
+            "status": "complete",
+            "finished_at": "2026-04-20T00:00:00Z",
+            "proof_path": "specs/T1/PROOF.md"
+        },
+        "T2": {
+            "id": "T2",
+            "status": "awaiting_review",
+            "finished_at": "2026-04-20T00:00:00Z",
+            "proof_path": "specs/T2/PROOF.md"
+        }
+    });
+    write(
+        &dir.join("STATE.json"),
+        &serde_json::to_string_pretty(&state).unwrap(),
+    );
+
+    let out = run(tmp.path(), &["task", "next", "--mission", "demo"]);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["next"]["kind"], "run_review");
+    assert_eq!(json["data"]["next"]["task_id"], "T3");
+    assert_eq!(json["data"]["next"]["targets"], json!(["T2"]));
+}
+
+#[test]
+fn next_all_complete_reports_mission_close_review() {
+    let (tmp, dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let mut state = read_state(&dir);
+    state["tasks"] = json!({
+        "T1": {"id":"T1","status":"complete"},
+        "T2": {"id":"T2","status":"complete"}
+    });
+    write(
+        &dir.join("STATE.json"),
+        &serde_json::to_string_pretty(&state).unwrap(),
+    );
+    let out = run(tmp.path(), &["task", "next", "--mission", "demo"]);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["next"]["kind"], "mission_close_review");
+}
+
+#[test]
+fn start_dry_run_does_not_mutate() {
+    let (tmp, dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(
+        tmp.path(),
+        &["task", "start", "T1", "--dry-run", "--mission", "demo"],
+    );
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["dry_run"], json!(true));
+    assert_eq!(read_state(&dir)["revision"], 0);
+    assert!(events(&dir).is_empty());
+}
+
+#[test]
+fn finish_dry_run_does_not_mutate() {
+    let (tmp, dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    run(tmp.path(), &["task", "start", "T1", "--mission", "demo"]);
+    let rev_before = read_state(&dir)["revision"].as_u64().unwrap();
+    let ev_before = events(&dir).len();
+    write(&dir.join("specs/T1/PROOF.md"), "ok");
+    let out = run(
+        tmp.path(),
+        &[
+            "task",
+            "finish",
+            "T1",
+            "--proof",
+            "specs/T1/PROOF.md",
+            "--dry-run",
+            "--mission",
+            "demo",
+        ],
+    );
+    assert!(out.status.success(), "stderr: {:?}", out.stderr);
+    let json = parse_json(&out);
+    assert_eq!(json["data"]["dry_run"], json!(true));
+    assert_eq!(read_state(&dir)["revision"].as_u64().unwrap(), rev_before);
+    assert_eq!(events(&dir).len(), ev_before);
+}
+
+#[test]
+fn start_expect_revision_mismatch_returns_revision_conflict() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    let out = run(
+        tmp.path(),
+        &[
+            "task",
+            "start",
+            "T1",
+            "--expect-revision",
+            "99",
+            "--mission",
+            "demo",
+        ],
+    );
+    assert!(!out.status.success());
+    let json = parse_json(&out);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+    assert_eq!(json["retryable"], json!(true));
+    assert_eq!(json["context"]["expected"], json!(99));
+    assert_eq!(json["context"]["actual"], json!(0));
+}
+
+#[test]
+fn finish_expect_revision_mismatch_returns_revision_conflict() {
+    let (tmp, _dir) = seed_mission(PLAN_LINEAR_NO_REVIEW, &[]);
+    run(tmp.path(), &["task", "start", "T1", "--mission", "demo"]);
+    let mission_dir = tmp.path().join("PLANS/demo");
+    write(&mission_dir.join("specs/T1/PROOF.md"), "ok");
+    let out = run(
+        tmp.path(),
+        &[
+            "task",
+            "finish",
+            "T1",
+            "--proof",
+            "specs/T1/PROOF.md",
+            "--expect-revision",
+            "99",
+            "--mission",
+            "demo",
+        ],
+    );
+    assert!(!out.status.success());
+    let json = parse_json(&out);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+}


### PR DESCRIPTION
## Summary
- Implement `codex1 task {next,start,finish,status,packet}` end-to-end with mission-state lifecycle transitions (Pending → Ready → InProgress → AwaitingReview | Complete).
- Ready-state is computed on-demand from PLAN.yaml deps; review tasks treat a dep in `AwaitingReview` as satisfied so the review can run before the work is marked Complete.
- `task packet` assembles a worker-subagent prompt from SPEC.md, PLAN.yaml, and the `interpreted_destination` in OUTCOME.md frontmatter, including the standing worker-role instruction block.

## Scope
- Owned files: `crates/codex1/src/cli/task/{mod,next,start,finish,status_cmd,packet,lifecycle,worker_packet}.rs`, `crates/codex1/tests/task.rs`.
- No DO-NOT-TOUCH file modified. Enum `TaskCmd` variants preserved.
- Foundation test `task_stubs_return_not_implemented` was retargeted to `review status` (still stubbed) and renamed `review_stubs_return_not_implemented` so coverage of the stub-error path remains while Unit 7 is unmerged. (`tests/foundation.rs` is not in DO-NOT-TOUCH; flagged here for reviewer awareness.)

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 13/13 foundation + 18/18 task tests pass
- [x] All numbered tests from the unit spec covered: next fresh, start ready, start incomplete deps (TASK_NOT_READY), start twice idempotent, finish no review (Complete), finish with review (AwaitingReview), finish missing proof (PROOF_MISSING), finish without --proof (clap error), status envelope, packet envelope, next after work with review pending (run_review), dry-run (start/finish), expect-revision mismatch (REVISION_CONFLICT).

Generated with [Claude Code](https://claude.com/claude-code)