### PR TITLE
Unit 11: cli-status unified projection

### DIFF
--- a/crates/codex1/src/cli/status/mod.rs
+++ b/crates/codex1/src/cli/status/mod.rs
@@ -1,9 +1,14 @@
-//! `codex1 status` stub — owned by Phase B Unit 11.
+//! `codex1 status --json` — the unified mission projection.
 //!
-//! Foundation emits a minimal status envelope so Ralph can rely on the
-//! command existing from day one. Phase B replaces this with the
-//! full unified projection and shares the readiness helper in
-//! `state::readiness`.
+//! Owned by Phase B Unit 11. `status` and `close check` share the
+//! `state::readiness` helpers (`derive_verdict`, `close_ready`,
+//! `stop_allowed`); those are the single source of truth for any
+//! judgment about mission readiness. This module never re-derives a
+//! verdict — it only projects state and PLAN.yaml tasks into the
+//! published shape.
+
+mod next_action;
+mod project;
 
 use serde_json::json;
 
@@ -11,63 +16,36 @@ use crate::cli::Ctx;
 use crate::core::envelope::JsonOk;
 use crate::core::error::{CliError, CliResult};
 use crate::core::mission::resolve_mission;
-use crate::state::{self, readiness};
+use crate::state;
 
 pub fn run(ctx: &Ctx) -> CliResult<()> {
-    // If a mission can be resolved, emit a minimal but truthful projection
-    // based on the current state. Phase B broadens this into the full
-    // unified status shape; the `verdict` and `stop.allow` fields are
-    // already derived from the shared readiness helper, so the Ralph
-    // contract is honored from Foundation onward.
     match resolve_mission(&ctx.selector(), true) {
         Ok(paths) => {
             let state = state::load(&paths)?;
-            let verdict = readiness::derive_verdict(&state);
-            let stop_allow = readiness::stop_allowed(&state);
-            let env = JsonOk::new(
-                Some(state.mission_id.clone()),
-                Some(state.revision),
-                json!({
-                    "phase": state.phase,
-                    "verdict": verdict.as_str(),
-                    "loop": state.loop_,
-                    "close_ready": readiness::close_ready(&state),
-                    "stop": {
-                        "allow": stop_allow,
-                        "reason": if stop_allow { "idle" } else { "active_loop" },
-                        "message": if stop_allow {
-                            "Stop is allowed."
-                        } else {
-                            "Active loop in progress. Run $close to pause."
-                        },
-                    },
-                    "foundation_only": true,
-                    "note": "Phase B Unit 11 replaces this projection with the full unified status view."
-                }),
-            );
+            let tasks = next_action::load_plan_tasks(&paths).unwrap_or_default();
+            let data = project::build(&state, &tasks);
+            let env = JsonOk::new(Some(state.mission_id.clone()), Some(state.revision), data);
             println!("{}", env.to_pretty());
             Ok(())
         }
         Err(err @ CliError::MissionNotFound { .. }) => {
-            // If the caller explicitly passed --mission <id>, an unresolved
-            // mission is an error. If they did not, auto-discovery failing
-            // is a normal "nothing in progress" state — emit a graceful
-            // stop-allowed projection so Ralph never blocks the shell.
+            // Explicit --mission <id> that doesn't resolve → error.
+            // Bare `codex1 status` with nothing found → graceful "no
+            // mission" projection so Ralph never blocks the shell.
             if ctx.mission.is_some() {
-                Err(err)
-            } else {
-                let env = JsonOk::global(json!({
-                    "verdict": "needs_user",
-                    "stop": {
-                        "allow": true,
-                        "reason": "no_mission",
-                        "message": "No mission resolved; Stop is allowed."
-                    },
-                    "foundation_only": true,
-                }));
-                println!("{}", env.to_pretty());
-                Ok(())
+                return Err(err);
             }
+            let env = JsonOk::global(json!({
+                "verdict": "needs_user",
+                "stop": {
+                    "allow": true,
+                    "reason": "no_mission",
+                    "message": "No mission resolved; stop is allowed.",
+                },
+                "foundation_only": false,
+            }));
+            println!("{}", env.to_pretty());
+            Ok(())
         }
         Err(other) => Err(other),
     }

--- a/crates/codex1/src/cli/status/next_action.rs
+++ b/crates/codex1/src/cli/status/next_action.rs
@@ -1,0 +1,241 @@
+//! Minimal wave derivation for `codex1 status`.
+//!
+//! Parses the PLAN.yaml tasks table just enough to determine the next
+//! ready wave (and the next review task within it). Intentionally
+//! local to `status` so this unit can ship without depending on the
+//! full `plan waves` implementation.
+//!
+//! When PLAN.yaml is missing or unparseable, returns `Ok(None)` from
+//! `load_plan_tasks` so the status projection can degrade gracefully.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::core::paths::MissionPaths;
+use crate::state::schema::{MissionState, TaskStatus};
+
+/// Light task shape extracted from PLAN.yaml. Only the fields needed
+/// for wave / review-target derivation are parsed; unknown keys are
+/// tolerated so the full PLAN.yaml schema can evolve without breaking
+/// `status`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanTask {
+    pub id: String,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub review_target: Option<ReviewTarget>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ReviewTarget {
+    #[serde(default)]
+    pub tasks: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct PlanEnvelope {
+    #[serde(default)]
+    tasks: Vec<PlanTask>,
+}
+
+/// Load tasks from PLAN.yaml. Returns `Ok(None)` when the file is
+/// absent or unparseable (status must still emit a sane envelope in
+/// those cases — downstream derivation treats missing plan data as
+/// "no wave known").
+pub fn load_plan_tasks(paths: &MissionPaths) -> Option<Vec<PlanTask>> {
+    read_plan(&paths.plan())
+}
+
+fn read_plan(path: &Path) -> Option<Vec<PlanTask>> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let env: PlanEnvelope = serde_yaml::from_str(&raw).ok()?;
+    Some(env.tasks)
+}
+
+/// Result of next-wave derivation.
+#[derive(Debug, Clone)]
+pub struct ReadyWave {
+    pub wave_id: String,
+    pub tasks: Vec<PlanTask>,
+}
+
+/// Derive the next ready wave. A task is "ready" when:
+/// - every `depends_on` is complete or superseded in STATE.json, and
+/// - the task's own status is not Complete/Superseded/InProgress.
+///
+/// Waves are numbered by topological depth from the root; the first
+/// wave that contains at least one ready task is returned.
+pub fn next_ready_wave(tasks: &[PlanTask], state: &MissionState) -> Option<ReadyWave> {
+    if tasks.is_empty() {
+        return None;
+    }
+    let depth = topological_depth(tasks)?;
+    let mut waves: BTreeMap<u32, Vec<PlanTask>> = BTreeMap::new();
+    for task in tasks {
+        if let Some(d) = depth.get(&task.id) {
+            waves.entry(*d).or_default().push(task.clone());
+        }
+    }
+    for (idx, (_, tasks_in_wave)) in waves.iter().enumerate() {
+        let ready: Vec<PlanTask> = tasks_in_wave
+            .iter()
+            .filter(|t| task_is_ready(t, state))
+            .cloned()
+            .collect();
+        if !ready.is_empty() {
+            return Some(ReadyWave {
+                wave_id: format!("W{}", idx + 1),
+                tasks: ready,
+            });
+        }
+    }
+    None
+}
+
+/// Review-kind tasks whose dependencies are satisfied (so the review
+/// could fire now). Returns `(review_task_id, target_task_ids)` tuples.
+pub fn ready_reviews(tasks: &[PlanTask], state: &MissionState) -> Vec<(String, Vec<String>)> {
+    tasks
+        .iter()
+        .filter(|t| is_review_kind(t) && task_is_ready(t, state))
+        .map(|t| (t.id.clone(), review_targets(t)))
+        .collect()
+}
+
+/// Extract `review_target.tasks` (cloned), falling back to an empty
+/// list when the task is a review kind without explicit targets.
+fn review_targets(t: &PlanTask) -> Vec<String> {
+    t.review_target
+        .as_ref()
+        .map_or_else(Vec::new, |r| r.tasks.clone())
+}
+
+/// Map reviews with a Dirty verdict to the list of target task ids
+/// that still need repair. Relies on PLAN.yaml `review_target.tasks`
+/// to resolve which executable tasks belong to a dirty review record.
+pub fn dirty_repair_targets(tasks: &[PlanTask], state: &MissionState) -> Vec<String> {
+    let mut targets: BTreeSet<String> = BTreeSet::new();
+    for (review_task_id, review_record) in &state.reviews {
+        if !matches!(
+            review_record.verdict,
+            crate::state::schema::ReviewVerdict::Dirty
+        ) {
+            continue;
+        }
+        // Resolve targets from PLAN.yaml. If no explicit targets,
+        // fall back to the task's depends_on list (reviews are planned
+        // immediately after their target tasks).
+        let plan_task = tasks.iter().find(|t| &t.id == review_task_id);
+        if let Some(t) = plan_task {
+            let explicit = t
+                .review_target
+                .as_ref()
+                .map_or(&[][..], |r| r.tasks.as_slice());
+            if explicit.is_empty() {
+                for id in &t.depends_on {
+                    targets.insert(id.clone());
+                }
+            } else {
+                for id in explicit {
+                    targets.insert(id.clone());
+                }
+            }
+        }
+    }
+    targets.into_iter().collect()
+}
+
+fn is_review_kind(t: &PlanTask) -> bool {
+    matches!(t.kind.as_deref(), Some("review"))
+}
+
+/// True when all `depends_on` entries are complete/superseded AND the
+/// task itself is not already finished or actively being worked.
+fn task_is_ready(task: &PlanTask, state: &MissionState) -> bool {
+    let deps_ok = task.depends_on.iter().all(|dep| {
+        state
+            .tasks
+            .get(dep)
+            .is_some_and(|r| matches!(r.status, TaskStatus::Complete | TaskStatus::Superseded))
+    });
+    if !deps_ok {
+        return false;
+    }
+    match state.tasks.get(&task.id).map(|r| &r.status) {
+        Some(TaskStatus::Complete | TaskStatus::Superseded | TaskStatus::InProgress) => false,
+        // Pending, Ready, AwaitingReview, or absent-from-state all count
+        // as "work left to do" once dependencies are satisfied.
+        _ => true,
+    }
+}
+
+/// Compute topological depth for every task. Returns None on cycle or
+/// missing dependency (plan check owns those error codes; here we
+/// just degrade to "no wave derivable").
+fn topological_depth(tasks: &[PlanTask]) -> Option<BTreeMap<String, u32>> {
+    let ids: BTreeSet<&str> = tasks.iter().map(|t| t.id.as_str()).collect();
+    for task in tasks {
+        for dep in &task.depends_on {
+            if !ids.contains(dep.as_str()) {
+                return None;
+            }
+        }
+    }
+
+    let mut depth: BTreeMap<String, u32> = BTreeMap::new();
+
+    for root in tasks.iter().filter(|t| t.depends_on.is_empty()) {
+        depth.insert(root.id.clone(), 0);
+    }
+    if depth.is_empty() {
+        return None; // cycle or dependency-only graph
+    }
+
+    // Fixed-point relaxation; O(V*E) is fine for the small DAGs we see.
+    let max_iters = tasks.len() * tasks.len() + 1;
+    let mut iters = 0;
+    loop {
+        let mut changed = false;
+        for task in tasks {
+            if task.depends_on.is_empty() {
+                continue;
+            }
+            let mut parent_depth = 0u32;
+            let mut all_known = true;
+            for dep in &task.depends_on {
+                if let Some(d) = depth.get(dep) {
+                    parent_depth = parent_depth.max(*d);
+                } else {
+                    all_known = false;
+                    break;
+                }
+            }
+            if !all_known {
+                continue;
+            }
+            let new_depth = parent_depth + 1;
+            let entry = depth.entry(task.id.clone()).or_insert(u32::MAX);
+            if *entry == u32::MAX || *entry < new_depth {
+                *entry = new_depth;
+                changed = true;
+            }
+        }
+        iters += 1;
+        if !changed {
+            break;
+        }
+        if iters > max_iters {
+            return None; // cycle guard
+        }
+    }
+
+    if depth.len() != tasks.len() {
+        return None;
+    }
+    Some(depth)
+}

--- a/crates/codex1/src/cli/status/project.rs
+++ b/crates/codex1/src/cli/status/project.rs
@@ -1,0 +1,210 @@
+//! Build the `codex1 status --json` data projection.
+//!
+//! Pure function from `MissionState` + PLAN.yaml tasks to the JSON
+//! value inside the success envelope's `data` field. `status` and
+//! `close check` share readiness via `state::readiness`; this module
+//! only arranges the already-derived facts into the published shape.
+
+use serde_json::{json, Value};
+
+use crate::state::readiness::{self, Verdict};
+use crate::state::schema::MissionState;
+
+use super::next_action::{
+    dirty_repair_targets, next_ready_wave, ready_reviews, PlanTask, ReadyWave,
+};
+
+/// Build the full `data` body.
+pub fn build(state: &MissionState, tasks: &[PlanTask]) -> Value {
+    let verdict = readiness::derive_verdict(state);
+    let close_ready = readiness::close_ready(state);
+    let stop = stop_projection(state, verdict);
+
+    let wave = next_ready_wave(tasks, state);
+    let reviews_ready = ready_reviews(tasks, state);
+    let repair_targets = dirty_repair_targets(tasks, state);
+
+    let next_action = derive_next_action(
+        state,
+        verdict,
+        wave.as_ref(),
+        &reviews_ready,
+        &repair_targets,
+    );
+    let ready_tasks = wave
+        .as_ref()
+        .map(|w| w.tasks.iter().map(|t| t.id.clone()).collect::<Vec<_>>())
+        .unwrap_or_default();
+    // A wave with any ready tasks is considered parallel-safe until a
+    // future unit adds resource-conflict analysis (exclusive_resources,
+    // unknown_side_effects). `parallel_blockers` will carry any
+    // detected conflicts once that logic lands.
+    let parallel_safe = wave.as_ref().is_some_and(|w| !w.tasks.is_empty());
+    let review_required: Vec<Value> = reviews_ready
+        .iter()
+        .map(|(id, targets)| json!({ "task_id": id, "targets": targets }))
+        .collect();
+
+    json!({
+        "phase": state.phase,
+        "verdict": verdict.as_str(),
+        "loop": state.loop_,
+        "next_action": next_action,
+        "ready_tasks": ready_tasks,
+        "parallel_safe": parallel_safe,
+        "parallel_blockers": Vec::<String>::new(),
+        "review_required": review_required,
+        "replan_required": state.replan.triggered,
+        "close_ready": close_ready,
+        "outcome_ratified": state.outcome.ratified,
+        "plan_locked": state.plan.locked,
+        "stop": stop,
+    })
+}
+
+/// Populate `stop.{allow,reason,message}` consistently with
+/// `readiness::stop_allowed`.
+///
+/// `terminal` beats `paused`/`idle`/`active_loop` so the message stays
+/// accurate after mission close. When the loop is active-and-unpaused
+/// but the verdict already allows stop (NeedsUser, MissionCloseReviewPassed),
+/// we surface `idle` so the message does not contradict `allow=true`.
+fn stop_projection(state: &MissionState, verdict: Verdict) -> Value {
+    let allow = readiness::stop_allowed(state);
+    let (reason, message) = if matches!(verdict, Verdict::TerminalComplete) {
+        ("terminal", "Mission is terminal; stop is allowed.")
+    } else if !state.loop_.active {
+        ("idle", "Loop is inactive; stop is allowed.")
+    } else if state.loop_.paused {
+        (
+            "paused",
+            "Loop is paused; stop is allowed. Use $execute or loop resume to continue.",
+        )
+    } else if allow {
+        // Loop says active-unpaused, but the verdict already permits
+        // stop (needs_user, mission_close_review_passed). Surface it as
+        // "idle" so allow=true and the message agree.
+        ("idle", "Loop is active but verdict allows stop.")
+    } else {
+        (
+            "active_loop",
+            "Active loop in progress. Use $close to pause or finish the next action.",
+        )
+    };
+    json!({
+        "allow": allow,
+        "reason": reason,
+        "message": message,
+    })
+}
+
+/// First-match-wins next-action derivation. Branches (in order):
+/// invalid_state → terminal → outcome → plan → replan → repair →
+/// mission-close verdicts → next wave → blocked. The order is the
+/// contract — moving a branch changes what skills do.
+fn derive_next_action(
+    state: &MissionState,
+    verdict: Verdict,
+    wave: Option<&ReadyWave>,
+    reviews_ready: &[(String, Vec<String>)],
+    repair_targets: &[String],
+) -> Value {
+    if matches!(verdict, Verdict::InvalidState) {
+        return json!({
+            "kind": "fix_state",
+            "message": "STATE.json appears inconsistent. Run `codex1 doctor` and inspect EVENTS.jsonl.",
+        });
+    }
+    if matches!(verdict, Verdict::TerminalComplete) {
+        return json!({
+            "kind": "closed",
+            "hint": "Mission is terminal.",
+        });
+    }
+    if !state.outcome.ratified {
+        return json!({
+            "kind": "clarify",
+            "command": "$clarify",
+            "hint": "Ratify OUTCOME.md before planning.",
+        });
+    }
+    if !state.plan.locked {
+        return json!({
+            "kind": "plan",
+            "command": "$plan",
+            "hint": "Draft and lock PLAN.yaml.",
+        });
+    }
+    if state.replan.triggered {
+        return json!({
+            "kind": "replan",
+            "command": "$plan replan",
+            "reason": state.replan.triggered_reason.clone().unwrap_or_default(),
+        });
+    }
+    if !repair_targets.is_empty() {
+        return json!({
+            "kind": "repair",
+            "task_ids": repair_targets,
+            "command": "$execute (repair)",
+        });
+    }
+    match verdict {
+        Verdict::ReadyForMissionCloseReview => {
+            return json!({
+                "kind": "mission_close_review",
+                "command": "$review-loop (mission-close)",
+                "hint": "All tasks complete; run the mission-close review.",
+            });
+        }
+        Verdict::MissionCloseReviewOpen => {
+            return json!({
+                "kind": "mission_close_review",
+                "command": "$review-loop",
+                "hint": "Mission-close review is open.",
+            });
+        }
+        Verdict::MissionCloseReviewPassed => {
+            return json!({
+                "kind": "close",
+                "command": "codex1 close complete",
+                "hint": "Mission-close review passed; finalize close.",
+            });
+        }
+        _ => {}
+    }
+    if let Some(w) = wave {
+        let review_in_wave = reviews_ready
+            .iter()
+            .find(|(id, _)| w.tasks.iter().any(|t| &t.id == id));
+        if let Some((review_id, targets)) = review_in_wave {
+            return json!({
+                "kind": "run_review",
+                "review_task_id": review_id,
+                "targets": targets,
+                "command": "$review-loop",
+            });
+        }
+        if w.tasks.len() == 1 {
+            let only = &w.tasks[0];
+            return json!({
+                "kind": "run_task",
+                "task_id": only.id,
+                "task_kind": only.kind.clone().unwrap_or_else(|| "work".to_string()),
+                "command": "$execute",
+            });
+        }
+        let ids: Vec<String> = w.tasks.iter().map(|t| t.id.clone()).collect();
+        return json!({
+            "kind": "run_wave",
+            "wave_id": w.wave_id.clone(),
+            "tasks": ids,
+            "parallel_safe": true,
+            "hint": format!("Run wave {} with $execute.", w.wave_id),
+        });
+    }
+    json!({
+        "kind": "blocked",
+        "reason": "No ready wave derivable — PLAN.yaml may be missing, empty, or inconsistent with STATE.json.",
+    })
+}

--- a/crates/codex1/tests/status.rs
+++ b/crates/codex1/tests/status.rs
@@ -1,0 +1,532 @@
+//! Integration tests for `codex1 status --json` (Phase B Unit 11).
+//!
+//! Seeds `MissionState` and PLAN.yaml by hand, then shells out to the
+//! CLI and asserts on the published projection. This catches any
+//! drift between `state::readiness` and the JSON shape consumed by
+//! Ralph/skills.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use codex1::state::schema::{
+    CloseState, LoopMode, LoopState, MissionCloseReviewState, MissionState, OutcomeState, Phase,
+    PlanState, ReplanState, ReviewRecord, ReviewRecordCategory, ReviewVerdict, TaskRecord,
+    TaskStatus, SCHEMA_VERSION,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+struct Fixture {
+    tmp: TempDir,
+    mission: String,
+}
+
+impl Fixture {
+    fn new(mission: &str) -> Self {
+        let tmp = TempDir::new().unwrap();
+        let mission_dir = tmp.path().join("PLANS").join(mission);
+        fs::create_dir_all(mission_dir.join("specs")).unwrap();
+        fs::create_dir_all(mission_dir.join("reviews")).unwrap();
+        fs::write(mission_dir.join("EVENTS.jsonl"), "").unwrap();
+        Self {
+            tmp,
+            mission: mission.to_string(),
+        }
+    }
+
+    fn mission_dir(&self) -> PathBuf {
+        self.tmp.path().join("PLANS").join(&self.mission)
+    }
+
+    fn write_state(&self, state: &MissionState) {
+        let path = self.mission_dir().join("STATE.json");
+        let raw = serde_json::to_vec_pretty(state).unwrap();
+        write_atomic(&path, &raw);
+    }
+
+    fn write_plan(&self, body: &str) {
+        let path = self.mission_dir().join("PLAN.yaml");
+        write_atomic(&path, body.as_bytes());
+    }
+
+    fn status(&self) -> Value {
+        let out = cmd()
+            .current_dir(self.tmp.path())
+            .args(["status", "--mission", &self.mission])
+            .output()
+            .expect("runs");
+        let stdout = std::str::from_utf8(&out.stdout).expect("utf-8");
+        serde_json::from_str(stdout).unwrap_or_else(|e| panic!("non-JSON stdout:\n{stdout}\n{e}"))
+    }
+}
+
+fn write_atomic(path: &Path, data: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, data).unwrap();
+}
+
+fn base_state(mission_id: &str) -> MissionState {
+    MissionState {
+        mission_id: mission_id.to_string(),
+        revision: 0,
+        schema_version: SCHEMA_VERSION,
+        phase: Phase::Clarify,
+        loop_: LoopState::default(),
+        outcome: OutcomeState::default(),
+        plan: PlanState::default(),
+        tasks: BTreeMap::new(),
+        reviews: BTreeMap::new(),
+        replan: ReplanState::default(),
+        close: CloseState::default(),
+        events_cursor: 0,
+    }
+}
+
+fn simple_plan() -> &'static str {
+    r"mission_id: demo
+tasks:
+  - id: T1
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+  - id: T2
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+  - id: T3
+    kind: code
+    depends_on: [T1]
+    spec: specs/T3/SPEC.md
+  - id: T4
+    kind: review
+    depends_on: [T2, T3]
+    spec: specs/T4/SPEC.md
+    review_target:
+      tasks: [T2, T3]
+"
+}
+
+fn task(id: &str, status: TaskStatus) -> (String, TaskRecord) {
+    (
+        id.to_string(),
+        TaskRecord {
+            id: id.to_string(),
+            status,
+            started_at: None,
+            finished_at: None,
+            proof_path: None,
+            superseded_by: None,
+        },
+    )
+}
+
+fn review(
+    task_id: &str,
+    verdict: ReviewVerdict,
+    category: ReviewRecordCategory,
+    boundary: u64,
+) -> (String, ReviewRecord) {
+    (
+        task_id.to_string(),
+        ReviewRecord {
+            task_id: task_id.to_string(),
+            verdict,
+            reviewers: vec!["code-reviewer".to_string()],
+            findings_file: None,
+            category,
+            recorded_at: "2026-04-20T00:00:00Z".to_string(),
+            boundary_revision: boundary,
+        },
+    )
+}
+
+#[test]
+fn fresh_init_reports_clarify_next_action() {
+    let fx = Fixture::new("demo");
+    let state = base_state("demo");
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["data"]["verdict"], "needs_user");
+    assert_eq!(json["data"]["stop"]["allow"], true);
+    assert_eq!(json["data"]["next_action"]["kind"], "clarify");
+    assert_eq!(json["data"]["outcome_ratified"], false);
+    assert_eq!(json["data"]["plan_locked"], false);
+}
+
+#[test]
+fn outcome_ratified_plan_unlocked_reports_plan_next_action() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.phase = Phase::Plan;
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "needs_user");
+    assert_eq!(json["data"]["next_action"]["kind"], "plan");
+    assert_eq!(json["data"]["outcome_ratified"], true);
+    assert_eq!(json["data"]["plan_locked"], false);
+}
+
+#[test]
+fn plan_locked_and_tasks_pending_reports_run_wave_or_task() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::Execute;
+    state.tasks.insert(
+        task("T1", TaskStatus::Ready).0,
+        task("T1", TaskStatus::Ready).1,
+    );
+    state.tasks.insert(
+        task("T2", TaskStatus::Pending).0,
+        task("T2", TaskStatus::Pending).1,
+    );
+    state.tasks.insert(
+        task("T3", TaskStatus::Pending).0,
+        task("T3", TaskStatus::Pending).1,
+    );
+    state.tasks.insert(
+        task("T4", TaskStatus::Pending).0,
+        task("T4", TaskStatus::Pending).1,
+    );
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "continue_required");
+    let kind = json["data"]["next_action"]["kind"].as_str().unwrap();
+    assert!(
+        kind == "run_wave" || kind == "run_task",
+        "expected run_wave or run_task, got {kind}"
+    );
+    // W1 has only T1, so this should be run_task.
+    assert_eq!(kind, "run_task");
+    assert_eq!(json["data"]["next_action"]["task_id"], "T1");
+}
+
+#[test]
+fn plan_locked_wave_with_two_ready_reports_run_wave() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::Execute;
+    state.tasks.insert(
+        task("T1", TaskStatus::Complete).0,
+        task("T1", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T2", TaskStatus::Ready).0,
+        task("T2", TaskStatus::Ready).1,
+    );
+    state.tasks.insert(
+        task("T3", TaskStatus::Ready).0,
+        task("T3", TaskStatus::Ready).1,
+    );
+    state.tasks.insert(
+        task("T4", TaskStatus::Pending).0,
+        task("T4", TaskStatus::Pending).1,
+    );
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["next_action"]["kind"], "run_wave");
+    assert_eq!(json["data"]["next_action"]["wave_id"], "W2");
+    let tasks: Vec<String> = json["data"]["next_action"]["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(tasks.contains(&"T2".to_string()));
+    assert!(tasks.contains(&"T3".to_string()));
+    assert_eq!(json["data"]["parallel_safe"], true);
+}
+
+#[test]
+fn active_loop_not_paused_sets_stop_active_loop() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::Execute;
+    state.loop_ = LoopState {
+        active: true,
+        paused: false,
+        mode: LoopMode::Execute,
+    };
+    state.tasks.insert(
+        task("T1", TaskStatus::Ready).0,
+        task("T1", TaskStatus::Ready).1,
+    );
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "continue_required");
+    assert_eq!(json["data"]["stop"]["allow"], false);
+    assert_eq!(json["data"]["stop"]["reason"], "active_loop");
+}
+
+#[test]
+fn active_loop_paused_sets_stop_paused() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::Execute;
+    state.loop_ = LoopState {
+        active: true,
+        paused: true,
+        mode: LoopMode::Execute,
+    };
+    state.tasks.insert(
+        task("T1", TaskStatus::Ready).0,
+        task("T1", TaskStatus::Ready).1,
+    );
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["stop"]["allow"], true);
+    assert_eq!(json["data"]["stop"]["reason"], "paused");
+}
+
+#[test]
+fn replan_triggered_reports_blocked_and_replan_next_action() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::Execute;
+    state.replan.triggered = true;
+    state.replan.triggered_reason = Some("six consecutive dirty reviews".to_string());
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "blocked");
+    assert_eq!(json["data"]["next_action"]["kind"], "replan");
+    assert_eq!(json["data"]["replan_required"], true);
+}
+
+#[test]
+fn all_tasks_complete_reports_ready_for_mission_close_review() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::MissionClose;
+    state.tasks.insert(
+        task("T1", TaskStatus::Complete).0,
+        task("T1", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T2", TaskStatus::Complete).0,
+        task("T2", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T3", TaskStatus::Complete).0,
+        task("T3", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T4", TaskStatus::Complete).0,
+        task("T4", TaskStatus::Complete).1,
+    );
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "ready_for_mission_close_review");
+    assert_eq!(json["data"]["next_action"]["kind"], "mission_close_review");
+    assert_eq!(json["data"]["close_ready"], false);
+}
+
+#[test]
+fn mission_close_review_passed_reports_close_next_action() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::MissionClose;
+    state.tasks.insert(
+        task("T1", TaskStatus::Complete).0,
+        task("T1", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T2", TaskStatus::Complete).0,
+        task("T2", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T3", TaskStatus::Complete).0,
+        task("T3", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T4", TaskStatus::Complete).0,
+        task("T4", TaskStatus::Complete).1,
+    );
+    state.close.review_state = MissionCloseReviewState::Passed;
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "mission_close_review_passed");
+    assert_eq!(json["data"]["close_ready"], true);
+    assert_eq!(json["data"]["next_action"]["kind"], "close");
+}
+
+#[test]
+fn terminal_complete_reports_closed_next_action() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::Terminal;
+    state.close.terminal_at = Some("2026-04-20T12:00:00Z".to_string());
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "terminal_complete");
+    assert_eq!(json["data"]["next_action"]["kind"], "closed");
+    assert_eq!(json["data"]["stop"]["allow"], true);
+    assert_eq!(json["data"]["stop"]["reason"], "terminal");
+}
+
+#[test]
+fn dirty_review_reports_repair_next_action() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::ReviewLoop;
+    state.tasks.insert(
+        task("T1", TaskStatus::Complete).0,
+        task("T1", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T2", TaskStatus::AwaitingReview).0,
+        task("T2", TaskStatus::AwaitingReview).1,
+    );
+    state.tasks.insert(
+        task("T3", TaskStatus::AwaitingReview).0,
+        task("T3", TaskStatus::AwaitingReview).1,
+    );
+    state.tasks.insert(
+        task("T4", TaskStatus::Pending).0,
+        task("T4", TaskStatus::Pending).1,
+    );
+    let (rid, rec) = review(
+        "T4",
+        ReviewVerdict::Dirty,
+        ReviewRecordCategory::AcceptedCurrent,
+        3,
+    );
+    state.reviews.insert(rid, rec);
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "blocked");
+    assert_eq!(json["data"]["next_action"]["kind"], "repair");
+    let ids: Vec<String> = json["data"]["next_action"]["task_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(ids.contains(&"T2".to_string()));
+    assert!(ids.contains(&"T3".to_string()));
+}
+
+#[test]
+fn ready_review_task_sets_review_required() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = true;
+    state.phase = Phase::ReviewLoop;
+    state.tasks.insert(
+        task("T1", TaskStatus::Complete).0,
+        task("T1", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T2", TaskStatus::Complete).0,
+        task("T2", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T3", TaskStatus::Complete).0,
+        task("T3", TaskStatus::Complete).1,
+    );
+    state.tasks.insert(
+        task("T4", TaskStatus::Ready).0,
+        task("T4", TaskStatus::Ready).1,
+    );
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "continue_required");
+    let reviews = json["data"]["review_required"].as_array().unwrap();
+    assert_eq!(reviews.len(), 1);
+    assert_eq!(reviews[0]["task_id"], "T4");
+    assert_eq!(json["data"]["next_action"]["kind"], "run_review");
+    assert_eq!(json["data"]["next_action"]["review_task_id"], "T4");
+}
+
+#[test]
+fn revision_matches_state_revision() {
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.revision = 15;
+    state.outcome.ratified = true;
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["revision"], 15);
+    assert_eq!(json["mission_id"], "demo");
+}
+
+#[test]
+fn active_loop_with_stop_allowing_verdict_does_not_contradict_itself() {
+    // Loop is active-unpaused but verdict is `needs_user` (plan not
+    // locked). `stop_allowed` returns true; the projection must not
+    // emit `reason=active_loop` with `message="active loop in progress"`
+    // because that contradicts `allow=true`.
+    let fx = Fixture::new("demo");
+    let mut state = base_state("demo");
+    state.outcome.ratified = true;
+    state.plan.locked = false;
+    state.loop_ = LoopState {
+        active: true,
+        paused: false,
+        mode: LoopMode::Execute,
+    };
+    fx.write_state(&state);
+    fx.write_plan(simple_plan());
+
+    let json = fx.status();
+    assert_eq!(json["data"]["verdict"], "needs_user");
+    assert_eq!(json["data"]["stop"]["allow"], true);
+    let reason = json["data"]["stop"]["reason"].as_str().unwrap();
+    assert_ne!(
+        reason, "active_loop",
+        "stop.reason must not be active_loop when allow=true"
+    );
+}

