### PR TITLE
Unit 12: Ralph Stop hook script + wiring docs

### DIFF
--- a/crates/codex1/tests/ralph_hook.rs
+++ b/crates/codex1/tests/ralph_hook.rs
@@ -1,0 +1,202 @@
+//! Integration tests for `scripts/ralph-stop-hook.sh`.
+//!
+//! Each test builds a tempdir with a fake `codex1` bash wrapper that emits a
+//! known status payload, prepends the tempdir to `PATH`, and runs the hook
+//! script. We assert on exit code and stderr contents.
+//!
+//! The hook must be status-only: these tests never build real mission state.
+//! They only feed the shell script a canned JSON blob and observe how it
+//! decides to exit. That is the whole Ralph contract.
+//!
+//! Tests are skipped gracefully if `bash` is not available on the host.
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn hook_script_path() -> PathBuf {
+    // CARGO_MANIFEST_DIR resolves to <repo>/crates/codex1 at test time.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent() // crates/
+        .and_then(Path::parent) // repo root
+        .expect("crates/codex1 has a repo root ancestor")
+        .join("scripts")
+        .join("ralph-stop-hook.sh")
+}
+
+fn write_fake_codex1(tmp: &TempDir, body: &str) -> PathBuf {
+    let path = tmp.path().join("codex1");
+    fs::write(&path, body).expect("write fake codex1");
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+/// Run the hook with `codex1` stubbed to emit `fake_status_json`.
+fn run_hook_with_mocked_codex1(fake_status_json: &str) -> Output {
+    let tmp = TempDir::new().expect("tempdir");
+    // Escape the JSON for single-quoted bash heredoc-alternative.
+    let escaped = fake_status_json.replace('\'', "'\"'\"'");
+    let body = format!("#!/usr/bin/env bash\nprintf '%s\\n' '{}'\n", escaped);
+    write_fake_codex1(&tmp, &body);
+    run_hook_with_path(Some(tmp.path().to_path_buf()))
+}
+
+fn run_hook_with_path(prepend: Option<PathBuf>) -> Output {
+    let hook = hook_script_path();
+    assert!(hook.is_file(), "hook script missing at {}", hook.display());
+
+    // Build PATH: prepend optional tempdir, otherwise strip any codex1 that
+    // might be in the environment so we can test the "no codex1 on PATH"
+    // case deterministically.
+    let path = build_path(prepend.as_deref());
+
+    let mut cmd = Command::new("bash");
+    cmd.arg(&hook);
+    // Close stdin, capture stdout/stderr so tests can inspect them.
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    cmd.env_clear();
+    cmd.env("PATH", path);
+    // Preserve HOME so jq/bash don't complain on some shells.
+    if let Ok(home) = std::env::var("HOME") {
+        cmd.env("HOME", home);
+    }
+
+    cmd.output().expect("run hook")
+}
+
+fn build_path(prepend: Option<&Path>) -> OsString {
+    // Start from a safe minimum so jq is discoverable. Drop any entry
+    // containing a literal `codex1` binary so the no-codex1 test is
+    // deterministic.
+    let baseline = std::env::var_os("PATH").unwrap_or_else(|| OsString::from("/usr/bin:/bin"));
+    let mut parts: Vec<PathBuf> = std::env::split_paths(&baseline)
+        .filter(|p| !p.join("codex1").exists())
+        .collect();
+    if let Some(extra) = prepend {
+        parts.insert(0, extra.to_path_buf());
+    }
+    std::env::join_paths(parts).expect("join PATH")
+}
+
+fn bash_available() -> bool {
+    Command::new("bash")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn stderr_str(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[test]
+fn stop_allow_true_exits_zero() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let out = run_hook_with_mocked_codex1(
+        r#"{"ok":true,"mission_id":"demo","data":{"stop":{"allow":true,"reason":"idle","message":"Stop is allowed."}}}"#,
+    );
+    assert!(
+        out.status.success(),
+        "hook should exit 0 when stop.allow=true; stderr: {}",
+        stderr_str(&out)
+    );
+    assert_eq!(out.status.code(), Some(0));
+}
+
+#[test]
+fn stop_allow_false_blocks_with_exit_two() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    let out = run_hook_with_mocked_codex1(
+        r#"{"ok":true,"mission_id":"demo","data":{"stop":{"allow":false,"reason":"active_loop","message":"Run $close to pause."}}}"#,
+    );
+    assert_eq!(out.status.code(), Some(2), "expected exit 2 to block Stop");
+    let err = stderr_str(&out);
+    assert!(
+        err.contains("blocking Stop"),
+        "stderr should mention blocking Stop; got: {err}"
+    );
+    assert!(
+        err.contains("active_loop"),
+        "stderr should include the reason; got: {err}"
+    );
+}
+
+#[test]
+fn empty_status_output_allows_stop() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    // A fake codex1 that prints nothing.
+    let tmp = TempDir::new().expect("tempdir");
+    write_fake_codex1(&tmp, "#!/usr/bin/env bash\nexit 0\n");
+    let out = run_hook_with_path(Some(tmp.path().to_path_buf()));
+    assert_eq!(out.status.code(), Some(0));
+    let err = stderr_str(&out);
+    assert!(
+        err.contains("empty status output"),
+        "stderr should warn about empty output; got: {err}"
+    );
+}
+
+#[test]
+fn missing_codex1_binary_allows_stop_with_warning() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    // No prepend -> PATH with codex1 stripped; hook must still exit 0.
+    let out = run_hook_with_path(None);
+    assert_eq!(out.status.code(), Some(0));
+    let err = stderr_str(&out);
+    assert!(
+        err.contains("codex1 not on PATH"),
+        "stderr should warn about missing codex1; got: {err}"
+    );
+}
+
+#[test]
+fn malformed_json_defaults_to_allow() {
+    if !bash_available() {
+        eprintln!("skipping: bash not available");
+        return;
+    }
+    // No `stop.allow` field -> jq returns `null`, hook falls through to the
+    // `*)` branch in the case statement and conservatively allows Stop.
+    let out = run_hook_with_mocked_codex1(
+        r#"{"ok":true,"mission_id":"demo","data":{"phase":"clarify"}}"#,
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "missing stop.allow should default to allowing Stop; stderr: {}",
+        stderr_str(&out)
+    );
+}
+
+#[test]
+fn hook_script_is_executable() {
+    let hook = hook_script_path();
+    let meta = fs::metadata(&hook).expect("hook script exists");
+    let mode = meta.permissions().mode();
+    assert!(
+        mode & 0o111 != 0,
+        "hook script must be executable; mode={mode:o}"
+    );
+}

