### PR TITLE
Unit 7: cli-review lifecycle + late-output classification

### DIFF
--- a/crates/codex1/src/cli/review/classify.rs
+++ b/crates/codex1/src/cli/review/classify.rs
@@ -1,0 +1,88 @@
+//! Review-record freshness classification.
+//!
+//! See `docs/cli-contract-schemas.md` § "Review record freshness". The
+//! classification is pure over `MissionState` — no IO, no mutation.
+
+use crate::state::schema::{MissionState, ReviewRecordCategory, ReviewVerdict, TaskStatus};
+
+/// Inputs to the classifier. `state_revision_at_record` is the pre-bump
+/// revision observed at the start of `review record`'s mutation closure.
+pub struct ClassifyInput<'a> {
+    pub state: &'a MissionState,
+    pub review_task_id: &'a str,
+    pub target_task_ids: &'a [String],
+    /// The mutation-closure-entry revision. `review record` runs inside
+    /// `state::mutate`; at closure entry `state.revision` is pre-bump.
+    pub state_revision_at_record: u64,
+}
+
+/// Classify a review record per the freshness rules.
+///
+/// Order (per handoff spec):
+/// 1. `close.terminal_at` set          -> `contaminated_after_terminal`.
+/// 2. Review task or any target has `superseded_by` set OR the target's
+///    status is `Superseded`                            -> `stale_superseded`.
+/// 3. No prior `review.started` record found            -> `accepted_current`
+///    (this is a first-time record; the boundary is "now"). Classification
+///    fall-through handles this by returning `accepted_current`.
+/// 4. `state_revision_at_record > boundary_revision`    -> `late_same_boundary`.
+/// 5. else                                              -> `accepted_current`.
+#[must_use]
+pub fn classify(input: &ClassifyInput<'_>) -> ReviewRecordCategory {
+    if input.state.close.terminal_at.is_some() {
+        return ReviewRecordCategory::ContaminatedAfterTerminal;
+    }
+    if is_superseded(input) {
+        return ReviewRecordCategory::StaleSuperseded;
+    }
+
+    // Pending record tells us the boundary revision the review was started
+    // at. If there is no start record, classify as `accepted_current` and
+    // let the record command create one.
+    let boundary = input
+        .state
+        .reviews
+        .get(input.review_task_id)
+        .map(|r| r.boundary_revision);
+    match boundary {
+        Some(b) if input.state_revision_at_record > b => ReviewRecordCategory::LateSameBoundary,
+        _ => ReviewRecordCategory::AcceptedCurrent,
+    }
+}
+
+fn is_superseded(input: &ClassifyInput<'_>) -> bool {
+    if let Some(review) = input.state.tasks.get(input.review_task_id) {
+        if review.superseded_by.is_some() || matches!(review.status, TaskStatus::Superseded) {
+            return true;
+        }
+    }
+    for tid in input.target_task_ids {
+        if let Some(t) = input.state.tasks.get(tid) {
+            if t.superseded_by.is_some() || matches!(t.status, TaskStatus::Superseded) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Human-friendly category label for event payloads.
+#[must_use]
+pub fn category_str(cat: ReviewRecordCategory) -> &'static str {
+    match cat {
+        ReviewRecordCategory::AcceptedCurrent => "accepted_current",
+        ReviewRecordCategory::LateSameBoundary => "late_same_boundary",
+        ReviewRecordCategory::StaleSuperseded => "stale_superseded",
+        ReviewRecordCategory::ContaminatedAfterTerminal => "contaminated_after_terminal",
+    }
+}
+
+/// Stable string label for a review verdict.
+#[must_use]
+pub fn verdict_str(v: &ReviewVerdict) -> &'static str {
+    match v {
+        ReviewVerdict::Pending => "pending",
+        ReviewVerdict::Clean => "clean",
+        ReviewVerdict::Dirty => "dirty",
+    }
+}

--- a/crates/codex1/src/cli/review/mod.rs
+++ b/crates/codex1/src/cli/review/mod.rs
@@ -1,11 +1,24 @@
-//! `codex1 review` stub — owned by Phase B Unit 7.
+//! `codex1 review` — reviewer packet emission, start/record/status.
+//!
+//! The CLI does not check caller identity; the main thread records review
+//! outcomes. Reviewer subagents only return findings (findings-file copied
+//! to `PLANS/<mission>/reviews/<id>.md`). See
+//! `docs/cli-contract-schemas.md` § Review record freshness for
+//! classification rules.
 
 use std::path::PathBuf;
 
 use clap::Subcommand;
 
 use crate::cli::Ctx;
-use crate::core::error::{CliError, CliResult};
+use crate::core::error::CliResult;
+
+mod classify;
+mod packet;
+mod plan_read;
+mod record;
+mod start;
+mod status_cmd;
 
 #[derive(Debug, Subcommand)]
 pub enum ReviewCmd {
@@ -24,10 +37,14 @@ pub enum ReviewCmd {
         #[arg(value_name = "TASK_ID")]
         task: String,
         /// Mark review clean (no P0/P1/P2 findings).
-        #[arg(long, conflicts_with = "findings_file")]
+        #[arg(
+            long,
+            conflicts_with = "findings_file",
+            required_unless_present = "findings_file"
+        )]
         clean: bool,
         /// Path to a markdown file with P0/P1/P2 findings.
-        #[arg(long, value_name = "PATH")]
+        #[arg(long, value_name = "PATH", required_unless_present = "clean")]
         findings_file: Option<PathBuf>,
         /// Comma-separated reviewer actor ids.
         #[arg(long, value_name = "LIST")]
@@ -40,14 +57,24 @@ pub enum ReviewCmd {
     },
 }
 
-pub fn dispatch(cmd: ReviewCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        ReviewCmd::Start { .. } => "review start",
-        ReviewCmd::Packet { .. } => "review packet",
-        ReviewCmd::Record { .. } => "review record",
-        ReviewCmd::Status { .. } => "review status",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: ReviewCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        ReviewCmd::Start { task } => start::run(ctx, &task),
+        ReviewCmd::Packet { task } => packet::run(ctx, &task),
+        ReviewCmd::Record {
+            task,
+            clean,
+            findings_file,
+            reviewers,
+        } => record::run(
+            ctx,
+            &record::RecordInputs {
+                task_id: &task,
+                clean,
+                findings_file,
+                reviewers_csv: reviewers,
+            },
+        ),
+        ReviewCmd::Status { task } => status_cmd::run(ctx, &task),
+    }
 }

