### PR TITLE
Unit 10: cli-close check, complete, record-review

### DIFF
--- a/crates/codex1/src/cli/close/check.rs
+++ b/crates/codex1/src/cli/close/check.rs
@@ -1,0 +1,157 @@
+//! `codex1 close check --json` — read-only mission-close readiness projection.
+//!
+//! The verdict string comes from `state::readiness::derive_verdict` so that
+//! `close check` and `status` can never disagree. The blocker list is
+//! derived independently from raw state fields — it enumerates every
+//! concrete reason the mission is not terminal-ready regardless of which
+//! single verdict `derive_verdict` collapsed to.
+
+use serde::Serialize;
+use serde_json::json;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::CliResult;
+use crate::core::mission::resolve_mission;
+use crate::state::readiness::{self, Verdict};
+use crate::state::schema::{MissionCloseReviewState, MissionState, ReviewVerdict, TaskStatus};
+use crate::state::{self};
+
+use super::serde_variant;
+
+/// One element of `close check`'s `blockers` array.
+#[derive(Debug, Clone, Serialize)]
+pub struct Blocker {
+    pub code: &'static str,
+    pub detail: String,
+}
+
+impl Blocker {
+    pub fn new(code: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            code,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Snapshot of the readiness signal used by both `check` and `complete`.
+pub struct ReadinessReport {
+    pub verdict: Verdict,
+    pub blockers: Vec<Blocker>,
+    pub ready: bool,
+}
+
+impl ReadinessReport {
+    pub fn from_state(state: &MissionState) -> Self {
+        let verdict = readiness::derive_verdict(state);
+        let blockers = derive_blockers(state);
+        let ready = matches!(verdict, Verdict::MissionCloseReviewPassed);
+        Self {
+            verdict,
+            blockers,
+            ready,
+        }
+    }
+
+    /// Concatenated blocker message for error envelopes.
+    pub fn blocker_summary(&self) -> String {
+        if self.blockers.is_empty() {
+            "not ready".to_string()
+        } else {
+            self.blockers
+                .iter()
+                .map(|b| format!("{}: {}", b.code, b.detail))
+                .collect::<Vec<_>>()
+                .join("; ")
+        }
+    }
+}
+
+/// Enumerate every concrete reason the mission is not terminal-ready.
+/// Independent of `derive_verdict` so a single collapsed verdict does
+/// not hide parallel issues from the caller.
+#[must_use]
+pub fn derive_blockers(state: &MissionState) -> Vec<Blocker> {
+    let mut blockers = Vec::new();
+
+    if !state.outcome.ratified {
+        blockers.push(Blocker::new(
+            "OUTCOME_NOT_RATIFIED",
+            "OUTCOME.md has not been ratified",
+        ));
+    }
+    if !state.plan.locked {
+        blockers.push(Blocker::new("PLAN_INVALID", "plan not locked"));
+    }
+    if state.replan.triggered {
+        let detail = state
+            .replan
+            .triggered_reason
+            .clone()
+            .unwrap_or_else(|| "replan triggered".to_string());
+        blockers.push(Blocker::new("REPLAN_REQUIRED", detail));
+    }
+    for (task_id, record) in &state.tasks {
+        if !matches!(record.status, TaskStatus::Complete | TaskStatus::Superseded) {
+            blockers.push(Blocker::new(
+                "TASK_NOT_READY",
+                format!("{task_id} is {}", serde_variant(&record.status)),
+            ));
+        }
+    }
+    for (review_id, record) in &state.reviews {
+        if matches!(record.verdict, ReviewVerdict::Dirty) {
+            blockers.push(Blocker::new(
+                "REVIEW_FINDINGS_BLOCK",
+                format!("{review_id} has dirty review"),
+            ));
+        }
+    }
+    if tasks_all_complete(state) {
+        match state.close.review_state {
+            MissionCloseReviewState::NotStarted => {
+                blockers.push(Blocker::new(
+                    "CLOSE_NOT_READY",
+                    "mission-close review has not started",
+                ));
+            }
+            MissionCloseReviewState::Open => {
+                blockers.push(Blocker::new(
+                    "CLOSE_NOT_READY",
+                    "mission-close review still open",
+                ));
+            }
+            MissionCloseReviewState::Passed => {}
+        }
+    }
+
+    blockers
+}
+
+fn tasks_all_complete(state: &MissionState) -> bool {
+    if state.tasks.is_empty() {
+        return false;
+    }
+    state
+        .tasks
+        .values()
+        .all(|t| matches!(t.status, TaskStatus::Complete | TaskStatus::Superseded))
+}
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let state = state::load(&paths)?;
+    let report = ReadinessReport::from_state(&state);
+    let env = JsonOk::new(
+        Some(state.mission_id.clone()),
+        Some(state.revision),
+        json!({
+            "ready": report.ready,
+            "verdict": report.verdict.as_str(),
+            "blockers": report.blockers,
+        }),
+    );
+    println!("{}", env.to_pretty());
+    Ok(())
+}

--- a/crates/codex1/src/cli/close/closeout.rs
+++ b/crates/codex1/src/cli/close/closeout.rs
@@ -1,0 +1,150 @@
+//! CLOSEOUT.md renderer for `codex1 close complete`.
+//!
+//! Emits a human-friendly summary pulled from `STATE.json` plus an
+//! excerpt of `interpreted_destination` from the ratified OUTCOME.md.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use crate::core::paths::MissionPaths;
+use crate::state::schema::{MissionCloseReviewState, MissionState};
+
+use super::{serde_variant, MISSION_CLOSE_TARGET};
+
+/// Render the CLOSEOUT.md body from the post-mutation mission state.
+#[must_use]
+pub fn render(state: &MissionState, paths: &MissionPaths) -> String {
+    let mut out = String::with_capacity(2048);
+    let terminal_at = state.close.terminal_at.as_deref().unwrap_or("unknown");
+
+    writeln!(out, "# CLOSEOUT — {}", state.mission_id).ok();
+    writeln!(out).ok();
+    writeln!(out, "**Terminal at:** {terminal_at}").ok();
+    writeln!(out, "**Final revision:** {}", state.revision).ok();
+    let planning_level = state
+        .plan
+        .effective_level
+        .as_ref()
+        .map_or("unspecified".to_string(), serde_variant);
+    writeln!(out, "**Planning level:** {planning_level}").ok();
+    writeln!(out).ok();
+
+    writeln!(out, "## Outcome").ok();
+    writeln!(out).ok();
+    let destination = read_interpreted_destination(&paths.outcome())
+        .unwrap_or_else(|| "_interpreted_destination not found in OUTCOME.md_".to_string());
+    writeln!(out, "{}", destination.trim()).ok();
+    writeln!(out).ok();
+
+    writeln!(out, "## Tasks").ok();
+    writeln!(out).ok();
+    if state.tasks.is_empty() {
+        writeln!(out, "_No tasks recorded._").ok();
+    } else {
+        writeln!(out, "| ID | Status | Proof |").ok();
+        writeln!(out, "|---|---|---|").ok();
+        for (id, task) in &state.tasks {
+            let proof = task.proof_path.clone().unwrap_or_else(|| "—".to_string());
+            writeln!(out, "| {id} | {} | {proof} |", serde_variant(&task.status)).ok();
+        }
+    }
+    writeln!(out).ok();
+
+    writeln!(out, "## Reviews").ok();
+    writeln!(out).ok();
+    let has_mission_close = !matches!(
+        state.close.review_state,
+        MissionCloseReviewState::NotStarted
+    );
+    if state.reviews.is_empty() && !has_mission_close {
+        writeln!(out, "_No reviews recorded._").ok();
+    } else {
+        writeln!(out, "| Review ID | Verdict | Reviewers | Findings |").ok();
+        writeln!(out, "|---|---|---|---|").ok();
+        for (id, record) in &state.reviews {
+            writeln!(
+                out,
+                "| {id} | {} | {} | {} |",
+                serde_variant(&record.verdict),
+                if record.reviewers.is_empty() {
+                    "—".to_string()
+                } else {
+                    record.reviewers.join(",")
+                },
+                record
+                    .findings_file
+                    .clone()
+                    .unwrap_or_else(|| "—".to_string()),
+            )
+            .ok();
+        }
+        if has_mission_close {
+            let mc_verdict = match state.close.review_state {
+                MissionCloseReviewState::Passed => "clean",
+                MissionCloseReviewState::Open => "open",
+                MissionCloseReviewState::NotStarted => "—",
+            };
+            writeln!(out, "| MC | {mc_verdict} | — | — |").ok();
+        }
+    }
+    writeln!(out).ok();
+
+    writeln!(out, "## Mission-close review").ok();
+    writeln!(out).ok();
+    let dirty_rounds = state
+        .replan
+        .consecutive_dirty_by_target
+        .get(MISSION_CLOSE_TARGET)
+        .copied()
+        .unwrap_or(0);
+    let summary = match state.close.review_state {
+        MissionCloseReviewState::Passed => {
+            if dirty_rounds == 0 {
+                "Clean on the first round.".to_string()
+            } else {
+                format!(
+                    "Clean after {dirty_rounds} dirty round{} along the way.",
+                    if dirty_rounds == 1 { "" } else { "s" }
+                )
+            }
+        }
+        MissionCloseReviewState::Open => {
+            format!("Review was still open at closeout ({dirty_rounds} recorded dirty rounds).")
+        }
+        MissionCloseReviewState::NotStarted => {
+            "Mission-close review was never started.".to_string()
+        }
+    };
+    writeln!(out, "{summary}").ok();
+    if state.replan.triggered {
+        let reason = state
+            .replan
+            .triggered_reason
+            .clone()
+            .unwrap_or_else(|| "replan triggered".to_string());
+        writeln!(out).ok();
+        writeln!(out, "Replan trigger noted in final state: {reason}").ok();
+    }
+
+    out
+}
+
+/// Extract `interpreted_destination` from the YAML frontmatter of
+/// OUTCOME.md. Returns `None` if the file is missing, has no
+/// frontmatter, or the key is absent. Failure to parse is tolerated —
+/// CLOSEOUT.md is an auditor artifact, not a gate.
+fn read_interpreted_destination(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let frontmatter = extract_frontmatter(&raw)?;
+    let value: serde_yaml::Value = serde_yaml::from_str(frontmatter).ok()?;
+    let dest = value.get("interpreted_destination")?.as_str()?;
+    Some(dest.trim().to_string())
+}
+
+fn extract_frontmatter(raw: &str) -> Option<&str> {
+    let rest = raw
+        .strip_prefix("---\n")
+        .or_else(|| raw.strip_prefix("---\r\n"))?;
+    let end = rest.find("\n---").or_else(|| rest.find("\r\n---"))?;
+    Some(&rest[..end])
+}

--- a/crates/codex1/src/cli/close/complete.rs
+++ b/crates/codex1/src/cli/close/complete.rs
@@ -1,0 +1,111 @@
+//! `codex1 close complete --json` — terminal mission close.
+//!
+//! Preconditions:
+//!
+//! 1. The shared readiness predicate (`close check`) must return
+//!    `ready: true`. Otherwise → `CliError::CloseNotReady`.
+//! 2. The mission must not already be terminal. Otherwise →
+//!    `CliError::TerminalAlreadyComplete`.
+//!
+//! The state mutation is authoritative: `terminal_at` is set through
+//! `state::mutate`, and CLOSEOUT.md is written afterwards. On a crash
+//! between the two, idempotency is preserved — the next `complete` call
+//! hits `TerminalAlreadyComplete` before doing any work.
+
+use serde_json::json;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::core::paths::MissionPaths;
+use crate::state::fs_atomic::atomic_write;
+use crate::state::schema::{LoopMode, LoopState, Phase};
+use crate::state::{self};
+
+use super::check::ReadinessReport;
+use super::closeout;
+
+pub fn run(ctx: &Ctx) -> CliResult<()> {
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let current = state::load(&paths)?;
+
+    if let Some(closed_at) = &current.close.terminal_at {
+        return Err(CliError::TerminalAlreadyComplete {
+            closed_at: closed_at.clone(),
+        });
+    }
+
+    let report = ReadinessReport::from_state(&current);
+    if !report.ready {
+        return Err(CliError::CloseNotReady {
+            message: report.blocker_summary(),
+        });
+    }
+
+    let now = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    if ctx.dry_run {
+        emit_success(
+            &current.mission_id,
+            Some(current.revision),
+            &paths,
+            &now,
+            /*dry_run=*/ true,
+        );
+        return Ok(());
+    }
+
+    let mutation = state::mutate(
+        &paths,
+        ctx.expect_revision,
+        "close.complete",
+        json!({ "terminal_at": now.clone() }),
+        |state| {
+            state.close.terminal_at = Some(now.clone());
+            state.phase = Phase::Terminal;
+            state.loop_ = LoopState {
+                active: false,
+                paused: false,
+                mode: LoopMode::None,
+            };
+            Ok(())
+        },
+    )?;
+
+    let closeout_body = closeout::render(&mutation.state, &paths);
+    atomic_write(&paths.closeout(), closeout_body.as_bytes())?;
+
+    emit_success(
+        &mutation.state.mission_id,
+        Some(mutation.new_revision),
+        &paths,
+        mutation.state.close.terminal_at.as_deref().unwrap_or(&now),
+        /*dry_run=*/ false,
+    );
+    Ok(())
+}
+
+fn emit_success(
+    mission_id: &str,
+    revision: Option<u64>,
+    paths: &MissionPaths,
+    terminal_at: &str,
+    dry_run: bool,
+) {
+    let env = JsonOk::new(
+        Some(mission_id.to_string()),
+        revision,
+        json!({
+            "closeout_path": paths.closeout(),
+            "terminal_at": terminal_at,
+            "mission_id": mission_id,
+            "dry_run": dry_run,
+        }),
+    );
+    println!("{}", env.to_pretty());
+}

--- a/crates/codex1/src/cli/close/mod.rs
+++ b/crates/codex1/src/cli/close/mod.rs
@@ -1,9 +1,44 @@
-//! `codex1 close` stub — owned by Phase B Unit 10.
+//! `codex1 close` — mission-close readiness, mission-close review, terminal close.
+//!
+//! Three subcommands share the same verdict source:
+//!
+//! - `check` — read-only projection of `state::readiness::derive_verdict`
+//!   with a concrete blocker list.
+//! - `record-review` — record the mission-close review outcome (clean or
+//!   findings-file). Dirty reviews increment the shared replan counter
+//!   under the `__mission_close__` target.
+//! - `complete` — idempotent terminal-close transition that writes
+//!   `CLOSEOUT.md`. Fails closed if `check` is not `ready: true`.
+//!
+//! `close check` and `status` call the same `readiness::derive_verdict`
+//! helper: the two CLI surfaces cannot disagree about whether a mission
+//! is ready to close.
+
+use std::path::PathBuf;
 
 use clap::Subcommand;
 
 use crate::cli::Ctx;
-use crate::core::error::{CliError, CliResult};
+use crate::core::error::CliResult;
+
+pub mod check;
+pub mod closeout;
+pub mod complete;
+pub mod record_review;
+
+/// Internal target key for the mission-close review dirty counter.
+pub(crate) const MISSION_CLOSE_TARGET: &str = "__mission_close__";
+
+/// Serialize a unit-variant enum (e.g. `TaskStatus`, `ReviewVerdict`,
+/// `PlanLevel`) to its canonical snake_case string. Relies on the
+/// `serde(rename_all = "snake_case")` pinned by the state schema so the
+/// CLI never drifts from the on-disk vocabulary.
+pub(crate) fn serde_variant<T: serde::Serialize>(value: &T) -> String {
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|v| v.as_str().map(ToString::to_string))
+        .unwrap_or_else(|| "unknown".to_string())
+}
 
 #[derive(Debug, Subcommand)]
 pub enum CloseCmd {
@@ -11,14 +46,28 @@ pub enum CloseCmd {
     Check,
     /// Write CLOSEOUT.md and mark the mission terminal.
     Complete,
+    /// Record the mission-close review outcome (clean or findings-file).
+    RecordReview {
+        /// Mark the mission-close review clean (no P0/P1/P2 findings).
+        #[arg(long, conflicts_with = "findings_file")]
+        clean: bool,
+        /// Path to a markdown file describing P0/P1/P2 findings.
+        #[arg(long, value_name = "PATH")]
+        findings_file: Option<PathBuf>,
+        /// Comma-separated reviewer actor ids recorded in the event payload.
+        #[arg(long, value_name = "LIST")]
+        reviewers: Option<String>,
+    },
 }
 
-pub fn dispatch(cmd: CloseCmd, _ctx: &Ctx) -> CliResult<()> {
-    let label = match cmd {
-        CloseCmd::Check => "close check",
-        CloseCmd::Complete => "close complete",
-    };
-    Err(CliError::NotImplemented {
-        command: label.to_string(),
-    })
+pub fn dispatch(cmd: CloseCmd, ctx: &Ctx) -> CliResult<()> {
+    match cmd {
+        CloseCmd::Check => check::run(ctx),
+        CloseCmd::Complete => complete::run(ctx),
+        CloseCmd::RecordReview {
+            clean,
+            findings_file,
+            reviewers,
+        } => record_review::run(ctx, clean, findings_file, reviewers.as_deref()),
+    }
 }

--- a/crates/codex1/src/cli/close/record_review.rs
+++ b/crates/codex1/src/cli/close/record_review.rs
@@ -1,0 +1,278 @@
+//! `codex1 close record-review --json` — record the mission-close review.
+//!
+//! Clean: sets `state.close.review_state = Passed`.
+//! Dirty: appends the provided findings file into the reviews dir, bumps
+//! `state.replan.consecutive_dirty_by_target["__mission_close__"]`, flips
+//! `state.replan.triggered` if the counter reaches six, and keeps
+//! `review_state = Open` so the next round restarts.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use crate::cli::Ctx;
+use crate::core::envelope::JsonOk;
+use crate::core::error::{CliError, CliResult};
+use crate::core::mission::resolve_mission;
+use crate::core::paths::MissionPaths;
+use crate::state::readiness::Verdict;
+use crate::state::schema::MissionCloseReviewState;
+use crate::state::{self};
+
+use super::check::ReadinessReport;
+use super::{serde_variant, MISSION_CLOSE_TARGET};
+
+/// Six consecutive dirty reviews on the same target triggers replan.
+const DIRTY_REPLAN_THRESHOLD: u32 = 6;
+
+/// Parsed CLI input after validating the clean/findings-file pairing.
+enum Outcome {
+    Clean,
+    Dirty { findings_file: PathBuf },
+}
+
+impl Outcome {
+    fn from_flags(clean: bool, findings_file: Option<PathBuf>) -> CliResult<Self> {
+        match (clean, findings_file) {
+            (true, None) => Ok(Self::Clean),
+            (false, Some(path)) => Ok(Self::Dirty {
+                findings_file: path,
+            }),
+            (true, Some(_)) => Err(CliError::ParseError {
+                message: "pass either --clean or --findings-file, not both".to_string(),
+            }),
+            (false, None) => Err(CliError::ParseError {
+                message: "pass either --clean or --findings-file".to_string(),
+            }),
+        }
+    }
+}
+
+pub fn run(
+    ctx: &Ctx,
+    clean: bool,
+    findings_file: Option<PathBuf>,
+    reviewers_csv: Option<&str>,
+) -> CliResult<()> {
+    let outcome = Outcome::from_flags(clean, findings_file)?;
+    let paths = resolve_mission(&ctx.selector(), true)?;
+    let current = state::load(&paths)?;
+    let reviewers = parse_reviewers(reviewers_csv);
+
+    // Gate: the mission must be in a state where recording a mission-close
+    // review is sensible. We allow both `ready_for_mission_close_review`
+    // (the first attempt, which transitions review_state to Open before
+    // recording) and `mission_close_review_open` (subsequent attempts).
+    let report = ReadinessReport::from_state(&current);
+    if !matches!(
+        report.verdict,
+        Verdict::ReadyForMissionCloseReview | Verdict::MissionCloseReviewOpen
+    ) {
+        return Err(CliError::CloseNotReady {
+            message: format!(
+                "cannot record mission-close review while verdict is `{}` ({})",
+                report.verdict.as_str(),
+                report.blocker_summary()
+            ),
+        });
+    }
+
+    match outcome {
+        Outcome::Clean => record_clean(ctx, &paths, &current, &reviewers),
+        Outcome::Dirty { findings_file } => {
+            record_dirty(ctx, &paths, &current, &findings_file, &reviewers)
+        }
+    }
+}
+
+fn record_clean(
+    ctx: &Ctx,
+    paths: &MissionPaths,
+    current: &state::MissionState,
+    reviewers: &[String],
+) -> CliResult<()> {
+    if ctx.dry_run {
+        emit_success(
+            &current.mission_id,
+            Some(current.revision),
+            "clean",
+            None,
+            reviewers,
+            /*dry_run=*/ true,
+            MissionCloseReviewState::Passed,
+            /*replan_triggered=*/ current.replan.triggered,
+            /*dirty_counter=*/ current_counter(current),
+        );
+        return Ok(());
+    }
+
+    let payload = json!({
+        "verdict": "clean",
+        "reviewers": reviewers,
+    });
+    let mutation = state::mutate(
+        paths,
+        ctx.expect_revision,
+        "close.review.clean",
+        payload,
+        |state| {
+            state.close.review_state = MissionCloseReviewState::Passed;
+            Ok(())
+        },
+    )?;
+
+    emit_success(
+        &mutation.state.mission_id,
+        Some(mutation.new_revision),
+        "clean",
+        None,
+        reviewers,
+        /*dry_run=*/ false,
+        MissionCloseReviewState::Passed,
+        mutation.state.replan.triggered,
+        current_counter(&mutation.state),
+    );
+    Ok(())
+}
+
+fn record_dirty(
+    ctx: &Ctx,
+    paths: &MissionPaths,
+    current: &state::MissionState,
+    findings_source: &Path,
+    reviewers: &[String],
+) -> CliResult<()> {
+    if !findings_source.is_file() {
+        return Err(CliError::ProofMissing {
+            path: findings_source.to_path_buf(),
+        });
+    }
+    let findings_body = std::fs::read_to_string(findings_source)?;
+
+    if ctx.dry_run {
+        // Preview the post-mutation values off the loaded snapshot. Under
+        // contention with another writer the preview may drift, but a
+        // dry-run is advisory by definition.
+        let predicted_revision = current.revision.saturating_add(1);
+        let findings_target = mission_close_review_path(paths, predicted_revision);
+        let predicted_counter = current_counter(current).saturating_add(1);
+        let predicted_trigger =
+            current.replan.triggered || predicted_counter >= DIRTY_REPLAN_THRESHOLD;
+        emit_success(
+            &current.mission_id,
+            Some(current.revision),
+            "dirty",
+            Some(&findings_target),
+            reviewers,
+            /*dry_run=*/ true,
+            MissionCloseReviewState::Open,
+            predicted_trigger,
+            predicted_counter,
+        );
+        return Ok(());
+    }
+
+    // Mutate the state first — it is the authoritative record. If the
+    // findings-file write fails afterwards, a subsequent run will observe
+    // the bumped counter and can prompt the reviewer to resubmit. The
+    // reverse ordering would allow a stale filename to land on disk when
+    // another writer mutated between our load and mutate.
+    std::fs::create_dir_all(paths.reviews_dir())?;
+    let mutation = state::mutate(
+        paths,
+        ctx.expect_revision,
+        "close.review.dirty",
+        json!({
+            "verdict": "dirty",
+            "reviewers": reviewers,
+        }),
+        |state| {
+            let counter = state
+                .replan
+                .consecutive_dirty_by_target
+                .entry(MISSION_CLOSE_TARGET.to_string())
+                .or_insert(0);
+            *counter = counter.saturating_add(1);
+            let hit = *counter >= DIRTY_REPLAN_THRESHOLD;
+            if hit && !state.replan.triggered {
+                state.replan.triggered = true;
+                state.replan.triggered_reason = Some(format!(
+                    "{DIRTY_REPLAN_THRESHOLD} consecutive dirty mission-close reviews"
+                ));
+            }
+            state.close.review_state = MissionCloseReviewState::Open;
+            Ok(())
+        },
+    )?;
+
+    let findings_target = mission_close_review_path(paths, mutation.new_revision);
+    crate::state::fs_atomic::atomic_write(&findings_target, findings_body.as_bytes())?;
+
+    emit_success(
+        &mutation.state.mission_id,
+        Some(mutation.new_revision),
+        "dirty",
+        Some(&findings_target),
+        reviewers,
+        /*dry_run=*/ false,
+        MissionCloseReviewState::Open,
+        mutation.state.replan.triggered,
+        current_counter(&mutation.state),
+    );
+    Ok(())
+}
+
+fn current_counter(state: &state::MissionState) -> u32 {
+    state
+        .replan
+        .consecutive_dirty_by_target
+        .get(MISSION_CLOSE_TARGET)
+        .copied()
+        .unwrap_or(0)
+}
+
+pub(crate) fn mission_close_review_path(paths: &MissionPaths, revision: u64) -> PathBuf {
+    paths
+        .reviews_dir()
+        .join(format!("mission-close-{revision}.md"))
+}
+
+fn parse_reviewers(csv: Option<&str>) -> Vec<String> {
+    match csv {
+        None => Vec::new(),
+        Some(raw) => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .collect(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_success(
+    mission_id: &str,
+    revision: Option<u64>,
+    verdict: &str,
+    findings_file: Option<&Path>,
+    reviewers: &[String],
+    dry_run: bool,
+    review_state: MissionCloseReviewState,
+    replan_triggered: bool,
+    dirty_counter: u32,
+) {
+    let env = JsonOk::new(
+        Some(mission_id.to_string()),
+        revision,
+        json!({
+            "verdict": verdict,
+            "review_state": serde_variant(&review_state),
+            "reviewers": reviewers,
+            "findings_file": findings_file.map(Path::to_path_buf),
+            "consecutive_dirty": dirty_counter,
+            "replan_triggered": replan_triggered,
+            "dry_run": dry_run,
+        }),
+    );
+    println!("{}", env.to_pretty());
+}

--- a/crates/codex1/tests/close.rs
+++ b/crates/codex1/tests/close.rs
@@ -1,0 +1,886 @@
+//! Integration tests for `codex1 close check`, `close complete`, and
+//! `close record-review`.
+//!
+//! States are seeded by writing `STATE.json` directly because other Phase
+//! B units (outcome/plan/task/review) are not yet merged. These tests
+//! exercise only the `close` surface; downstream-unit tests will cover
+//! their own mutations.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_demo(tmp: &TempDir, mission: &str) -> PathBuf {
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", mission])
+        .assert()
+        .success();
+    tmp.path().join("PLANS").join(mission)
+}
+
+fn write_state(mission_dir: &Path, state: &Value) {
+    let bytes = serde_json::to_vec_pretty(state).expect("serialize state");
+    fs::write(mission_dir.join("STATE.json"), bytes).expect("write STATE.json");
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    let raw = fs::read_to_string(mission_dir.join("STATE.json")).expect("read STATE.json");
+    serde_json::from_str(&raw).expect("parse STATE.json")
+}
+
+fn read_events(mission_dir: &Path) -> Vec<Value> {
+    let raw = fs::read_to_string(mission_dir.join("EVENTS.jsonl")).unwrap_or_default();
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("parse event"))
+        .collect()
+}
+
+fn parse_stdout(output: &std::process::Output) -> Value {
+    let stdout = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str(stdout).unwrap_or_else(|e| {
+        panic!("expected JSON stdout, got:\n{stdout}\nerror: {e}");
+    })
+}
+
+fn write_findings(mission_dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = mission_dir.join(name);
+    fs::write(&path, body).expect("write findings");
+    path
+}
+
+/// Builder for seeding `STATE.json` into common configurations.
+struct StateBuilder {
+    value: Value,
+}
+
+impl StateBuilder {
+    fn fresh(mission_id: &str) -> Self {
+        Self {
+            value: json!({
+                "mission_id": mission_id,
+                "revision": 0,
+                "schema_version": 1,
+                "phase": "clarify",
+                "loop": { "active": false, "paused": false, "mode": "none" },
+                "outcome": { "ratified": false },
+                "plan": { "locked": false },
+                "tasks": {},
+                "reviews": {},
+                "replan": { "consecutive_dirty_by_target": {}, "triggered": false },
+                "close": { "review_state": "not_started" },
+                "events_cursor": 0
+            }),
+        }
+    }
+
+    fn ratified(mut self) -> Self {
+        self.value["outcome"] = json!({
+            "ratified": true,
+            "ratified_at": "2026-04-20T00:00:00Z"
+        });
+        self
+    }
+
+    fn plan_locked(mut self) -> Self {
+        self.value["plan"] = json!({
+            "locked": true,
+            "requested_level": "medium",
+            "effective_level": "medium"
+        });
+        self
+    }
+
+    fn phase(mut self, phase: &str) -> Self {
+        self.value["phase"] = Value::String(phase.to_string());
+        self
+    }
+
+    fn task(mut self, id: &str, status: &str) -> Self {
+        self.value["tasks"][id] = json!({
+            "id": id,
+            "status": status,
+            "proof_path": if status == "complete" {
+                Value::String(format!("specs/{id}/PROOF.md"))
+            } else {
+                Value::Null
+            },
+            "superseded_by": Value::Null,
+        });
+        self
+    }
+
+    fn review(mut self, id: &str, verdict: &str) -> Self {
+        self.value["reviews"][id] = json!({
+            "task_id": id,
+            "verdict": verdict,
+            "reviewers": ["ci"],
+            "category": "accepted_current",
+            "recorded_at": "2026-04-20T00:00:00Z",
+            "boundary_revision": 1,
+        });
+        self
+    }
+
+    fn mission_close_review(mut self, state: &str) -> Self {
+        self.value["close"]["review_state"] = Value::String(state.to_string());
+        self
+    }
+
+    fn replan_triggered(mut self, reason: &str) -> Self {
+        self.value["replan"]["triggered"] = Value::Bool(true);
+        self.value["replan"]["triggered_reason"] = Value::String(reason.to_string());
+        self
+    }
+
+    fn terminal(mut self, at: &str) -> Self {
+        self.value["close"]["terminal_at"] = Value::String(at.to_string());
+        self.value["phase"] = Value::String("terminal".to_string());
+        self
+    }
+
+    fn revision(mut self, rev: u64) -> Self {
+        self.value["revision"] = Value::Number(rev.into());
+        self
+    }
+
+    fn build(self) -> Value {
+        self.value
+    }
+}
+
+/// Convenience: fresh mission brought through ratify+plan+task completion.
+fn seed_ready_for_mission_close_review(mission_dir: &Path) {
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .phase("mission_close")
+        .task("T1", "complete")
+        .task("T2", "complete")
+        .review("T2", "clean")
+        .revision(5)
+        .build();
+    write_state(mission_dir, &state);
+}
+
+// ---------------------------------------------------------------------------
+// check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_fresh_mission_reports_outcome_not_ratified() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["ready"], Value::Bool(false));
+    assert_eq!(json["data"]["verdict"], "needs_user");
+    let blockers = json["data"]["blockers"].as_array().unwrap();
+    assert!(
+        blockers.iter().any(|b| b["code"] == "OUTCOME_NOT_RATIFIED"),
+        "missing OUTCOME_NOT_RATIFIED: {blockers:?}"
+    );
+    // mission_dir is unused — silence the let-binding.
+    let _ = mission_dir;
+}
+
+#[test]
+fn check_mid_execute_reports_task_not_ready_and_continue_required() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .phase("execute")
+        .task("T1", "complete")
+        .task("T7", "pending")
+        .build();
+    write_state(&mission_dir, &state);
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["ready"], Value::Bool(false));
+    assert_eq!(json["data"]["verdict"], "continue_required");
+    let blockers = json["data"]["blockers"].as_array().unwrap();
+    assert!(
+        blockers
+            .iter()
+            .any(|b| b["code"] == "TASK_NOT_READY" && b["detail"].as_str().unwrap().contains("T7")),
+        "blockers missing T7 TASK_NOT_READY: {blockers:?}"
+    );
+}
+
+#[test]
+fn check_all_tasks_complete_but_no_mission_close_review_reports_ready_for_review() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_ready_for_mission_close_review(&mission_dir);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["verdict"], "ready_for_mission_close_review");
+    assert_eq!(json["data"]["ready"], Value::Bool(false));
+    let blockers = json["data"]["blockers"].as_array().unwrap();
+    assert!(
+        blockers.iter().any(|b| b["code"] == "CLOSE_NOT_READY"),
+        "missing CLOSE_NOT_READY blocker: {blockers:?}"
+    );
+}
+
+#[test]
+fn check_review_dirty_reports_review_findings_block() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .phase("review_loop")
+        .task("T1", "complete")
+        .review("T5", "dirty")
+        .build();
+    write_state(&mission_dir, &state);
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["verdict"], "blocked");
+    let blockers = json["data"]["blockers"].as_array().unwrap();
+    assert!(
+        blockers.iter().any(|b| b["code"] == "REVIEW_FINDINGS_BLOCK"
+            && b["detail"].as_str().unwrap().contains("T5")),
+        "missing REVIEW_FINDINGS_BLOCK T5: {blockers:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// record-review
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_review_clean_transitions_state_to_passed() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_ready_for_mission_close_review(&mission_dir);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "close",
+            "record-review",
+            "--clean",
+            "--mission",
+            "demo",
+            "--reviewers",
+            "alice,bob",
+        ])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["verdict"], "clean");
+    assert_eq!(json["data"]["review_state"], "passed");
+    assert_eq!(json["data"]["dry_run"], false);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["close"]["review_state"], "passed");
+
+    let events = read_events(&mission_dir);
+    assert!(events.iter().any(|e| e["kind"] == "close.review.clean"));
+}
+
+#[test]
+fn check_after_review_clean_reports_mission_close_review_passed_and_ready() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_ready_for_mission_close_review(&mission_dir);
+
+    cmd()
+        .current_dir(tmp.path())
+        .args(["close", "record-review", "--clean", "--mission", "demo"])
+        .assert()
+        .success();
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "check", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["verdict"], "mission_close_review_passed");
+    assert_eq!(json["data"]["ready"], Value::Bool(true));
+    assert_eq!(json["data"]["blockers"].as_array().map_or(0, Vec::len), 0);
+}
+
+#[test]
+fn record_review_findings_writes_review_file_and_bumps_counter() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_ready_for_mission_close_review(&mission_dir);
+    let findings = write_findings(&mission_dir, "round1.md", "# P0: broke everything\n");
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "close",
+            "record-review",
+            "--findings-file",
+            findings.to_str().unwrap(),
+            "--mission",
+            "demo",
+        ])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["verdict"], "dirty");
+    assert_eq!(json["data"]["review_state"], "open");
+    assert_eq!(json["data"]["consecutive_dirty"], 1);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["close"]["review_state"], "open");
+    assert_eq!(
+        state["replan"]["consecutive_dirty_by_target"]["__mission_close__"],
+        1
+    );
+    let events = read_events(&mission_dir);
+    assert!(events.iter().any(|e| e["kind"] == "close.review.dirty"));
+    // A review artifact was written under reviews/.
+    let entries: Vec<_> = fs::read_dir(mission_dir.join("reviews"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().into_string().unwrap())
+        .filter(|n| n.starts_with("mission-close-"))
+        .collect();
+    assert!(
+        !entries.is_empty(),
+        "expected at least one mission-close review file under reviews/: {entries:?}"
+    );
+}
+
+#[test]
+fn record_review_six_consecutive_dirty_triggers_replan() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_ready_for_mission_close_review(&mission_dir);
+    let findings = write_findings(&mission_dir, "r.md", "# P0 fail\n");
+
+    for _ in 0..6 {
+        cmd()
+            .current_dir(tmp.path())
+            .args([
+                "close",
+                "record-review",
+                "--findings-file",
+                findings.to_str().unwrap(),
+                "--mission",
+                "demo",
+            ])
+            .assert()
+            .success();
+    }
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["replan"]["triggered"], true);
+    assert_eq!(
+        state["replan"]["consecutive_dirty_by_target"]["__mission_close__"],
+        6
+    );
+
+    // The 7th attempt should fail closed because the verdict is now `blocked`.
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "close",
+            "record-review",
+            "--findings-file",
+            findings.to_str().unwrap(),
+            "--mission",
+            "demo",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["code"], "CLOSE_NOT_READY");
+}
+
+#[test]
+fn record_review_rejects_when_verdict_is_not_mission_close_ready() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    // Mid-execute: not yet ready for mission-close review.
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .task("T1", "pending")
+        .build();
+    write_state(&mission_dir, &state);
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "record-review", "--clean", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["code"], "CLOSE_NOT_READY");
+}
+
+#[test]
+fn record_review_dry_run_does_not_mutate() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_ready_for_mission_close_review(&mission_dir);
+    let before = read_state(&mission_dir);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "close",
+            "record-review",
+            "--clean",
+            "--mission",
+            "demo",
+            "--dry-run",
+        ])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["dry_run"], true);
+
+    let after = read_state(&mission_dir);
+    assert_eq!(before, after, "dry-run must not mutate STATE.json");
+    assert!(
+        read_events(&mission_dir).is_empty(),
+        "dry-run must not append events"
+    );
+}
+
+#[test]
+fn record_review_expect_revision_mismatch_returns_conflict() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    seed_ready_for_mission_close_review(&mission_dir); // revision = 5.
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "close",
+            "record-review",
+            "--clean",
+            "--mission",
+            "demo",
+            "--expect-revision",
+            "99",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+    assert_eq!(json["context"]["expected"], 99);
+    assert_eq!(json["context"]["actual"], 5);
+}
+
+// ---------------------------------------------------------------------------
+// complete
+// ---------------------------------------------------------------------------
+
+#[test]
+fn complete_on_ready_writes_closeout_and_marks_terminal() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    // Seed with interpreted_destination in OUTCOME so we can assert it
+    // shows up in CLOSEOUT.md.
+    fs::write(
+        mission_dir.join("OUTCOME.md"),
+        "---\nmission_id: demo\nstatus: ratified\ninterpreted_destination: |\n  Build a robust close surface.\n---\n\n# OUTCOME\n",
+    )
+    .unwrap();
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .phase("mission_close")
+        .task("T1", "complete")
+        .review("T2", "clean")
+        .mission_close_review("passed")
+        .revision(7)
+        .build();
+    write_state(&mission_dir, &state);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "complete", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert!(json["data"]["terminal_at"].is_string());
+    assert_eq!(json["data"]["mission_id"], "demo");
+    assert_eq!(json["data"]["dry_run"], false);
+
+    let closeout = fs::read_to_string(mission_dir.join("CLOSEOUT.md")).unwrap();
+    assert!(
+        closeout.contains("CLOSEOUT — demo"),
+        "closeout missing header: {closeout}"
+    );
+    assert!(
+        closeout.contains("Build a robust close surface."),
+        "closeout missing interpreted_destination excerpt: {closeout}"
+    );
+    assert!(closeout.contains("| T1 |"));
+    assert!(closeout.contains("| T2 |"));
+    assert!(closeout.contains("| MC |"));
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["phase"], "terminal");
+    assert!(state["close"]["terminal_at"].is_string());
+    assert_eq!(state["loop"]["active"], false);
+    assert_eq!(state["loop"]["paused"], false);
+    assert_eq!(state["loop"]["mode"], "none");
+
+    let events = read_events(&mission_dir);
+    assert!(events.iter().any(|e| e["kind"] == "close.complete"));
+}
+
+#[test]
+fn complete_twice_returns_terminal_already_complete() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .task("T1", "complete")
+        .mission_close_review("passed")
+        .terminal("2026-04-01T00:00:00Z")
+        .revision(9)
+        .build();
+    write_state(&mission_dir, &state);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "complete", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["code"], "TERMINAL_ALREADY_COMPLETE");
+    assert_eq!(json["context"]["closed_at"], "2026-04-01T00:00:00Z");
+}
+
+#[test]
+fn complete_when_not_ready_returns_close_not_ready_with_blockers() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .task("T1", "pending")
+        .build();
+    write_state(&mission_dir, &state);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "complete", "--mission", "demo"])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["code"], "CLOSE_NOT_READY");
+    let message = json["message"].as_str().unwrap();
+    assert!(
+        message.contains("TASK_NOT_READY") || message.contains("T1"),
+        "message should mention blockers: {message}"
+    );
+}
+
+#[test]
+fn complete_dry_run_does_not_mutate() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .task("T1", "complete")
+        .mission_close_review("passed")
+        .revision(6)
+        .build();
+    write_state(&mission_dir, &state);
+    let before = read_state(&mission_dir);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args(["close", "complete", "--mission", "demo", "--dry-run"])
+        .output()
+        .expect("runs");
+    assert!(output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["data"]["dry_run"], true);
+    assert!(json["data"]["terminal_at"].is_string());
+
+    let after = read_state(&mission_dir);
+    assert_eq!(before, after, "dry-run must not mutate STATE.json");
+    assert!(
+        !mission_dir.join("CLOSEOUT.md").exists(),
+        "dry-run must not write CLOSEOUT.md"
+    );
+    assert!(
+        read_events(&mission_dir).is_empty(),
+        "dry-run must not append events"
+    );
+}
+
+#[test]
+fn complete_expect_revision_mismatch_returns_conflict() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let state = StateBuilder::fresh("demo")
+        .ratified()
+        .plan_locked()
+        .task("T1", "complete")
+        .mission_close_review("passed")
+        .revision(6)
+        .build();
+    write_state(&mission_dir, &state);
+
+    let output = cmd()
+        .current_dir(tmp.path())
+        .args([
+            "close",
+            "complete",
+            "--mission",
+            "demo",
+            "--expect-revision",
+            "1",
+        ])
+        .output()
+        .expect("runs");
+    assert!(!output.status.success());
+    let json = parse_stdout(&output);
+    assert_eq!(json["code"], "REVISION_CONFLICT");
+    assert_eq!(json["context"]["expected"], 1);
+    assert_eq!(json["context"]["actual"], 6);
+}
+
+// ---------------------------------------------------------------------------
+// Property: close check and status always agree on close_ready / verdict.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn status_and_close_check_always_agree() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_demo(&tmp, "demo");
+    let cases = agreement_cases();
+    assert!(
+        cases.len() >= 20,
+        "need at least 20 states for agreement property"
+    );
+    for (idx, case) in cases.iter().enumerate() {
+        write_state(&mission_dir, case);
+        let status = cmd()
+            .current_dir(tmp.path())
+            .args(["status", "--mission", "demo"])
+            .output()
+            .expect("status runs");
+        assert!(
+            status.status.success(),
+            "status failed on case {idx}: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+        let s = parse_stdout(&status);
+
+        let check = cmd()
+            .current_dir(tmp.path())
+            .args(["close", "check", "--mission", "demo"])
+            .output()
+            .expect("close check runs");
+        assert!(
+            check.status.success(),
+            "close check failed on case {idx}: {}",
+            String::from_utf8_lossy(&check.stderr)
+        );
+        let c = parse_stdout(&check);
+
+        let status_verdict = s["data"]["verdict"].as_str().unwrap_or("").to_string();
+        let check_verdict = c["data"]["verdict"].as_str().unwrap_or("").to_string();
+        assert_eq!(
+            status_verdict, check_verdict,
+            "verdict disagreement on case {idx}: status={status_verdict}, check={check_verdict}"
+        );
+
+        let status_ready = s["data"]["close_ready"].as_bool().unwrap_or(false);
+        let check_ready = c["data"]["ready"].as_bool().unwrap_or(false);
+        assert_eq!(
+            status_ready, check_ready,
+            "close_ready disagreement on case {idx}: status={status_ready}, check={check_ready}"
+        );
+    }
+}
+
+/// Deterministic fixture set of 24 states covering every readiness branch:
+/// fresh, ratified only, plan locked, replan triggered, dirty review,
+/// incomplete tasks, all tasks complete in each mission-close review
+/// substate, terminal, and several combinations.
+fn agreement_cases() -> Vec<Value> {
+    vec![
+        StateBuilder::fresh("demo").build(),
+        StateBuilder::fresh("demo").ratified().build(),
+        StateBuilder::fresh("demo").ratified().plan_locked().build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "pending")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "in_progress")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "ready")
+            .task("T2", "pending")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .task("T2", "awaiting_review")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .task("T2", "superseded")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .review("T1", "dirty")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .review("T1", "clean")
+            .replan_triggered("six dirty on T1")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .task("T2", "complete")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .mission_close_review("open")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .mission_close_review("passed")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .mission_close_review("passed")
+            .terminal("2026-04-10T00:00:00Z")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .task("T2", "ready")
+            .mission_close_review("passed")
+            .build(),
+        StateBuilder::fresh("demo")
+            .plan_locked() // outcome not ratified
+            .task("T1", "complete")
+            .mission_close_review("passed")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified() // plan not locked
+            .task("T1", "complete")
+            .mission_close_review("passed")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .review("T1", "clean")
+            .review("T2", "dirty")
+            .mission_close_review("open")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .review("T1", "pending")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .task("T2", "complete")
+            .task("T3", "complete")
+            .task("T4", "complete")
+            .mission_close_review("open")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .replan_triggered("manual")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "superseded")
+            .task("T2", "complete")
+            .mission_close_review("passed")
+            .build(),
+        StateBuilder::fresh("demo")
+            .ratified()
+            .plan_locked()
+            .task("T1", "complete")
+            .mission_close_review("not_started") // same as default, but explicit
+            .build(),
+    ]
+}