--- a/scripts/README-hook.md
+++ b/scripts/README-hook.md
@@ -1,0 +1,109 @@
+# Ralph Stop Hook
+
+`scripts/ralph-stop-hook.sh` is the portable Codex1 Stop hook. It is the only
+piece of Ralph. Ralph is intentionally tiny: the hook reads
+`codex1 status --json` and decides whether to block or allow a Stop event.
+
+## What it does
+
+On every Codex Stop event the harness invokes the hook. The hook:
+
+1. Runs `codex1 status --json` in the current working directory.
+2. Inspects `data.stop.allow` in the returned envelope.
+3. Exits `0` when Stop is allowed (loop inactive, paused, or mission already
+   past mission-close-review-passed / terminal-complete).
+4. Exits `2` when Stop must be blocked (loop active, unpaused, and status
+   reports `stop.allow == false`). Codex treats exit code 2 as "block this
+   Stop and surface stderr to the user".
+
+The hook does **not** read plan files, subagent state, `.ralph/` directories,
+or any other artifact. It calls only `codex1 status --json`. If `codex1` is
+missing, the status output is empty, or the JSON cannot be parsed, the hook
+conservatively exits `0` so a broken install never wedges the terminal.
+
+## Requirements
+
+- `codex1` on `PATH`, or set `CODEX1_BIN=/absolute/path/to/codex1`.
+- `jq` (strongly recommended; the fallback grep parse is best-effort).
+- `bash` 4+.
+
+## Install
+
+Copy or symlink the script somewhere stable, then reference its absolute path
+from your Codex hooks file.
+
+Global user hooks live at `~/.codex/hooks.json`. Per-repo hooks live at
+`./.codex/hooks.json`. Either works; per-repo is preferred when the repo
+ships its own `codex1` workflow.
+
+Example hook wiring:
+
+```json
+{
+  "Stop": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "/absolute/path/to/codex1/scripts/ralph-stop-hook.sh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+You can also ask `codex1` to print the one-liner:
+
+```bash
+codex1 hook snippet
+```
+
+`codex1 hook snippet` only prints the wiring JSON; it does not install
+anything.
+
+## Verify
+
+In a mission with loop active and `stop.allow == false`:
+
+```bash
+bash scripts/ralph-stop-hook.sh; echo "exit=$?"   # expect exit=2
+```
+
+After `codex1 loop pause --mission demo` (or when the mission is idle):
+
+```bash
+bash scripts/ralph-stop-hook.sh; echo "exit=$?"   # expect exit=0
+```
+
+You can also drive the hook against a synthetic JSON by stubbing `codex1`:
+
+```bash
+tmpdir=$(mktemp -d)
+cat > "$tmpdir/codex1" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"ok":true,"data":{"stop":{"allow":false,"reason":"active_loop","message":"Run $close to pause."}}}'
+EOF
+chmod +x "$tmpdir/codex1"
+PATH="$tmpdir:$PATH" bash scripts/ralph-stop-hook.sh; echo "exit=$?"   # expect exit=2
+```
+
+## Uninstall
+
+Remove the `Stop` entry from `~/.codex/hooks.json` (or the repo-local
+`.codex/hooks.json`). The script itself is stateless; deleting the file is
+safe at any time.
+
+## Design notes
+
+- Ralph is status-only. It never inspects mission files. This keeps the
+  behavior consistent with whatever `codex1 status` reports today, even as
+  Phase B replaces the status projection.
+- Ralph does not enforce caller identity. Only the active main thread should
+  feel Stop pressure; subagents should be prompt-governed to finish and exit
+  on their own. Any additional filtering must be expressed through
+  `codex1 status`, not by adding logic to the hook.
+- The hook drains stdin if Codex provides hook input on the pipe, so the
+  launcher never stalls even though the current implementation does not use
+  the hook payload.

--- a/scripts/ralph-stop-hook.sh
+++ b/scripts/ralph-stop-hook.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Ralph Stop hook for Codex1.
+#
+# Reads `codex1 status --json` and blocks Stop (exit 2) only when a loop is
+# active-and-unpaused and stop.allow == false. Otherwise exits 0.
+#
+# Requires: codex1 on PATH, jq.
+# Never inspects mission files directly. Always goes through the CLI.
+
+set -euo pipefail
+
+# Codex passes hook input via stdin as JSON; we don't currently consume it,
+# but drain it so the pipe doesn't stall.
+if [ -t 0 ]; then : ; else cat > /dev/null || true; fi
+
+CODEX1=${CODEX1_BIN:-codex1}
+
+if ! command -v "$CODEX1" >/dev/null 2>&1; then
+  echo "ralph-stop-hook: codex1 not on PATH; allowing Stop" >&2
+  exit 0
+fi
+
+# Ask status in the current repo. If no mission resolves, status returns
+# stop.allow=true; exit 0 so Stop is allowed.
+status_json="$("$CODEX1" status --json 2>/dev/null || true)"
+if [ -z "$status_json" ]; then
+  echo "ralph-stop-hook: empty status output; allowing Stop" >&2
+  exit 0
+fi
+
+# Prefer jq when available; fallback to grep if jq is missing (degraded).
+#
+# Note: we read `.data.stop.allow` raw (no `//` default) because the jq `//`
+# alternative-operator treats literal `false` as "missing" and would flip a
+# real block into an allow. We handle the null/missing case explicitly below.
+if command -v jq >/dev/null 2>&1; then
+  allow="$(printf '%s' "$status_json" | jq -r '.data.stop.allow' 2>/dev/null || true)"
+  reason="$(printf '%s' "$status_json" | jq -r '.data.stop.reason // "idle"' 2>/dev/null || echo idle)"
+  message="$(printf '%s' "$status_json" | jq -r '.data.stop.message // ""' 2>/dev/null || echo "")"
+else
+  # Rough fallback parsing; jq is strongly preferred.
+  allow="$(printf '%s' "$status_json" | grep -o '"allow"[[:space:]]*:[[:space:]]*\(true\|false\)' | head -n1 | awk -F: '{print $2}' | tr -d ' ')"
+  reason="unknown"
+  message="jq not installed - degraded parse"
+fi
+
+case "$allow" in
+  true)
+    exit 0
+    ;;
+  false)
+    echo "ralph-stop-hook: blocking Stop - reason=$reason" >&2
+    [ -n "$message" ] && echo "ralph-stop-hook: $message" >&2
+    exit 2
+    ;;
+  *)
+    echo "ralph-stop-hook: could not parse stop.allow from status JSON; allowing Stop" >&2
+    exit 0
+    ;;
+esac