--- a/crates/codex1/src/cli/review/packet.rs
+++ b/crates/codex1/src/cli/review/packet.rs
@@ -1,0 +1,173 @@
+//! `codex1 review packet <id>` — emit a reviewer-subagent packet.
+//!
+//! Read-only. The packet names the target tasks, their specs/proofs, the
+//! files they touched (from PLAN.yaml `write_paths`), the mission summary
+//! (interpreted destination from OUTCOME.md), and the standing reviewer
+//! instructions literal.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::cli::review::plan_read::{fetch_review_task, load_tasks, review_targets, PlanTask};
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::CliResult;
+use crate::core::mission::resolve_mission;
+use crate::core::paths::MissionPaths;
+use crate::state;
+
+/// Standing reviewer instructions. See `04-roles-models-prompts.md`.
+pub const REVIEWER_INSTRUCTIONS: &str = "You are a Codex1 reviewer. Do not edit files. Do not invoke Codex1 skills. Do not record mission truth. Do not run commands that mutate mission state. Do not perform repairs.
+
+You may: inspect files, inspect diffs, run safe read-only commands, run tests if explicitly allowed.
+
+Return only: NONE or P0/P1/P2 findings with evidence refs and concise rationale.
+
+Only review the assigned target against the mission, outcome, plan, and profile. Do not review unrelated future work.";
+
+pub fn run(ctx: &Ctx, task_id: &str) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let plan_tasks = load_tasks(&paths.plan())?;
+    let review_task = fetch_review_task(&plan_tasks, task_id)?;
+    let targets = review_targets(&review_task)?;
+
+    // Build per-target spec/proof refs + aggregated diffs from write_paths.
+    let mut target_specs: Vec<Value> = Vec::new();
+    let mut target_proofs: Vec<String> = Vec::new();
+    let mut diffs: Vec<Value> = Vec::new();
+    for tid in &targets {
+        let target = plan_tasks.get(tid).cloned();
+        target_specs.push(target_spec_value(&paths, tid, target.as_ref()));
+        if let Some(p) = proof_path_string(&paths, tid) {
+            target_proofs.push(p);
+        }
+        if let Some(t) = target.as_ref() {
+            for path in &t.write_paths {
+                diffs.push(json!({ "path": path }));
+            }
+        }
+    }
+
+    let profiles = review_task.review_profiles.clone();
+    let primary_profile = profiles
+        .first()
+        .cloned()
+        .unwrap_or_else(|| "code_bug_correctness".to_string());
+    let mission_summary = read_interpreted_destination(&paths.outcome()).unwrap_or_default();
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        json!({
+            "task_id": task_id,
+            "review_profile": primary_profile,
+            "profiles": profiles,
+            "targets": targets,
+            "target_specs": target_specs,
+            "target_proofs": target_proofs,
+            "diffs": diffs,
+            "mission_summary": mission_summary,
+            "mission_id": state.mission_id,
+            "reviewer_instructions": REVIEWER_INSTRUCTIONS,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+fn target_spec_value(paths: &MissionPaths, task_id: &str, task: Option<&PlanTask>) -> Value {
+    let spec_path = task
+        .and_then(|t| t.spec.clone())
+        .unwrap_or_else(|| relative_from_repo(paths, &paths.spec_file_for(task_id)));
+    // `spec_path` in PLAN.yaml is a string relative to the mission dir,
+    // e.g. `specs/T2/SPEC.md`. Resolve it against the mission dir for
+    // the file read, but report the original string to the caller.
+    let spec_absolute = resolve_spec_path(paths, &spec_path);
+    let excerpt = read_excerpt(&spec_absolute).unwrap_or_default();
+    json!({
+        "task_id": task_id,
+        "spec_path": spec_path,
+        "spec_excerpt": excerpt,
+    })
+}
+
+fn resolve_spec_path(paths: &MissionPaths, spec_str: &str) -> PathBuf {
+    let p = Path::new(spec_str);
+    if p.is_absolute() {
+        return p.to_path_buf();
+    }
+    paths.mission_dir.join(p)
+}
+
+fn proof_path_string(paths: &MissionPaths, task_id: &str) -> Option<String> {
+    let abs = paths.proof_file_for(task_id);
+    if abs.is_file() {
+        Some(relative_from_repo(paths, &abs))
+    } else {
+        None
+    }
+}
+
+fn relative_from_repo(paths: &MissionPaths, abs: &Path) -> String {
+    abs.strip_prefix(&paths.repo_root).map_or_else(
+        |_| abs.to_string_lossy().into_owned(),
+        |p| p.to_string_lossy().replace('\\', "/"),
+    )
+}
+
+fn read_excerpt(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    const LIMIT: usize = 2_000;
+    if raw.len() <= LIMIT {
+        Some(raw)
+    } else {
+        let mut s = raw;
+        s.truncate(LIMIT);
+        s.push_str("\n…[truncated]");
+        Some(s)
+    }
+}
+
+fn read_interpreted_destination(outcome: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(outcome).ok()?;
+    // Naive pull: the block after `interpreted_destination:` up to the
+    // next top-level YAML key. We do not want to import a full YAML
+    // walker here; a substring pick is good enough for the packet.
+    let needle = "interpreted_destination:";
+    let start = raw.find(needle)?;
+    let rest = &raw[start + needle.len()..];
+    let mut out = String::new();
+    let mut first_non_empty_seen = false;
+    for line in rest.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            if first_non_empty_seen {
+                break;
+            }
+            continue;
+        }
+        if first_non_empty_seen {
+            // Stop when we leave the indented block.
+            let leading_ws = line.len() - line.trim_start().len();
+            if leading_ws == 0 {
+                break;
+            }
+        } else {
+            first_non_empty_seen = true;
+            // Skip the `|` or `>` that follow the key — we want the body.
+            if trimmed == "|" || trimmed == ">" {
+                continue;
+            }
+        }
+        out.push_str(trimmed.trim_start());
+        out.push('\n');
+    }
+    let s = out.trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}

