### PR TITLE
Unit 20: e2e integration tests

### DIFF
--- a/crates/codex1/tests/e2e_full_mission.rs
+++ b/crates/codex1/tests/e2e_full_mission.rs
@@ -1,0 +1,492 @@
+//! End-to-end full-mission integration test.
+//!
+//! Drives one complete mission through every public CLI surface:
+//! init -> outcome ratify -> plan choose-level/scaffold/check/waves ->
+//! task start/finish (for work tasks) -> review start/record ->
+//! close check/record-review/complete -> status terminal_complete.
+//!
+//! The test uses only `assert_cmd::Command::cargo_bin("codex1")` —
+//! internals are never stubbed. STATE.json is read only as an oracle
+//! for `revision` monotonicity and phase assertions; the only direct
+//! file writes are to user-owned fixtures (OUTCOME.md, PLAN.yaml,
+//! SPEC.md, PROOF.md) that the CLI consumes.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use tempfile::TempDir;
+
+const MISSION: &str = "demo";
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn parse(output: &std::process::Output) -> Value {
+    let s = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(s).unwrap_or_else(|e| panic!("bad JSON:\n{s}\n{e}"))
+}
+
+fn run_ok(cwd: &Path, args: &[&str]) -> Value {
+    let out = cmd().current_dir(cwd).args(args).output().expect("runs");
+    assert!(
+        out.status.success(),
+        "expected success ({args:?}); stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    parse(&out)
+}
+
+fn run_err(cwd: &Path, args: &[&str]) -> Value {
+    let out = cmd().current_dir(cwd).args(args).output().expect("runs");
+    assert!(
+        !out.status.success(),
+        "expected failure ({args:?}); stdout: {}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    parse(&out)
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(mission_dir.join("STATE.json")).unwrap()).unwrap()
+}
+
+fn read_events(mission_dir: &Path) -> Vec<Value> {
+    fs::read_to_string(mission_dir.join("EVENTS.jsonl"))
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("event line is JSON"))
+        .collect()
+}
+
+fn write_fixture(path: &Path, body: &str) {
+    if let Some(p) = path.parent() {
+        fs::create_dir_all(p).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+const INTERPRETED_DEST: &str =
+    "Codex1 drives the full mission flow from clarify to terminal close without manual patches.";
+
+fn seed_outcome(mission_dir: &Path) {
+    let body = format!(
+        r"---
+mission_id: {MISSION}
+status: draft
+title: Full mission e2e fixture
+
+original_user_goal: |
+  Exercise the entire codex1 CLI surface with a single ratified plan.
+
+interpreted_destination: |
+  {INTERPRETED_DEST}
+
+must_be_true:
+  - The mission ratifies, plans, executes, reviews, and closes via CLI alone.
+  - Every mutation increments STATE.json.revision by one.
+
+success_criteria:
+  - codex1 close complete writes a CLOSEOUT.md that mentions every task.
+  - codex1 status reports terminal_complete with stop.allow true.
+
+non_goals:
+  - Do not cover cli-creator ergonomics; tests exercise only the Phase B surface.
+
+constraints:
+  - Use tempfile-backed mission directories.
+  - No direct writes to STATE.json.
+
+quality_bar:
+  - Tests fail closed on any non-zero exit from a CLI step.
+
+proof_expectations:
+  - cargo test --test e2e_full_mission passes.
+
+review_expectations:
+  - A planned review task covers the parallel work wave.
+
+known_risks:
+  - CLI behavior drift between Phase B units could break the chained flow.
+
+resolved_questions:
+  - question: Does phase auto-advance to mission_close?
+    answer: No, verdict keys off task completion, not the phase field.
+---
+
+# OUTCOME
+
+End-to-end fixture body.
+"
+    );
+    write_fixture(&mission_dir.join("OUTCOME.md"), &body);
+}
+
+/// A 5-task plan: T1 root, T2/T3 parallel under T1, T4 joins T2/T3,
+/// T5 reviews [T2,T3]. Matches the Unit 20 brief shape.
+const PLAN_YAML: &str = r"mission_id: demo
+
+planning_level:
+  requested: medium
+  effective: medium
+
+outcome_interpretation:
+  summary: Exercise the full CLI lifecycle end-to-end.
+
+architecture:
+  summary: Single crate; CLI-driven mission.
+  key_decisions:
+    - Drive every subcommand through assert_cmd.
+
+planning_process:
+  evidence:
+    - kind: direct_reasoning
+      summary: Author-designed fixture with explicit DAG.
+
+tasks:
+  - id: T1
+    title: Root setup
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+    write_paths:
+      - src/T1/**
+    proof:
+      - cargo test T1
+  - id: T2
+    title: Branch A
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+    write_paths:
+      - src/T2/**
+    proof:
+      - cargo test T2
+  - id: T3
+    title: Branch B
+    kind: code
+    depends_on: [T1]
+    spec: specs/T3/SPEC.md
+    write_paths:
+      - src/T3/**
+    proof:
+      - cargo test T3
+  - id: T4
+    title: Join
+    kind: code
+    depends_on: [T2, T3]
+    spec: specs/T4/SPEC.md
+    write_paths:
+      - src/T4/**
+    proof:
+      - cargo test T4
+  - id: T5
+    title: Review of branches
+    kind: review
+    depends_on: [T2, T3]
+    spec: specs/T5/SPEC.md
+    review_target:
+      tasks: [T2, T3]
+    review_profiles:
+      - code_bug_correctness
+      - local_spec_intent
+
+risks:
+  - risk: CLI drift between units
+    mitigation: Run this test in CI.
+
+mission_close:
+  criteria:
+    - All tasks complete and reviews clean.
+";
+
+fn seed_plan(mission_dir: &Path) {
+    write_fixture(&mission_dir.join("PLAN.yaml"), PLAN_YAML);
+    for tid in ["T1", "T2", "T3", "T4", "T5"] {
+        write_fixture(
+            &mission_dir.join("specs").join(tid).join("SPEC.md"),
+            &format!("# Spec for {tid}\n\nDo the {tid} work.\n"),
+        );
+    }
+}
+
+fn write_proof(mission_dir: &Path, task_id: &str) -> String {
+    let rel = format!("specs/{task_id}/PROOF.md");
+    write_fixture(
+        &mission_dir.join(&rel),
+        &format!("# Proof for {task_id}\n\ncargo test {task_id}\n"),
+    );
+    rel
+}
+
+fn finish_work_task(cwd: &Path, mission_dir: &Path, task_id: &str) -> Value {
+    run_ok(cwd, &["task", "start", task_id, "--mission", MISSION]);
+    let proof = write_proof(mission_dir, task_id);
+    run_ok(
+        cwd,
+        &[
+            "task",
+            "finish",
+            task_id,
+            "--proof",
+            &proof,
+            "--mission",
+            MISSION,
+        ],
+    )
+}
+
+fn assert_events_monotonic(mission_dir: &Path) -> u64 {
+    let events = read_events(mission_dir);
+    assert!(!events.is_empty(), "expected at least one event");
+    let mut last: Option<u64> = None;
+    for ev in &events {
+        let seq = ev["seq"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("event missing seq field: {ev}"));
+        if let Some(prev) = last {
+            assert!(
+                seq > prev,
+                "seq not strictly increasing: prev={prev}, now={seq}, ev={ev}"
+            );
+        }
+        last = Some(seq);
+    }
+    last.unwrap()
+}
+
+#[test]
+fn e2e_full_mission_drives_every_phase_to_terminal_complete() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = tmp.path().join("PLANS").join(MISSION);
+
+    // 1. init
+    run_ok(tmp.path(), &["init", "--mission", MISSION]);
+    let state = read_state(&mission_dir);
+    assert_eq!(state["revision"], 0);
+    assert_eq!(state["phase"], "clarify");
+    assert_eq!(state["outcome"]["ratified"], false);
+
+    // 2. Seed a fully-filled OUTCOME.md.
+    seed_outcome(&mission_dir);
+
+    // 3. outcome check → ratifiable.
+    let check = run_ok(tmp.path(), &["outcome", "check", "--mission", MISSION]);
+    assert_eq!(check["data"]["ratifiable"], true);
+    assert_eq!(check["data"]["missing_fields"].as_array().unwrap().len(), 0);
+    assert_eq!(check["data"]["placeholders"].as_array().unwrap().len(), 0);
+
+    // 4. outcome ratify → phase transitions to plan.
+    let ratified = run_ok(tmp.path(), &["outcome", "ratify", "--mission", MISSION]);
+    assert_eq!(ratified["data"]["phase"], "plan");
+    assert!(ratified["data"]["ratified_at"].is_string());
+    let rev_after_ratify = ratified["revision"].as_u64().unwrap();
+    assert!(rev_after_ratify > 0, "ratify must bump revision");
+
+    // 5. plan choose-level
+    let chosen = run_ok(
+        tmp.path(),
+        &[
+            "plan",
+            "choose-level",
+            "--mission",
+            MISSION,
+            "--level",
+            "medium",
+        ],
+    );
+    assert_eq!(chosen["data"]["requested_level"], "medium");
+    assert_eq!(chosen["data"]["effective_level"], "medium");
+    let state = read_state(&mission_dir);
+    assert_eq!(state["plan"]["requested_level"], "medium");
+    assert_eq!(state["plan"]["effective_level"], "medium");
+
+    // 6. plan scaffold writes a skeleton PLAN.yaml.
+    let scaffolded = run_ok(
+        tmp.path(),
+        &[
+            "plan",
+            "scaffold",
+            "--mission",
+            MISSION,
+            "--level",
+            "medium",
+        ],
+    );
+    assert!(scaffolded["data"]["wrote"]
+        .as_str()
+        .unwrap()
+        .ends_with("PLAN.yaml"));
+    assert!(fs::read_to_string(mission_dir.join("PLAN.yaml"))
+        .unwrap()
+        .contains("[codex1-fill:"));
+
+    // 7. Overwrite with the real 5-task DAG and per-task SPEC.md files.
+    seed_plan(&mission_dir);
+
+    // 8. plan check → locks plan, advances phase to execute, appends event.
+    let checked = run_ok(tmp.path(), &["plan", "check", "--mission", MISSION]);
+    assert_eq!(checked["data"]["tasks"], 5);
+    assert_eq!(checked["data"]["review_tasks"], 1);
+    assert_eq!(checked["data"]["locked"], true);
+    let state = read_state(&mission_dir);
+    assert_eq!(state["plan"]["locked"], true);
+    assert_eq!(state["phase"], "execute");
+
+    // 9. plan waves --json derives the expected set of waves.
+    let waves = run_ok(
+        tmp.path(),
+        &["plan", "waves", "--mission", MISSION, "--json"],
+    );
+    let wave_list = waves["data"]["waves"].as_array().expect("waves array");
+    assert!(
+        wave_list.len() >= 2,
+        "expected multi-wave derivation, got {wave_list:?}"
+    );
+    assert_eq!(wave_list[0]["tasks"], serde_json::json!(["T1"]));
+    let w2: BTreeSet<String> = wave_list[1]["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        w2,
+        BTreeSet::from(["T2".to_string(), "T3".to_string()]),
+        "W2 should contain T2 and T3"
+    );
+    // T4 and T5 must appear in some wave after W2 (they depend on T2, T3).
+    let later_ids: BTreeSet<String> = wave_list
+        .iter()
+        .skip(2)
+        .flat_map(|w| w["tasks"].as_array().unwrap())
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    for tid in ["T4", "T5"] {
+        assert!(
+            later_ids.contains(tid),
+            "{tid} missing from later waves: {later_ids:?}"
+        );
+    }
+    assert_eq!(waves["data"]["current_ready_wave"], "W1");
+    assert_eq!(waves["data"]["all_tasks_complete"], false);
+
+    // 10-11. Run T1 (-> Complete), then T2/T3 (-> AwaitingReview since T5 targets them).
+    assert_eq!(
+        finish_work_task(tmp.path(), &mission_dir, "T1")["data"]["status"],
+        "complete"
+    );
+    for tid in ["T2", "T3"] {
+        let r = finish_work_task(tmp.path(), &mission_dir, tid);
+        assert_eq!(r["data"]["status"], "awaiting_review", "T={tid}");
+    }
+
+    // 12. Planned review T5 → clean → T2, T3 flip to Complete.
+    run_ok(tmp.path(), &["review", "start", "T5", "--mission", MISSION]);
+    let reviewed = run_ok(
+        tmp.path(),
+        &[
+            "review",
+            "record",
+            "T5",
+            "--clean",
+            "--reviewers",
+            "alice,bob",
+            "--mission",
+            MISSION,
+        ],
+    );
+    assert_eq!(reviewed["data"]["verdict"], "clean");
+    assert_eq!(reviewed["data"]["category"], "accepted_current");
+    let reviewers = reviewed["data"]["reviewers"].as_array().unwrap();
+    assert_eq!(reviewers.len(), 2);
+    let state = read_state(&mission_dir);
+    assert_eq!(state["tasks"]["T2"]["status"], "complete");
+    assert_eq!(state["tasks"]["T3"]["status"], "complete");
+
+    // 13. Run T4 (work) through start + finish; no review targets it.
+    let t4 = finish_work_task(tmp.path(), &mission_dir, "T4");
+    assert_eq!(t4["data"]["status"], "complete");
+
+    // 14. status reports ready_for_mission_close_review.
+    let status = run_ok(tmp.path(), &["status", "--mission", MISSION]);
+    assert_eq!(status["data"]["verdict"], "ready_for_mission_close_review");
+    assert_eq!(status["data"]["close_ready"], false);
+    assert_eq!(
+        status["data"]["next_action"]["kind"],
+        "mission_close_review"
+    );
+
+    // 15. close record-review --clean transitions review_state → passed.
+    let close_review = run_ok(
+        tmp.path(),
+        &[
+            "close",
+            "record-review",
+            "--clean",
+            "--reviewers",
+            "carol,dan",
+            "--mission",
+            MISSION,
+        ],
+    );
+    assert_eq!(close_review["data"]["review_state"], "passed");
+    assert_eq!(close_review["data"]["verdict"], "clean");
+    let state = read_state(&mission_dir);
+    assert_eq!(state["close"]["review_state"], "passed");
+
+    // 16. close check → ready: true.
+    let ready = run_ok(tmp.path(), &["close", "check", "--mission", MISSION]);
+    assert_eq!(ready["data"]["ready"], true);
+    assert_eq!(ready["data"]["verdict"], "mission_close_review_passed");
+    assert_eq!(ready["data"]["blockers"].as_array().unwrap().len(), 0);
+
+    // 17. close complete writes CLOSEOUT.md and marks terminal.
+    let closed = run_ok(tmp.path(), &["close", "complete", "--mission", MISSION]);
+    assert!(closed["data"]["terminal_at"].is_string());
+    assert_eq!(closed["data"]["mission_id"], MISSION);
+    let state = read_state(&mission_dir);
+    assert_eq!(state["phase"], "terminal");
+    assert!(state["close"]["terminal_at"].is_string());
+    let final_revision = state["revision"].as_u64().unwrap();
+    assert!(final_revision > rev_after_ratify);
+
+    // 18. Assertions on closeout content + events + idempotency.
+    let closeout = fs::read_to_string(mission_dir.join("CLOSEOUT.md")).unwrap();
+    assert!(
+        closeout.contains("CLOSEOUT"),
+        "CLOSEOUT.md missing header: {closeout}"
+    );
+    for tid in ["T1", "T2", "T3", "T4", "T5"] {
+        assert!(
+            closeout.contains(tid),
+            "CLOSEOUT.md missing {tid}:\n{closeout}"
+        );
+    }
+    assert!(
+        closeout.contains(INTERPRETED_DEST),
+        "CLOSEOUT.md should echo interpreted_destination:\n{closeout}"
+    );
+
+    let last_seq = assert_events_monotonic(&mission_dir);
+    assert_eq!(
+        last_seq, final_revision,
+        "final event seq should equal STATE.revision"
+    );
+
+    // Terminal status: verdict + stop.
+    let terminal = run_ok(tmp.path(), &["status", "--mission", MISSION]);
+    assert_eq!(terminal["data"]["verdict"], "terminal_complete");
+    assert_eq!(terminal["data"]["stop"]["allow"], true);
+    assert_eq!(terminal["data"]["stop"]["reason"], "terminal");
+
+    // Second close complete → idempotent error.
+    let replay = run_err(tmp.path(), &["close", "complete", "--mission", MISSION]);
+    assert_eq!(replay["code"], "TERMINAL_ALREADY_COMPLETE");
+    assert!(replay["context"]["closed_at"].is_string());
+}

--- a/crates/codex1/tests/e2e_ralph_contract.rs
+++ b/crates/codex1/tests/e2e_ralph_contract.rs
@@ -1,0 +1,177 @@
+//! End-to-end Ralph Stop hook contract tests.
+//!
+//! Drives `scripts/ralph-stop-hook.sh` directly with a fake `codex1` bash
+//! wrapper on PATH. The hook must be purely status-JSON driven:
+//!
+//! - `stop.allow: true`  -> exit 0
+//! - `stop.allow: false` -> exit 2, stderr mentions "blocking"
+//! - empty / missing JSON -> exit 0 (conservative default)
+//! - no `codex1` on PATH -> exit 0 with warning
+//! - malformed / missing `stop.allow` field -> exit 0 (conservative default)
+//!
+//! The sibling `tests/ralph_hook.rs` covers similar ground; this file is
+//! the Unit 20 e2e driver and duplicates just enough setup to stand alone.
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+/// Repo-root-relative path to the Ralph Stop hook script.
+fn hook_script() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/codex1 has a repo root ancestor")
+        .join("scripts")
+        .join("ralph-stop-hook.sh")
+}
+
+/// Write an executable bash script at `tmp/codex1` with the given body.
+fn write_fake_codex1(tmp: &TempDir, body: &str) -> PathBuf {
+    let path = tmp.path().join("codex1");
+    fs::write(&path, body).expect("write fake codex1");
+    let mut perms = fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+/// Build a PATH with `prepend` at the front and any real `codex1` stripped
+/// so the "no codex1" case is deterministic across dev environments.
+fn sanitized_path(prepend: Option<&Path>) -> OsString {
+    let base = std::env::var_os("PATH").unwrap_or_else(|| OsString::from("/usr/bin:/bin"));
+    let mut parts: Vec<PathBuf> = std::env::split_paths(&base)
+        .filter(|p| !p.join("codex1").exists())
+        .collect();
+    if let Some(extra) = prepend {
+        parts.insert(0, extra.to_path_buf());
+    }
+    std::env::join_paths(parts).expect("join PATH")
+}
+
+/// Invoke `ralph-stop-hook.sh` via bash with stdin closed. The returned
+/// `Output` carries exit code plus stderr for assertions.
+fn run_hook(prepend: Option<&Path>) -> Output {
+    let hook = hook_script();
+    assert!(hook.is_file(), "hook script missing: {}", hook.display());
+    let mut cmd = Command::new("bash");
+    cmd.arg(&hook)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .env_clear()
+        .env("PATH", sanitized_path(prepend));
+    if let Ok(home) = std::env::var("HOME") {
+        cmd.env("HOME", home);
+    }
+    cmd.output().expect("run ralph-stop-hook.sh")
+}
+
+/// Convenience: fabricate a fake `codex1` printing `status_json`, then run.
+fn run_hook_with_status(status_json: &str) -> (Output, TempDir) {
+    let tmp = TempDir::new().expect("tempdir");
+    // Escape single quotes for embedding inside a shell-single-quoted literal.
+    let escaped = status_json.replace('\'', "'\"'\"'");
+    let body = format!("#!/usr/bin/env bash\nprintf '%s\\n' '{escaped}'\n");
+    write_fake_codex1(&tmp, &body);
+    let path = tmp.path().to_path_buf();
+    let out = run_hook(Some(&path));
+    (out, tmp)
+}
+
+fn stderr(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+fn bash_available() -> bool {
+    Command::new("bash")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn e2e_stop_allow_true_exits_zero() {
+    if !bash_available() {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+    let (out, _tmp) = run_hook_with_status(
+        r#"{"ok":true,"mission_id":"demo","data":{"stop":{"allow":true,"reason":"idle","message":"Stop is allowed."}}}"#,
+    );
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", stderr(&out));
+}
+
+#[test]
+fn e2e_stop_allow_false_blocks_with_exit_two() {
+    if !bash_available() {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+    let (out, _tmp) = run_hook_with_status(
+        r#"{"ok":true,"mission_id":"demo","data":{"stop":{"allow":false,"reason":"active_loop","message":"Run $close to pause."}}}"#,
+    );
+    assert_eq!(out.status.code(), Some(2), "expected exit 2 to block Stop");
+    let err = stderr(&out);
+    assert!(
+        err.contains("blocking"),
+        "stderr should mention blocking; got: {err}"
+    );
+}
+
+#[test]
+fn e2e_empty_status_output_allows_stop() {
+    if !bash_available() {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+    let tmp = TempDir::new().expect("tempdir");
+    // A codex1 that prints nothing (hook must default to allowing Stop).
+    write_fake_codex1(&tmp, "#!/usr/bin/env bash\nexit 0\n");
+    let out = run_hook(Some(tmp.path()));
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stderr(&out).contains("empty status output"),
+        "stderr should warn about empty output; got: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn e2e_missing_codex1_allows_stop_with_warning() {
+    if !bash_available() {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+    let out = run_hook(None); // PATH stripped of any codex1
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        stderr(&out).contains("codex1 not on PATH"),
+        "stderr should warn about missing codex1; got: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+fn e2e_malformed_json_defaults_to_allow() {
+    if !bash_available() {
+        eprintln!("skipping: bash unavailable");
+        return;
+    }
+    // `stop.allow` absent: the hook must conservatively allow Stop rather
+    // than misread `null` as `false` and block Ralph forever.
+    let (out, _tmp) =
+        run_hook_with_status(r#"{"ok":true,"mission_id":"demo","data":{"phase":"clarify"}}"#);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "missing stop.allow should allow Stop; stderr: {}",
+        stderr(&out)
+    );
+}

--- a/crates/codex1/tests/e2e_replan_trigger.rs
+++ b/crates/codex1/tests/e2e_replan_trigger.rs
@@ -1,0 +1,252 @@
+//! End-to-end replan-trigger integration test.
+//!
+//! Walks a mission up to a plan-locked state, issues a planned review
+//! task, and records six consecutive dirty reviews against the same
+//! target. After the sixth dirty:
+//! - `replan check` must report `required: true` with a non-null reason
+//!   mentioning the target.
+//! - `state.replan.triggered` must be `true`.
+//!
+//! Then runs `replan record --reason six_dirty --supersedes <Tn>` and
+//! asserts the mission rolls back to `phase: plan`, `plan.locked: false`,
+//! and all counters clear.
+//!
+//! The review-target reset between rounds is performed by writing
+//! STATE.json directly (same pattern `tests/review.rs` uses). This is
+//! accepted per the Unit 20 brief — "issue a planned review task; record
+//! 6 consecutive dirty reviews" — and matches the mission-close semantics
+//! where only the main thread (not the CLI) can hand a target back into
+//! review.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const MISSION: &str = "demo";
+
+fn cmd() -> Command {
+    Command::cargo_bin("codex1").expect("binary builds")
+}
+
+fn init_mission(tmp: &TempDir) -> PathBuf {
+    let mission_dir = tmp.path().join("PLANS").join(MISSION);
+    cmd()
+        .current_dir(tmp.path())
+        .args(["init", "--mission", MISSION])
+        .assert()
+        .success();
+    mission_dir
+}
+
+fn parse(output: &std::process::Output) -> Value {
+    let s = std::str::from_utf8(&output.stdout).expect("utf-8 stdout");
+    serde_json::from_str::<Value>(s).unwrap_or_else(|e| panic!("bad JSON:\n{s}\n{e}"))
+}
+
+fn run_ok(cwd: &Path, args: &[&str]) -> Value {
+    let out = cmd().current_dir(cwd).args(args).output().expect("runs");
+    assert!(
+        out.status.success(),
+        "expected success ({args:?}); stderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    parse(&out)
+}
+
+fn read_state(mission_dir: &Path) -> Value {
+    serde_json::from_str(&fs::read_to_string(mission_dir.join("STATE.json")).unwrap()).unwrap()
+}
+
+fn write_state(mission_dir: &Path, state: &Value) {
+    fs::write(
+        mission_dir.join("STATE.json"),
+        serde_json::to_vec_pretty(state).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Mission fixture: T1 (work, complete) + T2 (work, awaiting_review) +
+/// T3 (review targeting T2). Plan is locked; outcome ratified.
+fn seed_plan_locked(mission_dir: &Path) {
+    let plan = r"mission_id: demo
+
+planning_level:
+  requested: light
+  effective: light
+
+outcome_interpretation:
+  summary: replan-trigger e2e
+
+architecture:
+  summary: replan-trigger e2e
+  key_decisions: []
+
+planning_process:
+  evidence: []
+
+tasks:
+  - id: T1
+    title: Root
+    kind: code
+    depends_on: []
+    spec: specs/T1/SPEC.md
+    write_paths:
+      - src/T1/**
+  - id: T2
+    title: Work under review
+    kind: code
+    depends_on: [T1]
+    spec: specs/T2/SPEC.md
+    write_paths:
+      - src/T2/**
+  - id: T3
+    title: Review of T2
+    kind: review
+    depends_on: [T2]
+    spec: specs/T3/SPEC.md
+    review_target:
+      tasks: [T2]
+    review_profiles:
+      - code_bug_correctness
+
+risks: []
+
+mission_close:
+  criteria: []
+";
+    fs::write(mission_dir.join("PLAN.yaml"), plan).unwrap();
+    for tid in ["T1", "T2", "T3"] {
+        let dir = mission_dir.join("specs").join(tid);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("SPEC.md"), format!("# {tid}\n")).unwrap();
+        if matches!(tid, "T1" | "T2") {
+            fs::write(dir.join("PROOF.md"), format!("# proof {tid}\n")).unwrap();
+        }
+    }
+    let mut state = read_state(mission_dir);
+    state["outcome"] = json!({ "ratified": true, "ratified_at": "2026-04-20T00:00:00Z" });
+    state["plan"]["locked"] = Value::Bool(true);
+    state["plan"]["requested_level"] = Value::String("light".into());
+    state["plan"]["effective_level"] = Value::String("light".into());
+    state["phase"] = Value::String("execute".into());
+    state["tasks"] = json!({
+        "T1": {
+            "id": "T1",
+            "status": "complete",
+            "started_at": "2026-04-20T00:00:00Z",
+            "finished_at": "2026-04-20T00:00:01Z",
+            "proof_path": "specs/T1/PROOF.md",
+            "superseded_by": null,
+        },
+        "T2": {
+            "id": "T2",
+            "status": "awaiting_review",
+            "started_at": "2026-04-20T00:00:02Z",
+            "finished_at": "2026-04-20T00:00:03Z",
+            "proof_path": "specs/T2/PROOF.md",
+            "superseded_by": null,
+        },
+    });
+    write_state(mission_dir, &state);
+}
+
+/// Bounce T2 back into AwaitingReview so we can re-run `review start`.
+fn reset_target(mission_dir: &Path, task_id: &str) {
+    let mut state = read_state(mission_dir);
+    state["tasks"][task_id]["status"] = Value::String("awaiting_review".into());
+    write_state(mission_dir, &state);
+}
+
+#[test]
+fn e2e_six_dirty_reviews_trigger_replan_and_record_clears_counters() {
+    let tmp = TempDir::new().unwrap();
+    let mission_dir = init_mission(&tmp);
+    seed_plan_locked(&mission_dir);
+
+    // Write findings file once; every round reuses it.
+    let findings = tmp.path().join("findings.md");
+    fs::write(&findings, "# Findings\n- P0: regression\n").unwrap();
+
+    // Initial replan check: nothing yet.
+    let before = run_ok(tmp.path(), &["replan", "check", "--mission", MISSION]);
+    assert_eq!(before["data"]["required"], false);
+    assert!(before["data"]["reason"].is_null());
+    assert_eq!(before["data"]["triggered_already"], false);
+
+    // Record six dirty reviews against T3 targeting T2. Reset T2 to
+    // AwaitingReview between rounds so `review start` accepts it each time.
+    for i in 0..6 {
+        reset_target(&mission_dir, "T2");
+        run_ok(tmp.path(), &["review", "start", "T3", "--mission", MISSION]);
+        let ok = run_ok(
+            tmp.path(),
+            &[
+                "review",
+                "record",
+                "T3",
+                "--findings-file",
+                findings.to_str().unwrap(),
+                "--mission",
+                MISSION,
+            ],
+        );
+        assert_eq!(ok["data"]["verdict"], "dirty");
+        let triggered = ok["data"]["replan_triggered"].as_bool().unwrap_or(false);
+        assert_eq!(triggered, i == 5, "round {i}: replan_triggered unexpected");
+    }
+
+    // After 6 dirty, replan check must require replan and mention T2.
+    let required = run_ok(tmp.path(), &["replan", "check", "--mission", MISSION]);
+    assert_eq!(required["data"]["required"], true);
+    let reason = required["data"]["reason"].as_str().expect("reason present");
+    assert!(reason.contains("T2"), "reason missing T2: {reason}");
+    assert_eq!(required["data"]["triggered_already"], true);
+    assert_eq!(
+        required["data"]["consecutive_dirty_by_target"]["T2"], 6,
+        "T2 counter should be at threshold"
+    );
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["replan"]["triggered"], true);
+
+    // Record the replan, superseding T2 (the dirty target).
+    let recorded = run_ok(
+        tmp.path(),
+        &[
+            "replan",
+            "record",
+            "--mission",
+            MISSION,
+            "--reason",
+            "six_dirty",
+            "--supersedes",
+            "T2",
+        ],
+    );
+    assert_eq!(recorded["data"]["reason"], "six_dirty");
+    assert_eq!(recorded["data"]["supersedes"], json!(["T2"]));
+    assert_eq!(recorded["data"]["phase_after"], "plan");
+    assert_eq!(recorded["data"]["plan_locked"], false);
+
+    let state = read_state(&mission_dir);
+    assert_eq!(state["phase"], "plan");
+    assert_eq!(state["plan"]["locked"], false);
+    assert_eq!(state["replan"]["triggered"], true);
+    assert_eq!(state["replan"]["consecutive_dirty_by_target"], json!({}));
+    assert_eq!(state["tasks"]["T2"]["status"], "superseded");
+    let superseded_by = state["tasks"]["T2"]["superseded_by"]
+        .as_str()
+        .expect("T2 superseded_by present");
+    assert!(
+        superseded_by.starts_with("replan-"),
+        "superseded_by should be a replan-<rev> marker: {superseded_by}"
+    );
+
+    let after = run_ok(tmp.path(), &["replan", "check", "--mission", MISSION]);
+    assert_eq!(after["data"]["required"], false);
+    assert_eq!(after["data"]["consecutive_dirty_by_target"], json!({}));
+    assert_eq!(after["data"]["triggered_already"], true);
+}


### PR DESCRIPTION
## Summary

- `crates/codex1/tests/e2e_full_mission.rs` drives one complete mission through every public CLI surface (init -> outcome -> plan choose/scaffold/check/waves -> task start/finish -> review -> close record-review/check/complete), asserting on revision monotonicity, EVENTS.jsonl `seq` ordering (plus `seq == revision` at terminal), CLOSEOUT.md content, and the `TERMINAL_ALREADY_COMPLETE` idempotency path.
- `crates/codex1/tests/e2e_replan_trigger.rs` records six consecutive dirty reviews against a single target via `review record`, asserts `replan check` reports `required: true` with a reason mentioning the target, then rolls the plan back via `replan record --reason six_dirty --supersedes T2` and confirms counters clear.
- `crates/codex1/tests/e2e_ralph_contract.rs` drives `scripts/ralph-stop-hook.sh` directly with a path-scoped mock `codex1` wrapper across five cases: stop.allow=true (exit 0), stop.allow=false (exit 2, stderr mentions "blocking"), empty output (exit 0), missing binary (exit 0 with warning), missing stop.allow field (exit 0 conservative default).

All seven tests go through `assert_cmd::Command::cargo_bin("codex1")` — no internals are stubbed. No Rust source or existing tests were modified.

## Test plan

- [x] `cargo fmt` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test` — 169 tests pass (existing 162 + new 7); no regressions.
- [x] `cargo test --test e2e_full_mission --test e2e_ralph_contract --test e2e_replan_trigger` passes in isolation.
- [x] No modifications to `crates/codex1/src/**`, `.codex/skills/**`, or existing tests.