### PR TITLE
Unit 9: cli-loop pause/resume/deactivate/activate

### DIFF
--- a/crates/codex1/src/cli/loop_/activate.rs
+++ b/crates/codex1/src/cli/loop_/activate.rs
@@ -1,0 +1,25 @@
+//! `codex1 loop activate --mode <mode>` — idempotently activate the loop.
+//!
+//! Central entry point for other units (outcome ratify, plan check) to
+//! turn the loop on without each inventing their own mutation.
+
+use crate::cli::loop_::{parse_mode, run_transition, Transition};
+use crate::cli::Ctx;
+use crate::core::error::CliResult;
+use crate::state::schema::LoopState;
+
+pub fn run(ctx: &Ctx, mode_raw: &str) -> CliResult<()> {
+    let mode = parse_mode(mode_raw)?;
+    run_transition(ctx, "loop.activated", move |current| {
+        let target = LoopState {
+            active: true,
+            paused: false,
+            mode,
+        };
+        if *current == target {
+            Transition::NoOp
+        } else {
+            Transition::Apply(target)
+        }
+    })
+}

--- a/crates/codex1/src/cli/loop_/deactivate.rs
+++ b/crates/codex1/src/cli/loop_/deactivate.rs
@@ -1,0 +1,21 @@
+//! `codex1 loop deactivate` — turn the loop off entirely.
+
+use crate::cli::loop_::{run_transition, Transition};
+use crate::cli::Ctx;
+use crate::core::error::CliResult;
+use crate::state::schema::{LoopMode, LoopState};
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    run_transition(ctx, "loop.deactivated", |current| {
+        let target = LoopState {
+            active: false,
+            paused: false,
+            mode: LoopMode::None,
+        };
+        if *current == target {
+            Transition::NoOp
+        } else {
+            Transition::Apply(target)
+        }
+    })
+}

--- a/crates/codex1/src/cli/loop_/mod.rs
+++ b/crates/codex1/src/cli/loop_/mod.rs
@@ -1,27 +1,174 @@
-//! `codex1 loop` stub — owned by Phase B Unit 9.
+//! `codex1 loop` — Phase B Unit 9.
+//!
+//! Drives `STATE.json.loop`. Ralph's Stop-allow decision keys off of
+//! `loop.active` and `loop.paused`; `$close` pauses, `$close` resume or
+//! deactivates. Other units activate the loop via `loop activate` rather
+//! than inventing the mutation themselves.
 
 use clap::Subcommand;
+use serde_json::json;
 
 use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
 use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::core::paths::MissionPaths;
+use crate::state;
+use crate::state::schema::{LoopMode, LoopState, MissionState};
+
+pub mod activate;
+pub mod deactivate;
+pub mod pause;
+pub mod resume;
 
 #[derive(Debug, Subcommand)]
 pub enum LoopCmd {
+    /// Activate the loop. Used by other units (outcome ratify, plan check) via shell-out.
+    Activate {
+        /// clarify | plan | execute | review_loop | mission_close
+        #[arg(long, default_value = "execute")]
+        mode: String,
+    },
     /// Pause the active loop (used by $close).
     Pause,
-    /// Resume the active loop.
+    /// Resume a paused loop.
     Resume,
     /// Deactivate the loop entirely.
     Deactivate,
 }
 