--- a/crates/codex1/src/cli/review/plan_read.rs
+++ b/crates/codex1/src/cli/review/plan_read.rs
@@ -1,0 +1,101 @@
+//! Minimal PLAN.yaml reader for review commands.
+//!
+//! We only pull what review needs: the review task's `kind`, its review
+//! target task ids, review profiles, and per-target `write_paths`.
+//! Anything richer belongs to `plan check` (Phase B Unit 3).
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::core::error::CliError;
+
+/// One entry in `tasks:`. Only the fields review cares about.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanTask {
+    pub id: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub spec: Option<String>,
+    #[serde(default)]
+    pub write_paths: Vec<String>,
+    #[serde(default)]
+    pub review_target: Option<ReviewTarget>,
+    #[serde(default)]
+    pub review_profiles: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReviewTarget {
+    #[serde(default)]
+    pub tasks: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PlanDoc {
+    #[serde(default)]
+    tasks: Vec<PlanTask>,
+}
+
+/// Load PLAN.yaml and return tasks indexed by id. Missing plan file is an
+/// error (planned reviews require a plan to exist).
+pub fn load_tasks(plan_path: &Path) -> Result<BTreeMap<String, PlanTask>, CliError> {
+    if !plan_path.is_file() {
+        return Err(CliError::PlanInvalid {
+            message: format!("PLAN.yaml missing at {}", plan_path.display()),
+            hint: Some("Run `codex1 plan scaffold --level <level>` first.".to_string()),
+        });
+    }
+    let raw = std::fs::read_to_string(plan_path)?;
+    let doc: PlanDoc = serde_yaml::from_str(&raw).map_err(|err| CliError::PlanInvalid {
+        message: format!("Failed to parse PLAN.yaml: {err}"),
+        hint: None,
+    })?;
+    let mut out = BTreeMap::new();
+    for task in doc.tasks {
+        out.insert(task.id.clone(), task);
+    }
+    Ok(out)
+}
+
+/// Fetch the review task by id, erroring if missing or not `kind: review`.
+pub fn fetch_review_task(
+    tasks: &BTreeMap<String, PlanTask>,
+    task_id: &str,
+) -> Result<PlanTask, CliError> {
+    let Some(task) = tasks.get(task_id) else {
+        return Err(CliError::PlanInvalid {
+            message: format!("Task {task_id} not found in PLAN.yaml"),
+            hint: None,
+        });
+    };
+    let kind = task.kind.as_deref().unwrap_or("");
+    if kind != "review" {
+        return Err(CliError::PlanInvalid {
+            message: format!("Task {task_id} has kind `{kind}`, not `review`"),
+            hint: Some("Review commands only operate on tasks with `kind: review`.".to_string()),
+        });
+    }
+    Ok(task.clone())
+}
+
+/// Targets declared on the review task. Empty `review_target.tasks` is an
+/// error — a review without targets has nothing to classify.
+pub fn review_targets(task: &PlanTask) -> Result<Vec<String>, CliError> {
+    let targets = task
+        .review_target
+        .as_ref()
+        .map(|t| t.tasks.clone())
+        .unwrap_or_default();
+    if targets.is_empty() {
+        return Err(CliError::PlanInvalid {
+            message: format!("Review task {} has no review_target.tasks", task.id),
+            hint: Some(
+                "Add a `review_target: { tasks: [T…] }` block to the review task.".to_string(),
+            ),
+        });
+    }
+    Ok(targets)
+}

--- a/crates/codex1/src/cli/review/record.rs
+++ b/crates/codex1/src/cli/review/record.rs
@@ -1,0 +1,354 @@
+//! `codex1 review record <id>` — record the outcome of a planned review.
+//!
+//! The main thread pipes reviewer findings through this command. The CLI
+//! classifies the record (`accepted_current | late_same_boundary |
+//! stale_superseded | contaminated_after_terminal`) and mutates state
+//! accordingly. See `docs/cli-contract-schemas.md` § Review record
+//! freshness.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::cli::review::classify::{category_str, classify, verdict_str, ClassifyInput};
+use crate::cli::review::plan_read::{fetch_review_task, load_tasks, review_targets};
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::core::paths::MissionPaths;
+use crate::state::fs_atomic::atomic_write;
+use crate::state::schema::{
+    MissionState, ReviewRecord, ReviewRecordCategory, ReviewVerdict, TaskStatus,
+};
+use crate::state::{self};
+
+/// Threshold at which consecutive dirty reviews trigger a replan.
+const DIRTY_STREAK_THRESHOLD: u32 = 6;
+
+pub struct RecordInputs<'a> {
+    pub task_id: &'a str,
+    pub clean: bool,
+    pub findings_file: Option<PathBuf>,
+    pub reviewers_csv: Option<String>,
+}
+
+pub fn run(ctx: &Ctx, inputs: &RecordInputs<'_>) -> CliResult<()> {
+    if inputs.clean == inputs.findings_file.is_some() {
+        // Either both supplied or neither — clap's `conflicts_with`/`required`
+        // should already reject this, but fail closed if we ever get here.
+        return Err(CliError::ParseError {
+            message: "review record requires exactly one of --clean or --findings-file".to_string(),
+        });
+    }
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let plan_tasks = load_tasks(&paths.plan())?;
+    let review_task = fetch_review_task(&plan_tasks, inputs.task_id)?;
+    let targets = review_targets(&review_task)?;
+
+    // Parse reviewers early so dry-run + wet run share the same vec.
+    let reviewers = parse_reviewers(inputs.reviewers_csv.as_deref());
+
+    let findings_path = inputs.findings_file.as_deref();
+    if let Some(p) = findings_path {
+        if !p.is_file() {
+            return Err(CliError::ReviewFindingsBlock {
+                message: format!("findings file not found: {}", p.display()),
+            });
+        }
+    }
+
+    let verdict = if inputs.clean {
+        ReviewVerdict::Clean
+    } else {
+        ReviewVerdict::Dirty
+    };
+
+    // Peek at state for dry-run (and to surface terminal/stale errors before
+    // we enter the mutation closure in the wet path).
+    let peek = state::load(&paths)?;
+    let peek_category = classify(&ClassifyInput {
+        state: &peek,
+        review_task_id: inputs.task_id,
+        target_task_ids: &targets,
+        // In peek-mode we just want the pre-mutate revision; classification
+        // thresholds use the closure's pre-bump revision too.
+        state_revision_at_record: peek.revision,
+    });
+
+    if matches!(
+        peek_category,
+        ReviewRecordCategory::ContaminatedAfterTerminal
+    ) {
+        let closed_at = peek
+            .close
+            .terminal_at
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+        return Err(CliError::TerminalAlreadyComplete { closed_at });
+    }
+
+    if ctx.dry_run {
+        let stored_findings = findings_path.map(|p| {
+            relative_from_repo(&paths, &paths.review_file_for(inputs.task_id))
+                .or_else(|| Some(p.display().to_string()))
+                .unwrap_or_default()
+        });
+        let env = JsonOk::new(
+            Some(peek.mission_id.clone()),
+            Some(peek.revision),
+            json!({
+                "dry_run": true,
+                "review_task_id": inputs.task_id,
+                "verdict": verdict_str(&verdict),
+                "category": category_str(peek_category),
+                "reviewers": reviewers,
+                "findings_file": stored_findings,
+                "replan_triggered": false,
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    // Stale records: emit `"review.stale"` event (mutation that touches no
+    // truth-bearing fields) and return `STALE_REVIEW_RECORD`.
+    if matches!(peek_category, ReviewRecordCategory::StaleSuperseded) {
+        state::mutate(
+            &paths,
+            ctx.expect_revision,
+            "review.stale",
+            json!({
+                "review_task_id": inputs.task_id,
+                "verdict": verdict_str(&verdict),
+                "reviewers": reviewers,
+                "targets": targets,
+            }),
+            |_state| Ok(()),
+        )?;
+        return Err(CliError::StaleReviewRecord {
+            message: format!(
+                "Review {} or one of its targets is superseded; record not applied",
+                inputs.task_id
+            ),
+        });
+    }
+
+    // If a findings file was provided, copy it into PLANS/<mission>/reviews/<id>.md
+    // BEFORE the state mutation closure so the mutation remains a pure
+    // state update. Idempotent: skip copy if source == destination.
+    let stored_findings_rel = if let Some(src) = findings_path {
+        let dest = paths.review_file_for(inputs.task_id);
+        copy_if_different(src, &dest)?;
+        relative_from_repo(&paths, &dest)
+    } else {
+        None
+    };
+
+    let review_task_id = inputs.task_id.to_string();
+    let targets_for_closure = targets.clone();
+    let reviewers_for_closure = reviewers.clone();
+    let findings_for_closure = stored_findings_rel.clone();
+
+    let event_kind = if matches!(verdict, ReviewVerdict::Clean) {
+        "review.recorded.clean"
+    } else {
+        "review.recorded.dirty"
+    };
+
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        event_kind,
+        json!({
+            "review_task_id": review_task_id,
+            "verdict": verdict_str(&verdict),
+            "reviewers": reviewers_for_closure,
+            "targets": targets_for_closure,
+        }),
+        |state| {
+            apply_record(
+                state,
+                &review_task_id,
+                &targets_for_closure,
+                &verdict,
+                &reviewers_for_closure,
+                findings_for_closure.clone(),
+            )
+        },
+    )?;
+
+    let category = mutation
+        .state
+        .reviews
+        .get(inputs.task_id)
+        .map_or(ReviewRecordCategory::AcceptedCurrent, |r| {
+            r.category.clone()
+        });
+    let replan_triggered = mutation.state.replan.triggered;
+    let warnings = match category {
+        ReviewRecordCategory::LateSameBoundary => {
+            vec!["recorded as late_same_boundary: state advanced since review start".to_string()]
+        }
+        _ => Vec::new(),
+    };
+
+    let env = JsonOk::new(
+        Some(mutation.state.mission_id.clone()),
+        Some(mutation.new_revision),
+        json!({
+            "review_task_id": inputs.task_id,
+            "verdict": verdict_str(&verdict),
+            "category": category_str(category),
+            "reviewers": reviewers,
+            "findings_file": stored_findings_rel,
+            "replan_triggered": replan_triggered,
+            "warnings": warnings,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}
+
+/// Mutate the state inside `state::mutate`. Classification is re-computed
+/// against the fresh state read under the lock (not the peek).
+fn apply_record(
+    state: &mut MissionState,
+    review_task_id: &str,
+    targets: &[String],
+    verdict: &ReviewVerdict,
+    reviewers: &[String],
+    findings_rel: Option<String>,
+) -> Result<(), CliError> {
+    // Re-classify under the lock — the peek may be stale if another writer
+    // mutated between peek and lock acquisition.
+    let category = classify(&ClassifyInput {
+        state,
+        review_task_id,
+        target_task_ids: targets,
+        state_revision_at_record: state.revision,
+    });
+
+    match category {
+        ReviewRecordCategory::ContaminatedAfterTerminal => {
+            // Should already be handled before we entered the closure; fail
+            // closed so we never silently mutate a terminal mission.
+            let closed_at = state
+                .close
+                .terminal_at
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            return Err(CliError::TerminalAlreadyComplete { closed_at });
+        }
+        ReviewRecordCategory::StaleSuperseded => {
+            // Likewise: stale path is handled before the mutation closure.
+            return Err(CliError::StaleReviewRecord {
+                message: format!("Review {review_task_id} or one of its targets is superseded"),
+            });
+        }
+        _ => {}
+    }
+
+    let boundary_revision = state
+        .reviews
+        .get(review_task_id)
+        .map_or(state.revision.saturating_add(1), |r| r.boundary_revision);
+    let recorded_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    let record = ReviewRecord {
+        task_id: review_task_id.to_string(),
+        verdict: verdict.clone(),
+        reviewers: reviewers.to_vec(),
+        findings_file: findings_rel,
+        category: category.clone(),
+        recorded_at,
+        boundary_revision,
+    };
+    state.reviews.insert(review_task_id.to_string(), record);
+
+    // Only accepted_current records affect the dirty counter / target
+    // status. late_same_boundary is still accepted per spec (same active
+    // review, same boundary) but does not mutate truth beyond recording.
+    if matches!(category, ReviewRecordCategory::AcceptedCurrent) {
+        match *verdict {
+            ReviewVerdict::Clean => apply_clean(state, targets),
+            ReviewVerdict::Dirty => apply_dirty(state, targets),
+            ReviewVerdict::Pending => {}
+        }
+    }
+    Ok(())
+}
+
+fn apply_clean(state: &mut MissionState, targets: &[String]) {
+    for tid in targets {
+        if let Some(task) = state.tasks.get_mut(tid) {
+            if matches!(task.status, TaskStatus::AwaitingReview) {
+                task.status = TaskStatus::Complete;
+                if task.finished_at.is_none() {
+                    task.finished_at = Some(
+                        OffsetDateTime::now_utc()
+                            .format(&Rfc3339)
+                            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string()),
+                    );
+                }
+            }
+        }
+        state
+            .replan
+            .consecutive_dirty_by_target
+            .insert(tid.clone(), 0);
+    }
+}
+
+fn apply_dirty(state: &mut MissionState, targets: &[String]) {
+    for tid in targets {
+        let entry = state
+            .replan
+            .consecutive_dirty_by_target
+            .entry(tid.clone())
+            .or_insert(0);
+        *entry = entry.saturating_add(1);
+        if *entry >= DIRTY_STREAK_THRESHOLD {
+            state.replan.triggered = true;
+            state.replan.triggered_reason = Some(format!(
+                "{DIRTY_STREAK_THRESHOLD} consecutive dirty reviews for {tid}"
+            ));
+        }
+    }
+}
+
+fn parse_reviewers(csv: Option<&str>) -> Vec<String> {
+    let Some(raw) = csv else { return Vec::new() };
+    raw.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn copy_if_different(src: &Path, dest: &Path) -> Result<(), CliError> {
+    if paths_equal(src, dest) {
+        return Ok(());
+    }
+    let data = std::fs::read(src)?;
+    atomic_write(dest, &data)?;
+    Ok(())
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    let ra = std::fs::canonicalize(a).ok();
+    let rb = std::fs::canonicalize(b).ok();
+    match (ra, rb) {
+        (Some(ra), Some(rb)) => ra == rb,
+        _ => a == b,
+    }
+}
+
+fn relative_from_repo(paths: &MissionPaths, abs: &Path) -> Option<String> {
+    abs.strip_prefix(&paths.repo_root)
+        .ok()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+}

--- a/crates/codex1/src/cli/review/start.rs
+++ b/crates/codex1/src/cli/review/start.rs
@@ -1,0 +1,118 @@
+//! `codex1 review start <id>` — begin a planned review.
+//!
+//! Preconditions:
+//! - Mission not terminal.
+//! - PLAN.yaml task `<id>` exists and `kind == review`.
+//! - Every target in `review_target.tasks` is `Complete` or `AwaitingReview`.
+//!
+//! Mutation:
+//! - Insert a `Pending` `ReviewRecord` into `state.reviews[<id>]`.
+//! - `boundary_revision` = the post-write revision (`state.revision + 1`
+//!   inside the closure) so that `review record` run immediately after
+//!   `review start` classifies as `accepted_current`.
+//! - Append `review.started` event.
+
+use serde_json::json;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::cli::review::plan_read::{fetch_review_task, load_tasks, review_targets};
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::state::schema::{ReviewRecord, ReviewRecordCategory, ReviewVerdict, TaskStatus};
+use crate::state::{self};
+
+pub fn run(ctx: &Ctx, task_id: &str) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let plan_tasks = load_tasks(&paths.plan())?;
+    let review_task = fetch_review_task(&plan_tasks, task_id)?;
+    let targets = review_targets(&review_task)?;
+
+    let state = state::load(&paths)?;
+    if let Some(closed_at) = state.close.terminal_at.as_ref() {
+        return Err(CliError::TerminalAlreadyComplete {
+            closed_at: closed_at.clone(),
+        });
+    }
+    for tid in &targets {
+        let Some(task) = state.tasks.get(tid) else {
+            return Err(CliError::TaskNotReady {
+                message: format!("Review target {tid} is not tracked in STATE.json"),
+            });
+        };
+        match task.status {
+            TaskStatus::Complete | TaskStatus::AwaitingReview | TaskStatus::Superseded => {}
+            TaskStatus::Pending | TaskStatus::Ready | TaskStatus::InProgress => {
+                return Err(CliError::TaskNotReady {
+                    message: format!(
+                        "Target {tid} is `{:?}`; review start requires Complete or AwaitingReview",
+                        task.status
+                    ),
+                });
+            }
+        }
+    }
+
+    if ctx.dry_run {
+        let env = JsonOk::new(
+            Some(state.mission_id.clone()),
+            Some(state.revision),
+            json!({
+                "dry_run": true,
+                "review_task_id": task_id,
+                "targets": targets,
+                "would": "set state.reviews[<id>] = Pending with boundary_revision",
+            }),
+        );
+        println!("{}", env.to_pretty());
+        return Ok(());
+    }
+
+    let review_task_id = task_id.to_string();
+    let targets_for_event = targets.clone();
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        "review.started",
+        json!({
+            "review_task_id": review_task_id,
+            "targets": targets_for_event,
+        }),
+        |state| {
+            // boundary_revision is the revision the state will take AFTER
+            // this mutation is persisted (closure runs pre-bump, so +1).
+            let boundary_revision = state.revision.saturating_add(1);
+            let recorded_at = OffsetDateTime::now_utc()
+                .format(&Rfc3339)
+                .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+            state.reviews.insert(
+                review_task_id.clone(),
+                ReviewRecord {
+                    task_id: review_task_id.clone(),
+                    verdict: ReviewVerdict::Pending,
+                    reviewers: Vec::new(),
+                    findings_file: None,
+                    category: ReviewRecordCategory::AcceptedCurrent,
+                    recorded_at,
+                    boundary_revision,
+                },
+            );
+            Ok(())
+        },
+    )?;
+
+    let env = JsonOk::new(
+        Some(mutation.state.mission_id.clone()),
+        Some(mutation.new_revision),
+        json!({
+            "review_task_id": task_id,
+            "verdict": "pending",
+            "targets": targets,
+            "boundary_revision": mutation.new_revision,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/review/status_cmd.rs
+++ b/crates/codex1/src/cli/review/status_cmd.rs
@@ -1,0 +1,64 @@
+//! `codex1 review status <id>` — read-only review record projection.
+//!
+//! Returns the current record if any, plus target states and dirty-streak
+//! counters for the main thread to surface in the unified `status` view.
+
+use serde_json::{json, Value};
+
+use crate::cli::review::classify::{category_str, verdict_str};
+use crate::cli::review::plan_read::{fetch_review_task, load_tasks, review_targets};
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::CliResult;
+use crate::core::mission::resolve_mission;
+use crate::state::{self};
+
+pub fn run(ctx: &Ctx, task_id: &str) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let plan_tasks = load_tasks(&paths.plan())?;
+    let review_task = fetch_review_task(&plan_tasks, task_id)?;
+    let targets = review_targets(&review_task)?;
+
+    let record_value = state.reviews.get(task_id).map_or(Value::Null, |r| {
+        json!({
+            "verdict": verdict_str(&r.verdict),
+            "reviewers": r.reviewers,
+            "findings_file": r.findings_file,
+            "category": category_str(r.category.clone()),
+            "recorded_at": r.recorded_at,
+            "boundary_revision": r.boundary_revision,
+        })
+    });
+
+    let target_states: Vec<Value> = targets
+        .iter()
+        .map(|tid| {
+            let status = state.tasks.get(tid).map(|t| format!("{:?}", t.status));
+            let streak = state
+                .replan
+                .consecutive_dirty_by_target
+                .get(tid)
+                .copied()
+                .unwrap_or(0);
+            json!({
+                "task_id": tid,
+                "status": status,
+                "consecutive_dirty": streak,
+            })
+        })
+        .collect();
+
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        json!({
+            "review_task_id": task_id,
+            "record": record_value,
+            "targets": target_states,
+            "replan_triggered": state.replan.triggered,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/tests/review.rs
+++ b/crates/codex1/tests/review.rs
@@ -1,0 +1,623 @@
+//! Integration tests for the `codex1 review` lifecycle.
+//!
+//! Seeds a small mission (T1..T4 work, T5 review targeting [T2,T3]) by
+//! writing STATE.json and PLAN.yaml directly under a TempDir. Drives the
+//! CLI through `assert_cmd` to exercise the public contract.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+const MISSION: &str = "demo";
+
+struct Seeded {
+    tmp: TempDir,
+    mission_dir: PathBuf,
+}
+
+impl Seeded {
+    fn new() -> Self {
+        Self::with_targets(&["T2", "T3"])
+    }
+
+    /// Seed a mission with:
+    /// - T1 work (Complete)
+    /// - each target in `targets` as AwaitingReview
+    /// - T5 review targeting those targets
+    fn with_targets(targets: &[&str]) -> Self {
+        let tmp = TempDir::new().unwrap();
+        cmd()
+            .current_dir(tmp.path())
+            .args(["init", "--mission", MISSION])
+            .assert()
+            .success();
+        let mission_dir = tmp.path().join("PLANS").join(MISSION);
+        write_plan(&mission_dir, targets);
+        set_targets_awaiting(&mission_dir, targets);
+        write_specs(&mission_dir, targets);
+        Self { tmp, mission_dir }
+    }
+
+    fn path(&self) -> &Path {
+        self.tmp.path()
+    }
+
+    fn review_file(&self) -> PathBuf {
+        self.mission_dir.join("reviews").join("T5.md")
+    }
+}
+
+fn write_plan(mission_dir: &Path, targets: &[&str]) {
+    use std::fmt::Write;
+    let mut tasks = String::new();
+    // T1 is a root work task already complete in the seeded state below.
+    tasks.push_str(
+        "  - id: T1\n    title: Root\n    kind: code\n    depends_on: []\n    spec: specs/T1/SPEC.md\n",
+    );
+    for t in targets {
+        let _ = write!(
+            tasks,
+            "  - id: {t}\n    title: Work {t}\n    kind: code\n    depends_on: [T1]\n    spec: specs/{t}/SPEC.md\n    write_paths:\n      - src/{t}/**\n",
+        );
+    }
+    tasks.push_str("  - id: T4\n    title: Later\n    kind: code\n    depends_on: [T1]\n    spec: specs/T4/SPEC.md\n");
+    let target_list = targets
+        .iter()
+        .map(|t| (*t).to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let review_deps = targets
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let plan = format!(
+        r"mission_id: {MISSION}
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: 'test'
+
+architecture:
+  summary: 'test'
+  key_decisions: []
+
+planning_process:
+  evidence: []
+
+tasks:
+{tasks}  - id: T5
+    title: Review wave
+    kind: review
+    depends_on: [{review_deps}]
+    spec: specs/T5/SPEC.md
+    review_target:
+      tasks: [{target_list}]
+    review_profiles:
+      - code_bug_correctness
+      - local_spec_intent
+
+risks: []
+
+mission_close:
+  criteria: []
+"
+    );
+    fs::write(mission_dir.join("PLAN.yaml"), plan).unwrap();
+}
+
+fn write_specs(mission_dir: &Path, targets: &[&str]) {
+    let specs_dir = mission_dir.join("specs");
+    for tid in std::iter::once("T1")
+        .chain(targets.iter().copied())
+        .chain(["T4", "T5"])
+    {
+        let dir = specs_dir.join(tid);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("SPEC.md"),
+            format!("# Spec for {tid}\n\nDo the thing.\n"),
+        )
+        .unwrap();
+        // Only targets get a PROOF.md (they're "done").
+        if targets.contains(&tid) {
+            fs::write(
+                dir.join("PROOF.md"),
+                format!("# Proof for {tid}\n\ncargo test passed.\n"),
+            )
+            .unwrap();
+        }
+    }
+}
+
+/// Mutate STATE.json in place: mark T1 Complete and each target as AwaitingReview.
+fn set_targets_awaiting(mission_dir: &Path, targets: &[&str]) {
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    let tasks = state["tasks"].as_object_mut().unwrap();
+    tasks.insert(
+        "T1".into(),
+        serde_json::json!({
+            "id": "T1",
+            "status": "complete",
+            "started_at": "2026-04-20T00:00:00Z",
+            "finished_at": "2026-04-20T00:00:01Z",
+            "superseded_by": null,
+        }),
+    );
+    for t in targets {
+        tasks.insert(
+            (*t).into(),
+            serde_json::json!({
+                "id": *t,
+                "status": "awaiting_review",
+                "started_at": "2026-04-20T00:00:00Z",
+                "finished_at": "2026-04-20T00:00:01Z",
+                "superseded_by": null,
+            }),
+        );
+    }
+    // Also mark outcome ratified + plan locked so status is cleaner in the tests.
+    state["outcome"] =
+        serde_json::json!({ "ratified": true, "ratified_at": "2026-04-20T00:00:00Z" });
+    state["plan"]["locked"] = Value::Bool(true);
+    state["phase"] = Value::String("execute".into());
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+fn parse_stdout(output: &std::process::Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(stdout)
+        .unwrap_or_else(|e| panic!("expected JSON stdout, got:\n{stdout}\nerror: {e}"))
+}
+
+fn run_ok(tmp: &Path, args: &[&str]) -> Value {
+    let output = cmd().current_dir(tmp).args(args).output().expect("runs");
+    assert!(
+        output.status.success(),
+        "expected success, got:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    parse_stdout(&output)
+}
+
+fn run_err(tmp: &Path, args: &[&str]) -> Value {
+    let output = cmd().current_dir(tmp).args(args).output().expect("runs");
+    assert!(
+        !output.status.success(),
+        "expected failure:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    parse_stdout(&output)
+}
+
+fn set_task_status(mission_dir: &Path, task_id: &str, status: &str) {
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    let task = state["tasks"]
+        .as_object_mut()
+        .unwrap()
+        .entry(task_id.to_string())
+        .or_insert_with(|| {
+            serde_json::json!({
+                "id": task_id,
+                "status": "pending",
+                "superseded_by": null,
+            })
+        });
+    task["status"] = Value::String(status.into());
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+fn bump_revision_without_mutation(mission_dir: &Path) {
+    // Simulate a concurrent mutation so the next record classifies as
+    // late_same_boundary. Incrementing the revision is the minimum that
+    // the classifier keys off.
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    let rev = state["revision"].as_u64().unwrap();
+    state["revision"] = serde_json::json!(rev + 1);
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+fn set_terminal(mission_dir: &Path) {
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    state["close"] = serde_json::json!({
+        "review_state": "passed",
+        "terminal_at": "2026-04-20T00:00:00Z",
+    });
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+fn set_target_superseded(mission_dir: &Path, task_id: &str) {
+    let state_path = mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    let tasks = state["tasks"].as_object_mut().unwrap();
+    let task = tasks.get_mut(task_id).unwrap();
+    task["status"] = Value::String("superseded".into());
+    task["superseded_by"] = Value::String("T99".into());
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+#[test]
+fn t1_start_before_targets_finished_returns_task_not_ready() {
+    let s = Seeded::new();
+    set_task_status(&s.mission_dir, "T2", "in_progress");
+    let err = run_err(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    assert_eq!(err["code"], "TASK_NOT_READY");
+}
+
+#[test]
+fn t2_start_records_pending_and_event() {
+    let s = Seeded::new();
+    let ok = run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    assert_eq!(ok["ok"], Value::Bool(true));
+    assert_eq!(ok["data"]["review_task_id"], "T5");
+    assert_eq!(ok["data"]["verdict"], "pending");
+
+    // Record appears in STATE.
+    let state: Value =
+        serde_json::from_str(&fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["reviews"]["T5"]["verdict"], "pending");
+
+    // Event is in EVENTS.jsonl.
+    let events = fs::read_to_string(s.mission_dir.join("EVENTS.jsonl")).unwrap();
+    assert!(events.contains("review.started"), "events: {events}");
+}
+
+#[test]
+fn t3_record_clean_transitions_targets_and_resets_streak() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    // Seed a prior dirty streak so we can confirm the reset.
+    let state_path = s.mission_dir.join("STATE.json");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    state["replan"]["consecutive_dirty_by_target"] = serde_json::json!({ "T2": 2, "T3": 1 });
+    fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let ok = run_ok(
+        s.path(),
+        &[
+            "review",
+            "record",
+            "T5",
+            "--clean",
+            "--reviewers",
+            "a,b",
+            "--mission",
+            MISSION,
+        ],
+    );
+    assert_eq!(ok["data"]["verdict"], "clean");
+    assert_eq!(ok["data"]["category"], "accepted_current");
+    assert_eq!(ok["data"]["replan_triggered"], false);
+    let reviewers = ok["data"]["reviewers"].as_array().unwrap();
+    assert_eq!(reviewers.len(), 2);
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    assert_eq!(state["tasks"]["T2"]["status"], "complete");
+    assert_eq!(state["tasks"]["T3"]["status"], "complete");
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"]["T2"], 0);
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"]["T3"], 0);
+}
+
+#[test]
+fn t4_record_findings_increments_dirty_and_copies_file() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+
+    let findings_src = s.path().join("findings.md");
+    fs::write(&findings_src, "# Findings\n- P1: something is off.\n").unwrap();
+
+    let ok = run_ok(
+        s.path(),
+        &[
+            "review",
+            "record",
+            "T5",
+            "--findings-file",
+            findings_src.to_str().unwrap(),
+            "--mission",
+            MISSION,
+        ],
+    );
+    assert_eq!(ok["data"]["verdict"], "dirty");
+    assert_eq!(ok["data"]["category"], "accepted_current");
+
+    let state: Value =
+        serde_json::from_str(&fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"]["T2"], 1);
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"]["T3"], 1);
+
+    // File was copied to reviews/T5.md.
+    let stored = s.review_file();
+    assert!(stored.is_file(), "expected {} to exist", stored.display());
+    assert!(fs::read_to_string(&stored)
+        .unwrap()
+        .contains("P1: something"));
+    // Source is untouched.
+    assert!(findings_src.is_file());
+}
+
+#[test]
+fn t5_six_dirty_triggers_replan() {
+    let s = Seeded::with_targets(&["T2"]);
+    let findings_src = s.path().join("findings.md");
+    fs::write(&findings_src, "# F\n- P0: bug\n").unwrap();
+
+    for i in 0..6 {
+        // Reset T2 to AwaitingReview so `review start` accepts it each round.
+        set_task_status(&s.mission_dir, "T2", "awaiting_review");
+        run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+        let ok = run_ok(
+            s.path(),
+            &[
+                "review",
+                "record",
+                "T5",
+                "--findings-file",
+                findings_src.to_str().unwrap(),
+                "--mission",
+                MISSION,
+            ],
+        );
+        let triggered = ok["data"]["replan_triggered"].as_bool().unwrap_or(false);
+        if i < 5 {
+            assert!(!triggered, "round {i}: should not trigger yet");
+        } else {
+            assert!(triggered, "round {i}: should trigger after 6th");
+        }
+    }
+    let state: Value =
+        serde_json::from_str(&fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["replan"]["triggered"], true);
+    assert!(state["replan"]["triggered_reason"]
+        .as_str()
+        .unwrap()
+        .contains("T2"));
+}
+
+#[test]
+fn t6_clean_interrupts_dirty_streak() {
+    let s = Seeded::with_targets(&["T2"]);
+    let findings_src = s.path().join("findings.md");
+    fs::write(&findings_src, "# F\n- P0: x\n").unwrap();
+
+    for _ in 0..3 {
+        set_task_status(&s.mission_dir, "T2", "awaiting_review");
+        run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+        run_ok(
+            s.path(),
+            &[
+                "review",
+                "record",
+                "T5",
+                "--findings-file",
+                findings_src.to_str().unwrap(),
+                "--mission",
+                MISSION,
+            ],
+        );
+    }
+    let state: Value =
+        serde_json::from_str(&fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"]["T2"], 3);
+
+    // Clean reset.
+    set_task_status(&s.mission_dir, "T2", "awaiting_review");
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    run_ok(
+        s.path(),
+        &["review", "record", "T5", "--clean", "--mission", MISSION],
+    );
+    let state: Value =
+        serde_json::from_str(&fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"]["T2"], 0);
+    assert_eq!(state["replan"]["triggered"], false);
+}
+
+#[test]
+fn t7_clap_rejects_conflicting_clean_and_findings() {
+    let s = Seeded::new();
+    let output = cmd()
+        .current_dir(s.path())
+        .args([
+            "review",
+            "record",
+            "T5",
+            "--clean",
+            "--findings-file",
+            "x.md",
+            "--mission",
+            MISSION,
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflict"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn t8_clap_rejects_neither_clean_nor_findings() {
+    let s = Seeded::new();
+    let output = cmd()
+        .current_dir(s.path())
+        .args(["review", "record", "T5", "--mission", MISSION])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("required") || stderr.contains("error:"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn t9_stale_superseded_returns_stale_review_record() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    // Supersede one target.
+    set_target_superseded(&s.mission_dir, "T2");
+    let err = run_err(
+        s.path(),
+        &["review", "record", "T5", "--clean", "--mission", MISSION],
+    );
+    assert_eq!(err["code"], "STALE_REVIEW_RECORD");
+    // Event should be appended.
+    let events = fs::read_to_string(s.mission_dir.join("EVENTS.jsonl")).unwrap();
+    assert!(events.contains("review.stale"), "events: {events}");
+    // State truth must not reflect clean: record stays Pending.
+    let state: Value =
+        serde_json::from_str(&fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["reviews"]["T5"]["verdict"], "pending");
+}
+
+#[test]
+fn t10_terminal_already_complete_refused() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    set_terminal(&s.mission_dir);
+    let err = run_err(
+        s.path(),
+        &["review", "record", "T5", "--clean", "--mission", MISSION],
+    );
+    assert_eq!(err["code"], "TERMINAL_ALREADY_COMPLETE");
+}
+
+#[test]
+fn t11_dry_run_preserves_state() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    let before = fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap();
+    let events_before = fs::read_to_string(s.mission_dir.join("EVENTS.jsonl")).unwrap();
+
+    let ok = run_ok(
+        s.path(),
+        &[
+            "review",
+            "record",
+            "T5",
+            "--clean",
+            "--dry-run",
+            "--mission",
+            MISSION,
+        ],
+    );
+    assert_eq!(ok["data"]["dry_run"], true);
+    let after = fs::read_to_string(s.mission_dir.join("STATE.json")).unwrap();
+    let events_after = fs::read_to_string(s.mission_dir.join("EVENTS.jsonl")).unwrap();
+    assert_eq!(before, after, "state must not change on dry run");
+    assert_eq!(events_before, events_after, "events must not change");
+}
+
+#[test]
+fn t12_expect_revision_mismatch_returns_conflict() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    let err = run_err(
+        s.path(),
+        &[
+            "review",
+            "record",
+            "T5",
+            "--clean",
+            "--expect-revision",
+            "999",
+            "--mission",
+            MISSION,
+        ],
+    );
+    assert_eq!(err["code"], "REVISION_CONFLICT");
+    assert_eq!(err["retryable"], true);
+}
+
+#[test]
+fn t13_status_after_record_returns_record() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    run_ok(
+        s.path(),
+        &[
+            "review",
+            "record",
+            "T5",
+            "--clean",
+            "--reviewers",
+            "code-reviewer",
+            "--mission",
+            MISSION,
+        ],
+    );
+    let ok = run_ok(s.path(), &["review", "status", "T5", "--mission", MISSION]);
+    assert_eq!(ok["data"]["review_task_id"], "T5");
+    assert_eq!(ok["data"]["record"]["verdict"], "clean");
+    assert_eq!(ok["data"]["record"]["category"], "accepted_current");
+    assert_eq!(ok["data"]["record"]["reviewers"][0], "code-reviewer");
+    let targets = ok["data"]["targets"].as_array().unwrap();
+    assert_eq!(targets.len(), 2);
+}
+
+#[test]
+fn t14_packet_includes_reviewer_instructions() {
+    let s = Seeded::new();
+    let ok = run_ok(s.path(), &["review", "packet", "T5", "--mission", MISSION]);
+    assert_eq!(ok["data"]["task_id"], "T5");
+    let instructions = ok["data"]["reviewer_instructions"].as_str().unwrap();
+    assert!(
+        instructions.contains("Do not edit files"),
+        "instructions: {instructions}"
+    );
+    assert!(instructions.contains("NONE or P0/P1/P2"));
+    let profiles = ok["data"]["profiles"].as_array().unwrap();
+    assert_eq!(profiles.len(), 2);
+    let diffs = ok["data"]["diffs"].as_array().unwrap();
+    // T2 + T3 each have one write_path → 2 entries total.
+    assert_eq!(diffs.len(), 2);
+    let targets = ok["data"]["targets"].as_array().unwrap();
+    assert_eq!(targets.len(), 2);
+}
+
+#[test]
+fn late_same_boundary_is_flagged() {
+    let s = Seeded::new();
+    run_ok(s.path(), &["review", "start", "T5", "--mission", MISSION]);
+    // Simulate another mutation advancing the revision.
+    bump_revision_without_mutation(&s.mission_dir);
+    let ok = run_ok(
+        s.path(),
+        &["review", "record", "T5", "--clean", "--mission", MISSION],
+    );
+    assert_eq!(ok["data"]["category"], "late_same_boundary");
+    let warnings = ok["data"]["warnings"].as_array().unwrap();
+    assert!(!warnings.is_empty(), "expected late warning");
+}
+
+#[test]
+fn status_without_start_returns_null_record() {
+    let s = Seeded::new();
+    let ok = run_ok(s.path(), &["review", "status", "T5", "--mission", MISSION]);
+    assert_eq!(ok["data"]["record"], Value::Null);
+}


### PR DESCRIPTION
## Summary

- Implements `codex1 review start|packet|record|status` (Phase B Unit 7). Start opens a Pending record with a post-write `boundary_revision`; packet emits the reviewer-subagent packet with the standing findings-only instructions literal; record classifies freshness and only mutates truth for `accepted_current` records; status is read-only.
- Dirty `accepted_current` records bump `state.replan.consecutive_dirty_by_target[<target>]` and trip `state.replan.triggered` at 6. Clean `accepted_current` records reset the per-target counter and transition `AwaitingReview` targets to `Complete`. `late_same_boundary` is flagged with a warning but still recorded. `stale_superseded` appends `"review.stale"` and returns `STALE_REVIEW_RECORD`. Terminal missions return `TERMINAL_ALREADY_COMPLETE`.
- Findings files are copied into `PLANS/<mission>/reviews/<id>.md` (source left alone; idempotent when source == dest).

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test` — 29/29 pass (13 foundation + 16 review).
- [x] Start refuses when targets are Pending/Ready/InProgress (TASK_NOT_READY).
- [x] Start records Pending + `review.started` event.
- [x] Record --clean moves AwaitingReview targets to Complete and zeroes the streak.
- [x] Record --findings-file increments streak; file copied to `reviews/<id>.md`.
- [x] 6 consecutive dirty for the same target sets `replan.triggered = true`.
- [x] One clean interrupts a dirty streak and resets the counter.
- [x] clap rejects `--clean --findings-file` together and rejects neither flag.
- [x] Superseded target returns `STALE_REVIEW_RECORD` and appends `review.stale`.
- [x] Terminal mission returns `TERMINAL_ALREADY_COMPLETE`.
- [x] `--dry-run` preserves STATE.json and EVENTS.jsonl.
- [x] `--expect-revision 999` returns retryable `REVISION_CONFLICT`.
- [x] `review status` returns the record after record; null before start.
- [x] `review packet` includes the reviewer instructions literal and the target write_paths as diffs.
- [x] `review record` after state advanced post-start classifies as `late_same_boundary`.

Quality bar: obeys DO-NOT-TOUCH (Cargo, src/bin, lib, cli/mod, init, doctor, hook, core, state, Makefile, cli-contract-schemas), no caller-identity checks, no `.ralph/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)