### PR DESCRIPTION
## Summary

- `scripts/ralph-stop-hook.sh` — the tiny portable Stop hook. Runs `codex1 status --json`, reads `data.stop.allow`, exits 2 to block Stop or 0 to allow. Never touches plan files, subagent state, or `.ralph/`.
- `scripts/README-hook.md` — wiring docs for `~/.codex/hooks.json` (or per-repo `.codex/hooks.json`), verification steps, and uninstall.
- `crates/codex1/tests/ralph_hook.rs` — Rust integration tests that run the shell script against a mocked `codex1` binary. Covers: `stop.allow: true`, `stop.allow: false`, empty output, no `codex1` on PATH, malformed JSON, and executable-bit check.

### Notable design decision

The hook reads `.data.stop.allow` directly instead of `.data.stop.allow // true`. jq's `//` alternative-operator treats literal `false` as "missing" and would have flipped a real block into an allow. Null / missing is handled explicitly by the shell `case *)` branch.

## Smoke test

```
$ cd /tmp/codex1-u12 && codex1 init --mission demo
$ codex1 --json status --mission demo
  ... "stop": { "allow": true, "reason": "idle", ... }
$ CODEX1_BIN=/path/to/codex1 bash scripts/ralph-stop-hook.sh; echo "exit=$?"
exit=0
```

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test` (13 foundation + 6 new ralph_hook tests, all pass)
- [x] `bash -n scripts/ralph-stop-hook.sh` (syntax OK; shellcheck not installed locally)
- [x] Manual smoke test against a freshly-initialized mission (hook exits 0 as expected)
- [x] Manual test with stubbed `codex1` returning `stop.allow: false` (hook exits 2 with `blocking Stop` on stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)