-pub fn dispatch(cmd: LoopCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        LoopCmd::Pause => "loop pause",
-        LoopCmd::Resume => "loop resume",
-        LoopCmd::Deactivate => "loop deactivate",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: LoopCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        LoopCmd::Activate { mode } => activate::run(ctx, &mode),
+        LoopCmd::Pause => pause::run(ctx),
+        LoopCmd::Resume => resume::run(ctx),
+        LoopCmd::Deactivate => deactivate::run(ctx),
+    }
+}
+
+/// Outcome of evaluating a loop transition against the current state.
+pub(crate) enum Transition {
+    /// State already matches the target; emit success without writing.
+    NoOp,
+    /// State needs to change to `target`.
+    Apply(LoopState),
+    /// Transition is rejected with a canonical error.
+    Reject(CliError),
+}
+
+/// Run a loop transition: resolve the mission, load state, classify the
+/// transition, and either emit a no-op success or perform the mutation
+/// (and append the event). Honors `--dry-run` and `--expect-revision`.
+pub(crate) fn run_transition(
+    ctx: &Ctx,
+    event_kind: &'static str,
+    classify: impl FnOnce(&LoopState) -> Transition,
+) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let current = state::load(&paths)?;
+
+    match classify(&current.loop_) {
+        Transition::Reject(err) => {
+            // Enforce --expect-revision first: callers that pinned the
+            // revision want to know the state moved out from under them,
+            // even if the transition is also semantically invalid.
+            check_expected_revision(ctx, &current)?;
+            Err(err)
+        }
+        Transition::NoOp => {
+            check_expected_revision(ctx, &current)?;
+            emit(
+                &paths,
+                current.revision,
+                &current.loop_,
+                None,
+                ctx.dry_run,
+                true,
+            );
+            Ok(())
+        }
+        Transition::Apply(target) => {
+            if ctx.dry_run {
+                check_expected_revision(ctx, &current)?;
+                emit(
+                    &paths,
+                    current.revision,
+                    &target,
+                    Some(&current.loop_),
+                    true,
+                    false,
+                );
+                return Ok(());
+            }
+            let payload = json!(&target);
+            let mutation = state::mutate(&paths, ctx.expect_revision, event_kind, payload, |s| {
+                s.loop_ = target;
+                Ok(())
+            })?;
+            emit(
+                &paths,
+                mutation.state.revision,
+                &mutation.state.loop_,
+                None,
+                false,
+                false,
+            );
+            Ok(())
+        }
+    }
+}
+
+fn check_expected_revision(ctx: &Ctx, state: &MissionState) -> CliResult<()> {
+    if let Some(expected) = ctx.expect_revision {
+        if expected != state.revision {
+            return Err(CliError::RevisionConflict {
+                expected,
+                actual: state.revision,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn emit(
+    paths: &MissionPaths,
+    revision: u64,
+    loop_: &LoopState,
+    before: Option<&LoopState>,
+    dry_run: bool,
+    noop: bool,
+) {
+    // Mirror LoopState at the top of `data` (matching the task contract
+    // `{ active, paused, mode }`) and add `noop` / `dry_run` / optional
+    // `before` as extras callers can rely on without schema contention.
+    let mut data = json!(loop_);
+    data["noop"] = json!(noop);
+    data["dry_run"] = json!(dry_run);
+    if let Some(prev) = before {
+        data["before"] = json!(prev);
+    }
+    let env = JsonOk::new(Some(paths.mission_id.clone()), Some(revision), data);
+    println!("{}", env.to_pretty());
+}
+
+/// Parse a mode string from the CLI into `LoopMode`. `none` is rejected —
+/// that is what `deactivate` is for.
+pub(crate) fn parse_mode(raw: &str) -> CliResult<LoopMode> {
+    match raw {
+        "clarify" => Ok(LoopMode::Clarify),
+        "plan" => Ok(LoopMode::Plan),
+        "execute" => Ok(LoopMode::Execute),
+        "review_loop" => Ok(LoopMode::ReviewLoop),
+        "mission_close" => Ok(LoopMode::MissionClose),
+        "none" => Err(CliError::PlanInvalid {
+            message: "mode `none` is not a valid activation target".to_string(),
+            hint: Some("Use `codex1 loop deactivate` instead.".to_string()),
+        }),
+        other => Err(CliError::PlanInvalid {
+            message: format!("unknown loop mode `{other}`"),
+            hint: Some(
+                "Valid modes: clarify, plan, execute, review_loop, mission_close.".to_string(),
+            ),
+        }),
+    }
 }

--- a/crates/codex1/src/cli/loop_/pause.rs
+++ b/crates/codex1/src/cli/loop_/pause.rs
@@ -1,0 +1,24 @@
+//! `codex1 loop pause` — pause an active loop (used by $close).
+
+use crate::cli::loop_::{run_transition, Transition};
+use crate::cli::Ctx;
+use crate::core::error::{CliError, CliResult};
+use crate::state::schema::LoopState;
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    run_transition(ctx, "loop.paused", |current| {
+        if !current.active {
+            return Transition::Reject(CliError::TaskNotReady {
+                message: "No active loop to pause".to_string(),
+            });
+        }
+        if current.paused {
+            return Transition::NoOp;
+        }
+        Transition::Apply(LoopState {
+            active: true,
+            paused: true,
+            mode: current.mode.clone(),
+        })
+    })
+}

--- a/crates/codex1/src/cli/loop_/resume.rs
+++ b/crates/codex1/src/cli/loop_/resume.rs
@@ -1,0 +1,28 @@
+//! `codex1 loop resume` — resume a paused loop.
+
+use crate::cli::loop_::{run_transition, Transition};
+use crate::cli::Ctx;
+use crate::core::error::{CliError, CliResult};
+use crate::state::schema::LoopState;
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    run_transition(ctx, "loop.resumed", |current| {
+        // Idempotent only when already active and unpaused; otherwise the
+        // caller must go through activate/deactivate for the intended
+        // semantic (resume presumes there is a loop to resume).
+        if current.active && !current.paused {
+            return Transition::NoOp;
+        }
+        if !current.active {
+            return Transition::Reject(CliError::TaskNotReady {
+                message: "Loop is not active; cannot resume".to_string(),
+            });
+        }
+        // active && paused → unpause.
+        Transition::Apply(LoopState {
+            active: true,
+            paused: false,
+            mode: current.mode.clone(),
+        })
+    })
+}

--- a/crates/codex1/tests/loop_.rs
+++ b/crates/codex1/tests/loop_.rs
@@ -1,0 +1,572 @@
+//! Integration tests for `codex1 loop {activate,pause,resume,deactivate}`.
+//!
+//! These exercise the state transitions, idempotency, `--dry-run`, and
+//! `--expect-revision`, plus the Ralph stop-allow projection that hangs
+//! off the paused-loop check in `status`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+use codex1::state::schema::{LoopMode, LoopState, MissionCloseReviewState, PlanLevel, TaskStatus};
+use codex1::state::{self, MissionState, TaskRecord};
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_demo(tmp: &TempDir, mission: &str) -> PathBuf {
+    let mission_dir = tmp.path().join("PLANS").join(mission);
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", mission])
+        .assert()
+        .success();
+    mission_dir
+}
+
+fn parse_stdout_json(output: &Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(stdout)
+        .unwrap_or_else(|e| panic!("expected JSON stdout:\n{stdout}\nerror: {e}"))
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    let raw = fs::read_to_string(mission_dir.join("STATE.json")).expect("read STATE.json");
+    serde_json::from_str(&raw).expect("parse STATE.json")
+}
+
+fn read_event_lines(mission_dir: &Path) -> Vec<String> {
+    let raw = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap_or_default();
+    raw.lines().map(ToString::to_string).collect()
+}
+
+fn event_kinds(mission_dir: &Path) -> Vec<String> {
+    read_event_lines(mission_dir)
+        .into_iter()
+        .map(|line| {
+            let v: Value = serde_json::from_str(&line).expect("event jsonl");
+            v["kind"].as_str().unwrap_or_default().to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn fresh_mission_loop_inactive() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["active"], false);
+    assert_eq!(state["loop"]["paused"], false);
+    assert_eq!(state["loop"]["mode"], "none");
+}
+
+#[test]
+fn activate_sets_state_and_appends_event() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo", "--mode", "execute"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["active"], true);
+    assert_eq!(json["data"]["paused"], false);
+    assert_eq!(json["data"]["mode"], "execute");
+    assert_eq!(json["data"]["noop"], false);
+    assert_eq!(json["revision"], 1);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["active"], true);
+    assert_eq!(state["loop"]["mode"], "execute");
+    assert_eq!(event_kinds(&mission_dir), vec!["loop.activated"]);
+}
+
+#[test]
+fn activate_default_mode_is_execute() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["mode"], "execute");
+}
+
+#[test]
+fn pause_sets_paused_and_appends_event() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+
+    // Activate first.
+    cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo"])
+        .assert()
+        .success();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "pause", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["active"], true);
+    assert_eq!(json["data"]["paused"], true);
+    assert_eq!(json["data"]["noop"], false);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["paused"], true);
+    assert_eq!(
+        event_kinds(&mission_dir),
+        vec!["loop.activated", "loop.paused"]
+    );
+}
+
+#[test]
+fn resume_clears_paused_and_appends_event() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo"])
+        .assert()
+        .success();
+    cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "pause", "--mission", "demo"])
+        .assert()
+        .success();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "resume", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["active"], true);
+    assert_eq!(json["data"]["paused"], false);
+    assert_eq!(json["data"]["noop"], false);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["paused"], false);
+    assert_eq!(
+        event_kinds(&mission_dir),
+        vec!["loop.activated", "loop.paused", "loop.resumed"]
+    );
+}
+
+#[test]
+fn pause_twice_is_idempotent_with_no_extra_event() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo"])
+        .assert()
+        .success();
+    cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "pause", "--mission", "demo"])
+        .assert()
+        .success();
+    let revision_after_first_pause = read_state(&mission_dir)["revision"].as_u64().unwrap();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "pause", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["noop"], true);
+    assert_eq!(json["revision"], revision_after_first_pause);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(
+        state["revision"].as_u64().unwrap(),
+        revision_after_first_pause
+    );
+    // No second `loop.paused` event.
+    assert_eq!(
+        event_kinds(&mission_dir),
+        vec!["loop.activated", "loop.paused"]
+    );
+}
+
+#[test]
+fn deactivate_resets_to_default() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo", "--mode", "plan"])
+        .assert()
+        .success();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "deactivate", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["active"], false);
+    assert_eq!(json["data"]["paused"], false);
+    assert_eq!(json["data"]["mode"], "none");
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["active"], false);
+    assert_eq!(state["loop"]["mode"], "none");
+    assert_eq!(
+        event_kinds(&mission_dir),
+        vec!["loop.activated", "loop.deactivated"]
+    );
+}
+
+#[test]
+fn deactivate_twice_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    // No activate — state already matches default deactivated.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "deactivate", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["noop"], true);
+    assert_eq!(json["revision"], 0);
+    // Nothing appended.
+    assert!(read_event_lines(&mission_dir).is_empty());
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "deactivate", "--mission", "demo"])
+        .output()
+        .unwrap();
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["noop"], true);
+    assert!(read_event_lines(&mission_dir).is_empty());
+}
+
+#[test]
+fn pause_inactive_loop_is_task_not_ready() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "pause", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["code"], "TASK_NOT_READY");
+    assert!(json["message"].as_str().unwrap().contains("No active loop"));
+    // State untouched.
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["active"], false);
+    assert_eq!(state["revision"], 0);
+}
+
+#[test]
+fn resume_unpaused_active_loop_is_noop() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo"])
+        .assert()
+        .success();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "resume", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["noop"], true);
+    // No resumed event appended.
+    assert_eq!(event_kinds(&mission_dir), vec!["loop.activated"]);
+}
+
+#[test]
+fn resume_inactive_loop_is_task_not_ready() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "resume", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "TASK_NOT_READY");
+    assert!(json["message"].as_str().unwrap().contains("not active"));
+}
+
+#[test]
+fn activate_bogus_mode_is_plan_invalid() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "loop",
+            "activate",
+            "--mission",
+            "demo",
+            "--mode",
+            "whatever",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["active"], false);
+    assert_eq!(state["revision"], 0);
+}
+
+#[test]
+fn activate_mode_none_is_plan_invalid() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "activate", "--mission", "demo", "--mode", "none"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "PLAN_INVALID");
+    assert!(json["hint"].as_str().unwrap().contains("loop deactivate"));
+}
+
+#[test]
+fn dry_run_preserves_state_on_activate() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "loop",
+            "activate",
+            "--mission",
+            "demo",
+            "--mode",
+            "execute",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["active"], true);
+    assert_eq!(json["data"]["before"]["active"], false);
+    // Nothing was written.
+    let state = read_state(&mission_dir);
+    assert_eq!(state["loop"]["active"], false);
+    assert_eq!(state["revision"], 0);
+    assert!(read_event_lines(&mission_dir).is_empty());
+}
+
+#[test]
+fn dry_run_preserves_state_on_pause_and_still_errors_when_inactive() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    // pause --dry-run against inactive: honest error, no mutation.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "pause", "--mission", "demo", "--dry-run"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "TASK_NOT_READY");
+    let state = read_state(&mission_dir);
+    assert_eq!(state["revision"], 0);
+}
+
+#[test]
+fn expect_revision_enforced_on_mutating_transitions() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    // Fresh state has revision 0. Passing --expect-revision 5 should
+    // fail with REVISION_CONFLICT.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "loop",
+            "activate",
+            "--mission",
+            "demo",
+            "--expect-revision",
+            "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+    assert_eq!(json["retryable"], true);
+    assert_eq!(json["context"]["expected"], 5);
+    assert_eq!(json["context"]["actual"], 0);
+}
+
+#[test]
+fn expect_revision_enforced_on_noop_transitions() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    // `deactivate` on a fresh mission is a noop at revision 0.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "loop",
+            "deactivate",
+            "--mission",
+            "demo",
+            "--expect-revision",
+            "9",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+}
+
+#[test]
+fn expect_revision_matches_allow_mutation() {
+    let tmp = TempDir::new().unwrap();
+    init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "loop",
+            "activate",
+            "--mission",
+            "demo",
+            "--expect-revision",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["revision"], 1);
+}
+
+#[test]
+fn paused_loop_allows_stop_in_status() {
+    // Build a mission by hand that sits in `continue_required`:
+    // ratified outcome, locked plan, one pending task. With the loop
+    // active and unpaused, status.stop.allow == false. Pause and it
+    // flips to true.
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+
+    // Hand-craft state past clarify/plan so the verdict is
+    // `continue_required`. Foundation's helpers make this safe.
+    let mut state = MissionState::fresh("demo");
+    state.revision = 0;
+    state.phase = codex1::state::schema::Phase::Execute;
+    state.outcome.ratified = true;
+    state.outcome.ratified_at = Some("2026-04-20T12:00:00Z".to_string());
+    state.plan.locked = true;
+    state.plan.requested_level = Some(PlanLevel::Medium);
+    state.plan.effective_level = Some(PlanLevel::Medium);
+    state.plan.hash = Some("deadbeef".to_string());
+    state.tasks.insert(
+        "T1".to_string(),
+        TaskRecord {
+            id: "T1".to_string(),
+            status: TaskStatus::Pending,
+            started_at: None,
+            finished_at: None,
+            proof_path: None,
+            superseded_by: None,
+        },
+    );
+    state.close.review_state = MissionCloseReviewState::NotStarted;
+    state.loop_ = LoopState {
+        active: true,
+        paused: false,
+        mode: LoopMode::Execute,
+    };
+    let raw = serde_json::to_vec_pretty(&state).unwrap();
+    state::fs_atomic::atomic_write(&mission_dir.join("STATE.json"), &raw).unwrap();
+
+    // Sanity: with active loop + continue_required, stop.allow is false.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["status", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["verdict"], "continue_required");
+    assert_eq!(json["data"]["stop"]["allow"], false);
+
+    // Pause the loop.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["loop", "pause", "--mission", "demo"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // After pause, stop.allow flips to true because loop.paused == true.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["status", "--mission", "demo"])
+        .output()
+        .unwrap();
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["data"]["verdict"], "continue_required");
+    assert_eq!(json["data"]["loop"]["paused"], true);
+    assert_eq!(json["data"]["stop"]["allow"], true);
+}
+
+#[test]
+fn pause_resume_cycle_appends_events_in_order() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    for args in [
+        &["loop", "activate", "--mission", "demo", "--mode", "execute"][..],
+        &["loop", "pause", "--mission", "demo"][..],
+        &["loop", "resume", "--mission", "demo"][..],
+        &["loop", "pause", "--mission", "demo"][..],
+        &["loop", "deactivate", "--mission", "demo"][..],
+    ] {
+        cmd().current_dir(tmp.path()).args(args).assert().success();
+    }
+    assert_eq!(
+        event_kinds(&mission_dir),
+        vec![
+            "loop.activated",
+            "loop.paused",
+            "loop.resumed",
+            "loop.paused",
+            "loop.deactivated"
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

- Implements `codex1 loop activate|pause|resume|deactivate --json`, driving `STATE.json.loop` so Ralph's Stop-allow decision keys off `loop.active` / `loop.paused`.
- Adds a new `Activate { mode }` variant to `LoopCmd` so other units (outcome ratify, plan check) have a single idempotent entry point for loop activation rather than each inventing their own mutation.
- Shares a `run_transition` helper across all four commands that classifies each request into NoOp / Apply / Reject, skipping the mutation pipeline entirely for no-ops (no revision bump, no event append) while still honoring `--expect-revision`.

## Shape notes

- Success envelope mirrors `LoopState` flat at the top of `data` (`{ active, paused, mode }`) per the task contract, with `noop` and `dry_run` as metadata extras. `--dry-run` previews also emit a `before` block showing the prior LoopState.
- `parse_mode` rejects `none` with `PLAN_INVALID` (hint: use `loop deactivate`); unknown modes return `PLAN_INVALID` with the valid-modes list. Clap default mode is `execute`.
- `pause` on an inactive loop returns `TASK_NOT_READY`. `resume` is a no-op on an already-active+unpaused loop; returns `TASK_NOT_READY` if the loop is inactive (there is no paused state to resume from).
- Event kinds appended to EVENTS.jsonl: `loop.activated`, `loop.paused`, `loop.resumed`, `loop.deactivated`.

## DO-NOT-TOUCH compliance

No changes to `Cargo.toml`, `src/bin/**`, `src/lib.rs`, `src/cli/mod.rs`, `src/core/**`, `src/state/**`, `init.rs`, `doctor.rs`, `hook.rs`, `Makefile`, or `docs/cli-contract-schemas.md`. Only the four owned modules and `tests/loop_.rs`. The `LoopCmd` enum gained the required `Activate` variant; the three existing variants (`Pause`, `Resume`, `Deactivate`) are preserved in name and shape.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 20 new tests in `tests/loop_.rs` plus 13 existing foundation tests all pass
- [x] Tests exercise: fresh-mission loop state, activate+event append, default mode, pause+event, resume+event, double-pause idempotency (no second event), deactivate reset, double-deactivate idempotency, pause-inactive rejection, resume-noop-active, resume-inactive rejection, bogus mode (`PLAN_INVALID`), `none` mode (`PLAN_INVALID`), dry-run preservation for both activate and pause-inactive, `--expect-revision` enforcement on mutating transitions, no-op transitions, and matching revisions, and the Ralph-facing `stop.allow` flip after pause on a hand-crafted `continue_required` mission.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>