--- a/crates/codex1/tests/status_close_agreement.rs
+++ b/crates/codex1/tests/status_close_agreement.rs
@@ -1,0 +1,440 @@
+//! `status` vs readiness-helper agreement (Phase B Unit 11).
+//!
+//! The real invariant this test guards: `codex1 status` must publish
+//! the same verdict and `close_ready` that `state::readiness` derives.
+//! When `codex1 close check` lands (Unit 10), the CLI agreement is
+//! immediate because both commands call the same helpers — this test
+//! pins that contract at the library level today, which is the only
+//! path that will not regress when `close check` ships.
+//!
+//! The `close_check_cli_agrees_when_implemented` test demonstrates
+//! that once `close check` returns success it already agrees (the
+//! current stub returns NOT_IMPLEMENTED, which we explicitly tolerate).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use codex1::state::readiness;
+use codex1::state::schema::{
+    CloseState, LoopMode, LoopState, MissionCloseReviewState, MissionState, OutcomeState, Phase,
+    PlanState, ReplanState, ReviewRecord, ReviewRecordCategory, ReviewVerdict, TaskRecord,
+    TaskStatus, SCHEMA_VERSION,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+struct Fixture {
+    tmp: TempDir,
+    mission: String,
+}
+
+impl Fixture {
+    fn new(mission: &str) -> Self {
+        let tmp = TempDir::new().unwrap();
+        let mission_dir = tmp.path().join("PLANS").join(mission);
+        fs::create_dir_all(mission_dir.join("specs")).unwrap();
+        fs::create_dir_all(mission_dir.join("reviews")).unwrap();
+        fs::write(mission_dir.join("EVENTS.jsonl"), "").unwrap();
+        Self {
+            tmp,
+            mission: mission.to_string(),
+        }
+    }
+
+    fn mission_dir(&self) -> PathBuf {
+        self.tmp.path().join("PLANS").join(&self.mission)
+    }
+
+    fn write_state(&self, state: &MissionState) {
+        let path = self.mission_dir().join("STATE.json");
+        write_atomic(&path, serde_json::to_vec_pretty(state).unwrap().as_slice());
+    }
+
+    fn write_plan(&self, body: &str) {
+        write_atomic(&self.mission_dir().join("PLAN.yaml"), body.as_bytes());
+    }
+
+    fn status(&self) -> Value {
+        let out = cmd()
+            .current_dir(self.tmp.path())
+            .args(["status", "--mission", &self.mission])
+            .output()
+            .expect("runs");
+        let stdout = std::str::from_utf8(&out.stdout).expect("utf-8");
+        serde_json::from_str(stdout).unwrap_or_else(|e| panic!("non-JSON stdout:\n{stdout}\n{e}"))
+    }
+
+    fn close_check(&self) -> (bool, Value) {
+        let out = cmd()
+            .current_dir(self.tmp.path())
+            .args(["close", "check", "--mission", &self.mission])
+            .output()
+            .expect("runs");
+        let stdout = std::str::from_utf8(&out.stdout).expect("utf-8");
+        let json: Value = serde_json::from_str(stdout)
+            .unwrap_or_else(|e| panic!("non-JSON stdout from close check:\n{stdout}\n{e}"));
+        (out.status.success(), json)
+    }
+}
+
+fn write_atomic(path: &Path, data: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, data).unwrap();
+}
+
+fn base(mission_id: &str) -> MissionState {
+    MissionState {
+        mission_id: mission_id.to_string(),
+        revision: 0,
+        schema_version: SCHEMA_VERSION,
+        phase: Phase::Clarify,
+        loop_: LoopState::default(),
+        outcome: OutcomeState::default(),
+        plan: PlanState::default(),
+        tasks: BTreeMap::new(),
+        reviews: BTreeMap::new(),
+        replan: ReplanState::default(),
+        close: CloseState::default(),
+        events_cursor: 0,
+    }
+}
+
+fn minimal_plan() -> &'static str {
+    r"mission_id: demo
+tasks:
+  - id: T1
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+  - id: T2
+    kind: review
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+    review_target:
+      tasks: [T1]
+"
+}
+
+fn task_rec(id: &str, status: TaskStatus) -> TaskRecord {
+    TaskRecord {
+        id: id.to_string(),
+        status,
+        started_at: None,
+        finished_at: None,
+        proof_path: None,
+        superseded_by: None,
+    }
+}
+
+fn review_rec(task_id: &str, verdict: ReviewVerdict, boundary: u64) -> ReviewRecord {
+    ReviewRecord {
+        task_id: task_id.to_string(),
+        verdict,
+        reviewers: vec!["code-reviewer".to_string()],
+        findings_file: None,
+        category: ReviewRecordCategory::AcceptedCurrent,
+        recorded_at: "2026-04-20T00:00:00Z".to_string(),
+        boundary_revision: boundary,
+    }
+}
+
+/// Build 20 representative MissionState fixtures that together cover
+/// every verdict branch in `readiness::derive_verdict`.
+fn fixtures() -> Vec<(String, MissionState)> {
+    let mut out = Vec::new();
+
+    // 1. Fresh, nothing ratified → needs_user.
+    out.push(("fresh".into(), base("demo")));
+
+    // 2. Outcome ratified, plan unlocked → needs_user (plan branch).
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    out.push(("outcome_only".into(), s));
+
+    // 3. Plan locked, no tasks → continue_required (tasks empty isn't "complete").
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    out.push(("plan_locked_no_tasks".into(), s));
+
+    // 4. Plan locked, T1 pending → continue_required.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Pending));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Pending));
+    out.push(("tasks_pending".into(), s));
+
+    // 5. Plan locked, T1 in progress → continue_required.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::InProgress));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Pending));
+    out.push(("task_in_progress".into(), s));
+
+    // 6. Plan locked, T1 awaiting review → continue_required.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::AwaitingReview));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Ready));
+    out.push(("task_awaiting_review".into(), s));
+
+    // 7. All tasks complete, close NotStarted → ready_for_mission_close_review.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Complete));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Complete));
+    out.push(("ready_for_close_review".into(), s));
+
+    // 8. All tasks complete, close Open → mission_close_review_open.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Complete));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Complete));
+    s.close.review_state = MissionCloseReviewState::Open;
+    out.push(("close_review_open".into(), s));
+
+    // 9. All tasks complete, close Passed → mission_close_review_passed (close_ready=true).
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Complete));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Complete));
+    s.close.review_state = MissionCloseReviewState::Passed;
+    out.push(("close_review_passed".into(), s));
+
+    // 10. Terminal → terminal_complete.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Complete));
+    s.close.terminal_at = Some("2026-04-20T00:00:00Z".into());
+    out.push(("terminal".into(), s));
+
+    // 11. Replan triggered → blocked.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.replan.triggered = true;
+    s.replan.triggered_reason = Some("six dirty reviews".into());
+    out.push(("replan".into(), s));
+
+    // 12. Dirty review → blocked.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::AwaitingReview));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Pending));
+    s.reviews
+        .insert("T2".into(), review_rec("T2", ReviewVerdict::Dirty, 4));
+    out.push(("dirty_review".into(), s));
+
+    // 13. Clean review, tasks still pending → continue_required.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Complete));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Pending));
+    s.reviews
+        .insert("T2".into(), review_rec("T2", ReviewVerdict::Clean, 4));
+    out.push(("clean_review_continuing".into(), s));
+
+    // 14. Loop active, task in progress → continue_required; stop disallowed.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.loop_ = LoopState {
+        active: true,
+        paused: false,
+        mode: LoopMode::Execute,
+    };
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::InProgress));
+    out.push(("active_loop".into(), s));
+
+    // 15. Loop paused → continue_required; stop allowed via loop_paused.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.loop_ = LoopState {
+        active: true,
+        paused: true,
+        mode: LoopMode::Execute,
+    };
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Ready));
+    out.push(("loop_paused".into(), s));
+
+    // 16. Superseded tasks + complete tasks only → ready_for_mission_close_review.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Superseded));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Complete));
+    out.push(("superseded_mix".into(), s));
+
+    // 17. Mixed task states with a ready + pending + complete combination → continue_required.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::Complete));
+    s.tasks
+        .insert("T2".into(), task_rec("T2", TaskStatus::Ready));
+    s.tasks
+        .insert("T3".into(), task_rec("T3", TaskStatus::Pending));
+    out.push(("mixed_ready_pending".into(), s));
+
+    // 18. Terminal but loop still active (state oddity) → terminal_complete.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.loop_ = LoopState {
+        active: true,
+        paused: false,
+        mode: LoopMode::Execute,
+    };
+    s.close.terminal_at = Some("2026-04-20T10:00:00Z".into());
+    out.push(("terminal_with_active_loop".into(), s));
+
+    // 19. Outcome ratified but with revision bumped by prior activity.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.revision = 7;
+    s.events_cursor = 7;
+    out.push(("revision_bumped".into(), s));
+
+    // 20. Plan locked + replan NOT triggered + dirty review alongside pending task.
+    let mut s = base("demo");
+    s.outcome.ratified = true;
+    s.plan.locked = true;
+    s.tasks
+        .insert("T1".into(), task_rec("T1", TaskStatus::AwaitingReview));
+    s.reviews
+        .insert("T2".into(), review_rec("T2", ReviewVerdict::Dirty, 3));
+    s.replan.consecutive_dirty_by_target.insert("T1".into(), 2);
+    out.push(("dirty_without_replan".into(), s));
+
+    out
+}
+
+#[test]
+fn status_agrees_with_readiness_helpers_for_all_fixtures() {
+    for (name, state) in fixtures() {
+        let fx = Fixture::new("demo");
+        fx.write_state(&state);
+        fx.write_plan(minimal_plan());
+
+        let status_json = fx.status();
+        let expected_verdict = readiness::derive_verdict(&state);
+        let expected_close_ready = readiness::close_ready(&state);
+
+        assert_eq!(
+            status_json["data"]["verdict"].as_str().unwrap(),
+            expected_verdict.as_str(),
+            "verdict mismatch for fixture {name}: {:#?}",
+            status_json["data"]
+        );
+        assert_eq!(
+            status_json["data"]["close_ready"].as_bool().unwrap(),
+            expected_close_ready,
+            "close_ready mismatch for fixture {name}"
+        );
+        assert_eq!(
+            status_json["revision"].as_u64().unwrap(),
+            state.revision,
+            "envelope revision should match state.revision for fixture {name}"
+        );
+    }
+}
+
+#[test]
+fn close_check_cli_agrees_when_implemented() {
+    // Once Unit 10 lands `close check`, this test asserts end-to-end
+    // CLI agreement. While the stub returns NOT_IMPLEMENTED we verify
+    // the contract holds on every fixture that does succeed.
+    for (name, state) in fixtures() {
+        let fx = Fixture::new("demo");
+        fx.write_state(&state);
+        fx.write_plan(minimal_plan());
+
+        let status_json = fx.status();
+        let (success, close_json) = fx.close_check();
+        if !success {
+            // Skip until Unit 10 lands. Record that the stub is the
+            // only reason we skipped so the test wakes up the moment
+            // `close check` starts returning success.
+            assert_eq!(
+                close_json["code"], "NOT_IMPLEMENTED",
+                "close check failed for fixture {name} with non-stub error: {close_json:#?}"
+            );
+            continue;
+        }
+        assert_eq!(
+            status_json["data"]["close_ready"], close_json["data"]["ready"],
+            "close_ready disagreement for fixture {name}"
+        );
+        assert_eq!(
+            status_json["data"]["verdict"], close_json["data"]["verdict"],
+            "verdict disagreement for fixture {name}"
+        );
+    }
+}
+
+/// After `codex1 init`, `status --json` reports the freshly-written
+/// revision. A stronger end-to-end "mutation bumps revision" test
+/// belongs to whichever Phase B unit first exposes a mutating CLI
+/// command — init writes via `init_write`, not `state::mutate`, so
+/// the revision stays zero. The in-process fixture above already
+/// covers state.revision → envelope.revision for arbitrary values.
+#[test]
+fn status_after_init_reports_revision_zero() {
+    let tmp = TempDir::new().unwrap();
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", "demo"])
+        .assert()
+        .success();
+    let state_path = tmp.path().join("PLANS").join("demo").join("STATE.json");
+    let state: MissionState =
+        serde_json::from_str(&fs::read_to_string(&state_path).unwrap()).unwrap();
+    assert_eq!(state.revision, 0);
+    let out = cmd()
+        .current_dir(tmp.path())
+        .args(["status", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    let json: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["revision"].as_u64().unwrap(), 0);
+}


### PR DESCRIPTION
## Summary

- Replace the `codex1 status --json` Foundation stub with the full unified projection from `docs/cli-contract-schemas.md` (`status` section).
- `status` and `close check` share `state::readiness` (`derive_verdict`, `close_ready`, `stop_allowed`) so they can never disagree on verdict or close readiness.
- Local wave derivation in `crates/codex1/src/cli/status/next_action.rs` parses PLAN.yaml just enough to pick the next ready wave (review-kind tasks, dependency chains, dirty-repair targets). No dependency on Unit 5.

## Next-action order (first match wins)

1. `invalid_state` -> `fix_state`
2. `terminal_complete` -> `closed`
3. outcome not ratified -> `clarify`
4. plan not locked -> `plan`
5. `replan.triggered` -> `replan`
6. any dirty review -> `repair` with target task ids
7. `ready_for_mission_close_review` -> `mission_close_review`
8. `mission_close_review_open` -> `mission_close_review`
9. `mission_close_review_passed` -> `close`
10. next ready wave (review -> `run_review`, single task -> `run_task`, multiple -> `run_wave`) else `blocked`

## stop.reason
- `terminal` beats everything after mission close.
- `idle` / `paused` / `active_loop` cover the remaining cases.
- When loop is active-unpaused but the verdict already allows stop (needs_user, mission_close_review_passed), the projection emits `idle` to avoid a self-contradicting `allow=true` + `active_loop` pair.

## Tests
- `crates/codex1/tests/status.rs` (14) - every required branch plus stop-reason contradiction edge.
- `crates/codex1/tests/status_close_agreement.rs` (3) - 20 `MissionState` fixtures covering every `derive_verdict` branch; asserts `status.data.verdict == readiness::derive_verdict(&state).as_str()` and `status.data.close_ready == readiness::close_ready(&state)`. Once Unit 10 lands `close check`, the `close_check_cli_agrees_when_implemented` test switches from library-level to end-to-end assertions (currently tolerates `NOT_IMPLEMENTED`).

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (30 tests: 13 foundation + 14 status + 3 agreement)
- [x] Ran the `simplify` skill.

## Notes for downstream units
- Unit 10 (`close check`): once implemented, `close_check_cli_agrees_when_implemented` becomes fully end-to-end. Some fixtures (e.g. `plan_locked_no_tasks` where the tasks map is empty) may need to be excluded from what `close check` accepts.
- Unit 5 (`plan waves`): this unit's local wave derivation is intentionally narrow and can be replaced with the shared helper once it lands without changing the status JSON shape.