### PR DESCRIPTION
## Summary

- Wires up `codex1 close check --json`, `codex1 close complete --json`, and a new `codex1 close record-review --json` for the mission-close review lifecycle.
- `close check` and `status` now share the Foundation-owned `readiness::derive_verdict` helper, with a property test over 24 seeded states asserting the two surfaces never drift on `verdict` or `close_ready`.
- `record-review` records the mission-close review under the `__mission_close__` replan-counter target; six consecutive dirty rounds trip `replan.triggered`. `complete` fails closed when `check` is not `ready: true`, is idempotent via `TerminalAlreadyComplete`, and writes a `CLOSEOUT.md` summary pulling `interpreted_destination` from OUTCOME.md.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (30 tests: 17 new in `tests/close.rs` + 13 foundation)
- [x] Property test in `tests/close.rs::status_and_close_check_always_agree` covers 24 distinct states (fresh, mid-execute, review dirty, replan triggered, every mission-close review substate, terminal, and combinations).
- [x] `--dry-run` and `--expect-revision` exercised for both `record-review` and `complete`.

## Notes

- The only Foundation file touched is `crates/codex1/src/cli/close/mod.rs`, preserving the `CloseCmd::Check`/`Complete` variants and adding `RecordReview` as specified.
- `record-review --findings-file` mutates state first, then writes the artifact under `reviews/mission-close-<revision>.md` using the authoritative post-mutation revision, so a contended write cannot produce a stale filename that disagrees with the dirty-counter bump.

Generated with Claude Code.