### PR TITLE
Unit 21: reviewer-wave-audit reports

### DIFF
--- a/docs/audits/cli-contract-audit.md
+++ b/docs/audits/cli-contract-audit.md
@@ -1,0 +1,142 @@
+# CLI Contract Audit
+
+Branch audited: `integration/phase-b` @ `a9e9abc`
+Audited on: 2026-04-20 UTC
+Binary: `target/release/codex1 0.1.0` (built from the audited tree).
+
+## Scope
+
+Every command listed in `docs/codex1-rebuild-handoff/02-cli-contract.md` § Minimal Command Surface was exercised against the compiled binary. For each, I verified:
+
+- Presence in the clap dispatch tree rooted at `crates/codex1/src/cli/mod.rs`.
+- `--help` output.
+- Stable JSON envelope shape (success and error).
+- Error codes against the canonical `CliError` set in `crates/codex1/src/core/error.rs`.
+- `status` ↔ `close check` agreement on `verdict` / `close_ready` / `ready` across seven synthetic states.
+
+## Summary
+
+0 P0, 2 P1, 3 P2. The contract is materially honored: every minimal-surface command is wired, error envelopes match the canonical shape, and `status` and `close check` share `state::readiness` so they cannot disagree. The two P1s are documentation-vs-implementation drift inside Phase B; the three P2s are schema-drift issues that should be absorbed into `docs/cli-contract-schemas.md`.
+
+## Findings
+
+### P1-1: `plan choose-level` does not enforce `OUTCOME_NOT_RATIFIED`
+
+- **Severity:** P1
+- **Where:** `crates/codex1/src/cli/plan/choose_level.rs:19-81` (no ratification check before mutating `plan.*_level`); contradicts `docs/cli-reference.md:98` ("**Errors:** `OUTCOME_NOT_RATIFIED`, `MISSION_NOT_FOUND`").
+- **Observed:** Against a freshly-`init`'d mission (`outcome.ratified == false`), `codex1 plan choose-level --level medium --mission <id>` returns `ok: true` and mutates `STATE.json` to record `plan.requested_level = Medium` and `plan.effective_level = Medium`. Verified live:
+  ```bash
+  $ codex1 init --mission test1
+  $ codex1 plan choose-level --level medium --mission test1
+  { "ok": true, ..., "data": { "requested_level": "medium", ... } }
+  ```
+- **Expected:** Either (a) reject with `OUTCOME_NOT_RATIFIED` per `docs/cli-reference.md:98`, or (b) drop the documented error from the reference so the contract stops advertising a gate the code does not provide.
+- **Contract reference:** `docs/cli-reference.md:98`. The authoritative schemas (`docs/cli-contract-schemas.md`) do not list a ratification gate for this command, so this is a Phase-B-internal doc/impl drift rather than a handoff-level contract break — hence P1, not P0.
+- **Fix sketch:** Load state early, short-circuit with `Err(CliError::OutcomeNotRatified)` when `!state.outcome.ratified`, before either the interactive prompt or the mutation. Alternatively amend `docs/cli-reference.md:98`.
+
+### P1-2: `close record-review` and `loop activate` are not listed in the handoff's minimal surface
+
+- **Severity:** P1
+- **Where:**
+  - `crates/codex1/src/cli/close/mod.rs:44-61` adds `CloseCmd::RecordReview`.
+  - `crates/codex1/src/cli/loop_/mod.rs:24-38` adds `LoopCmd::Activate`.
+  - `docs/codex1-rebuild-handoff/02-cli-contract.md:59-92` defines the minimal surface, which names only `loop pause|resume|deactivate` and `close check|complete`.
+- **Observed:** Both commands ship in the clap tree and are exercised by the skills (`.codex/skills/review-loop/SKILL.md:45` calls `codex1 close record-review`; `crates/codex1/src/cli/loop_/activate.rs:1-3` documents its role as a shared entry point for other mutating handlers). They fill real gaps — `MissionCloseReviewState::Passed` has no other write path, and `loop.active = true` has no other entry point — but they are invisible to any agent reading the handoff contract.
+- **Expected:** Either (a) add both to `docs/codex1-rebuild-handoff/02-cli-contract.md` § Minimal Command Surface and to the per-command shape sections of `docs/cli-contract-schemas.md`, or (b) fold `record-review` into `review record <mission-close-target>` and move loop activation behind ratify/check internal state mutations so the surface stays minimal.
+- **Contract reference:** `docs/codex1-rebuild-handoff/02-cli-contract.md:59-92` ("Do not add more commands until the minimal set is excellent.").
+- **Fix sketch:** Prefer (a) — document them in `docs/cli-contract-schemas.md` with data shapes, error codes, and the `STATE.json` fields each mutates. Rename `close record-review` if the review-record wording should stay unified.
+
+### P2-1: `CliError::Other → "INTERNAL"` is an undocumented error code
+
+- **Severity:** P2
+- **Where:** `crates/codex1/src/core/error.rs:77,104` emits `"INTERNAL"` for `CliError::Other(anyhow)`; `docs/cli-contract-schemas.md:36-57` canonical error-code table does not include `INTERNAL`.
+- **Observed:** The variant is unreachable from the live handlers (the only `anyhow`-returning helper, `crates/codex1/src/core/config.rs:26-33`, is referenced by `crates/codex1/src/cli/doctor.rs:6` only for `default_config_path()`, not `load()`). But a future handler that `?`-propagates an `anyhow::Result` would silently produce a `code: "INTERNAL"` envelope outside the documented error set.
+- **Expected:** Either list `INTERNAL` in the canonical table or delete `CliError::Other` and `impl From<anyhow::Error>` so that schema drift is impossible.
+- **Contract reference:** `docs/cli-contract-schemas.md:36-57`.
+- **Fix sketch:** Remove the `Other(anyhow::Error)` variant (no caller relies on it). Move `config::load` off `anyhow::Error` onto `CliError`.
+
+### P2-2: Error envelopes omit optional `hint` / `context` fields when null
+
+- **Severity:** P2
+- **Where:** `crates/codex1/src/core/envelope.rs:72-77` uses `skip_serializing_if = "Option::is_none"` for `hint` and `skip_serializing_if = "Value::is_null"` for `context`.
+- **Observed:** Some error envelopes omit keys that the schema example in `docs/cli-contract-schemas.md:25-34` shows present:
+  ```bash
+  $ codex1 close complete --mission test1
+  { "ok": false, "code": "CLOSE_NOT_READY", "message": "…", "retryable": false }
+  # no `hint`, no `context`
+  ```
+- **Expected:** Either (a) update `docs/cli-contract-schemas.md` § JSON envelopes § Error to note the two fields are optional and absent when null, or (b) always serialize both fields (use `""` / `{}` defaults).
+- **Contract reference:** `docs/cli-contract-schemas.md:25-34`.
+- **Fix sketch:** Prefer (a) — the current shape is compact and serde-idiomatic. A one-line clarification in the schema keeps the contract honest.
+
+### P2-3: `doctor` help omits the command's non-global purpose and status
+
+- **Severity:** P2
+- **Where:** `crates/codex1/src/cli/mod.rs:77` (`/// Report CLI health. Never crashes on missing auth or config.`) — fine as-is.
+- **Observed:** `codex1 doctor --help` prints a single-line summary only. All other commands have more context in their help, but the error-surface and success-surface are compact JSON. Not a contract violation; just slightly less helpful than siblings like `close --help`.
+- **Expected:** Optional: one extra sentence describing the success envelope fields (`version`, `config`, `install`, `auth`, `warnings`).
+- **Contract reference:** None — cosmetic.
+- **Fix sketch:** Extend the `Commands::Doctor` doc comment.
+
+## Clean checks (no findings)
+
+### Minimal command surface (25 verbs from `02-cli-contract.md` § Minimal Command Surface)
+
+All verbs exist in the clap dispatch tree and resolve via `codex1 <group> <verb> --help`:
+
+- `codex1 init` — `crates/codex1/src/cli/mod.rs:76`, `init.rs:19`.
+- `codex1 status` — `cli/mod.rs:121`, `status/mod.rs:21`.
+- `codex1 outcome check` / `ratify` — `outcome/mod.rs:22-35`.
+- `codex1 plan choose-level` / `scaffold` / `check` / `graph` / `waves` — `plan/mod.rs:22-67`.
+- `codex1 task next` / `start` / `finish` / `status` / `packet` — `task/mod.rs:22-58`.
+- `codex1 review start` / `packet` / `record` / `status` — `review/mod.rs:23-81`.
+- `codex1 replan check` / `record` — `replan/mod.rs:18-37`.
+- `codex1 loop pause` / `resume` / `deactivate` — `loop_/mod.rs:24-47` (plus the undocumented `activate`, see P1-2).
+- `codex1 close check` / `complete` — `close/mod.rs:43-73` (plus `record-review`, see P1-2).
+
+All 25 minimal-surface commands have clap-generated `--help` text (verified by calling `--help` on each group and leaf).
+
+### Stable JSON envelopes
+
+- Success envelope: `{ ok: true, mission_id?, revision?, data }` per `core/envelope.rs:20-29`. Verified live on `doctor`, `init`, `status`, `hook snippet`, `outcome check` (success path), `plan choose-level`, `plan waves`, `plan graph`, `task next`, `replan check`.
+- Error envelope: `{ ok: false, code, message, hint?, retryable, context? }` per `core/envelope.rs:67-78`. Verified live on `outcome check` (OUTCOME_INCOMPLETE), `close complete` (CLOSE_NOT_READY), `task start T1` (TASK_NOT_READY), `review status T99` (PLAN_INVALID).
+- Compact output is available via `to_compact()`; the binary defaults to pretty-printed JSON.
+
+### Error codes vs canonical `CliError` set
+
+- Every `CliError` variant's `code()` string (`core/error.rs:80-106`) appears in `docs/cli-contract-schemas.md:36-57` with the one exception documented as P2-1 (`INTERNAL`).
+- Every raw string code constructed under `crates/codex1/src/cli/**/*.rs` is a member of the canonical set:
+  - `cli/plan/check.rs` `exit_with_validation_error` calls use only `PLAN_INVALID` / `DAG_CYCLE` / `DAG_MISSING_DEP` (per grep at lines 45, 144, 155, 165, 174, 183, 192, 201, 217, 225, 248, 256, 289, 317, 325, 339, 360, 368, 377, 386, 397, 415, 428, 438, 447, 468, 479, 491).
+  - `cli/close/check.rs` `Blocker::new` codes at lines 80, 85, 93, 98, 106, 115, 121 are `OUTCOME_NOT_RATIFIED` / `PLAN_INVALID` / `REPLAN_REQUIRED` / `TASK_NOT_READY` / `REVIEW_FINDINGS_BLOCK` / `CLOSE_NOT_READY`. All canonical.
+- No handler constructs a bespoke `JsonErr` with a non-canonical string; the only such path is the foundation-owned `exit_with_validation_error` using canonical strings.
+
+### `status` and `close check` agreement (7 synthetic states)
+
+Across seven hand-authored `STATE.json` fixtures, `codex1 status --mission <id>` and `codex1 close check --mission <id>` never disagreed on `verdict`. Both derive through `state::readiness::derive_verdict` (`crates/codex1/src/state/readiness.rs:40-66`); `status` calls it from `cli/status/project.rs:19` and `close check` from `cli/close/check.rs:47`.
+
+| Fixture | `status.verdict` | `status.close_ready` | `close check.verdict` | `close check.ready` |
+| --- | --- | --- | --- | --- |
+| Fresh init (outcome unratified, plan unlocked) | `needs_user` | `false` | `needs_user` | `false` |
+| `loop.paused = true`, execute phase | `continue_required` | `false` | `continue_required` | `false` |
+| Plan locked + ready task, outcome ratified | `continue_required` | `false` | `continue_required` | `false` |
+| Dirty review present | `blocked` | `false` | `blocked` | `false` |
+| All tasks complete, mission-close review not started | `ready_for_mission_close_review` | `false` | `ready_for_mission_close_review` | `false` |
+| Mission-close review passed | `mission_close_review_passed` | `true` | `mission_close_review_passed` | `true` |
+| Terminal (`close.terminal_at` set) | `terminal_complete` | `false` | `terminal_complete` | `false` |
+
+`close_ready` / `ready` are both `true` exactly when the verdict is `mission_close_review_passed`, per `state::readiness::close_ready()` (`readiness.rs:69-72`) and `ReadinessReport::ready` (`cli/close/check.rs:49`). The two fields are synonyms, backed by the same predicate.
+
+### `stop.allow` projection consistency
+
+- `stop.allow` is derived in `state::readiness::stop_allowed` (`readiness.rs:92-101`); `status` projects it via `cli/status/project.rs:72-99`.
+- Paused state → `allow: true, reason: "paused"`. Terminal state → `allow: true, reason: "terminal"`. Active-unpaused with non-close verdict → `allow: false, reason: "active_loop"`. Active-unpaused with verdict in `{NeedsUser, MissionCloseReviewPassed}` → `allow: true, reason: "idle"`. Verified live on all three.
+- Bare `codex1 status` with no mission resolvable emits a graceful `stop.allow: true, reason: "no_mission"` envelope (`cli/status/mod.rs:38-49`) so Ralph never blocks a shell with no mission present.
+
+### Global flags
+
+- `--mission <id>`, `--repo-root <path>`, `--json`, `--dry-run`, `--expect-revision <N>` are declared as globals in `cli/mod.rs:46-69` and appear in every `--help` output.
+- Mission resolution precedence per `docs/cli-contract-schemas.md:70-76` is implemented in `core/mission::resolve_mission`; a no-mission `codex1 status` still returns a success envelope (cli/status/mod.rs:38-49).
+
+### Build proof
+
+`cargo build --release` in the audited tree succeeds with no warnings promoted to errors (`Finished release profile [optimized] target(s)`). No Rust source was modified by this audit.

--- a/docs/audits/handoff-cross-check.md
+++ b/docs/audits/handoff-cross-check.md
@@ -1,0 +1,175 @@
+# Handoff Cross-Check
+
+Branch audited: `integration/phase-b` @ `a9e9abc`
+Audited on: 2026-04-20 UTC.
+
+## Scope
+
+This audit cross-checks the repository against every "Non-Negotiable" and "Anti-Goal" declared in:
+
+- `docs/codex1-rebuild-handoff/00-why-and-lessons.md` § What To Reject.
+- `docs/codex1-rebuild-handoff/README.md` § Non-Negotiables and § Explicit Anti-Goals.
+- `docs/codex1-rebuild-handoff/02-cli-contract.md` § Important Non-Features.
+
+For each anti-goal I report whether it is honored in live code, skills, scripts, and docs.
+
+## Summary
+
+0 P0, 0 P1, 0 P2. Every declared anti-goal is honored. `.ralph/` only appears as an explicit prohibition in documentation and scripts; caller-identity patterns do not exist in Rust source; `plan scaffold` does not emit a `waves:` key; reviewer writeback is positively forbidden in the skill bodies; and no wrapper runtime or background daemon is invoked by the CLI.
+
+## Findings
+
+None.
+
+## Clean checks (anti-goal by anti-goal)
+
+### CC-1: No `.ralph/` live directory, path, or import
+
+All 11 matches for the substring `.ralph` in the repository are either (a) inside handoff docs where `.ralph` is defined as an anti-goal or (b) inline prohibitions:
+
+| File | Line | Kind |
+| --- | --- | --- |
+| `docs/codex1-rebuild-handoff/00-why-and-lessons.md` | 37, 82 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/01-product-flow.md` | 241 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/02-cli-contract.md` | 105 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/03-planning-artifacts.md` | 28, 31 | Anti-goal doc ("Do not use `.ralph` for mission truth.") |
+| `docs/codex1-rebuild-handoff/05-build-prompt.md` | 36, 91 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/README.md` | 79, 93 | Anti-goal doc |
+| `docs/mission-anatomy.md` | 3 | Anti-goal prose ("There is no hidden state directory, no `.ralph/`…") |
+| `README.md` | 3 | Anti-goal prose ("There is no hidden `.ralph/` state…") |
+| `scripts/README-hook.md` | 19 | Ralph hook scope ("The hook does **not** read … `.ralph/` directories") |
+| `.codex/skills/close/SKILL.md` | 112 | Prohibition ("Do not edit `.ralph/` files, STATE.json, or hooks to work around Ralph.") |
+| `crates/codex1/src/lib.rs` | 9 | Doc comment ("never hides state in `.ralph/`.") |
+
+No `std::fs`, `Path::new`, `PathBuf`, `include_str!`, `include_bytes!`, or shell invocation in the repo references a `.ralph` path. Grep confirms no Rust source creates, reads, or writes anything under `.ralph/`.
+
+### CC-2: No caller-identity checks in Rust source
+
+Grep over `crates/codex1` for:
+
+```text
+is_parent | is_subagent | caller_type | reviewer_id | parent_id | subagent_type
+session_owner | caller_identity | session_id | session_token | capability_token
+authority_token
+```
+
+Zero matches in any `.rs` file. `crates/codex1/src/cli/mod.rs:124-140` defines `Ctx` with only `{ mission, repo_root, json, dry_run, expect_revision }`; no caller-side identity is extracted or inspected. Every handler accepts the `Ctx` as-is and dispatches based on arguments + state file contents.
+
+The comment in `crates/codex1/src/cli/review/mod.rs:2-4` makes this explicit:
+
+> The CLI does not check caller identity; the main thread records review
+> outcomes.
+
+### CC-3: No `waves:` key emitted by `plan scaffold`
+
+- `crates/codex1/src/cli/plan/scaffold.rs:119-171` (`render_skeleton`) composes the PLAN.yaml skeleton. The output contains `mission_id`, `planning_level`, `outcome_interpretation`, `architecture`, `planning_process`, `tasks`, `risks`, and `mission_close` — and no `waves:` key.
+- Grep for `waves:` / `wave_id` across `crates/codex1/src/cli/plan/` finds only `graph.rs:11` (`use super::waves::{load_plan_tasks, ParsedTask};`) — a module import, not a YAML key emission.
+- Grep for `waves:` under `.codex/skills/` / `docs/` yields no emission of `waves:` as a plan field; every match is prose describing that waves are derived.
+- `codex1 plan waves --json` recomputes waves from `tasks[].depends_on` + current task state on each call (`cli/plan/waves.rs`), never from a stored `waves:` list.
+
+### CC-4: Reviewer writeback — main thread records (positive prohibition)
+
+`$review-loop`'s skill body and references explicitly say the main thread records, not the reviewer:
+
+- `.codex/skills/review-loop/SKILL.md:11`:
+  > The main thread is the sole writer of mission truth: it records clean/dirty via `codex1 review record` (planned review) or `codex1 close record-review` (mission close).
+- `.codex/skills/review-loop/SKILL.md:63`:
+  > Every spawn prompt must begin with the standing reviewer block in `references/reviewer-profiles.md` (findings-only, no edits, no `codex1` mutations, no repairs, no marking clean anywhere). The main thread is the sole writer of mission truth. Reviewer writeback is forbidden.
+- `.codex/skills/review-loop/SKILL.md:79`:
+  > - Record review results from inside a reviewer subagent — only the main thread records.
+- `.codex/skills/review-loop/references/reviewer-profiles.md:8-15` (standing reviewer instructions):
+  > Do not edit files. / Do not invoke Codex1 skills. / Do not run codex1 mutating commands (no `review record`, `task finish`, `close *`, etc.). / Do not record mission truth.
+
+`$execute/SKILL.md:117` reinforces from the orchestration side: `- Do not spawn reviewers, run codex1 review record, or write to reviews/`.
+
+The handoff's required "main-thread records" language is present in both positive and negative forms — exactly what the task's positive-prohibition check asked for.
+
+### CC-5: No wrapper runtime / `codex1-runtime` / `ralph-daemon`
+
+Grep over the repo for `codex1-runtime | ralph-daemon | wrapper_runtime`:
+
+```bash
+$ grep -rI --exclude-dir=target "codex1-runtime\|ralph-daemon\|wrapper_runtime" .
+# (no matches)
+```
+
+Grep for `daemon | spawn_process | Command::new.*codex` in source:
+
+- `crates/codex1/src/cli/doctor.rs:64-66` probes for a `codex1` binary on `PATH` (non-invocation).
+- `scripts/ralph-stop-hook.sh:25` runs `codex1 status --json` once and exits — no background process.
+
+No `std::process::Command::spawn` / `tokio::spawn` is used to launch any background worker, daemon, or helper process. The binary is a one-shot CLI on every invocation.
+
+### CC-6: CLI does not spawn subagents or read hidden chat state
+
+- `crates/codex1/src/cli/**/*.rs` contains no `Command::new("codex")` / `Command::new("claude")` / AI-model invocation.
+- No handler reads from stdin except `plan choose-level` (`cli/plan/choose_level.rs:102-120`), and only when stdin is a TTY — i.e. for the documented interactive level prompt.
+- `codex1 task packet` and `codex1 review packet` emit prompt strings for the main thread to paste into a subagent; neither spawns anything.
+
+### CC-7: Ralph is status-only
+
+`scripts/ralph-stop-hook.sh` (60 lines, owned by Unit 12):
+
+- Drains stdin.
+- Probes for `codex1` on `PATH` (or via `$CODEX1_BIN`).
+- Runs exactly one command: `codex1 status --json` (line 25).
+- Parses `.data.stop.allow` with `jq` (or a degraded grep fallback).
+- Exits 2 iff `allow == false`, else 0.
+
+It never reads PLAN.yaml, STATE.json, EVENTS.jsonl, reviews, specs, or `.ralph/`. It never spawns another process. `scripts/README-hook.md:19-22` makes this promise explicit.
+
+`codex1 hook snippet` (`crates/codex1/src/cli/hook.rs:24-50`) only prints wiring JSON; it does not install, probe, or invoke anything.
+
+### CC-8: Stored waves are not treated as editable truth
+
+- `crates/codex1/src/state/schema.rs:171-188` defines `MissionState`. The struct contains `tasks`, `reviews`, `replan`, `close`, etc. — no `waves` field.
+- `crates/codex1/src/cli/plan/waves.rs` derives waves on demand from plan tasks + state.
+- `docs/cli-contract-schemas.md:78-97` pins the Rust types for `MissionState`; no `waves:` collection is listed.
+
+### CC-9: Capability tokens / authority tokens / session-id authority
+
+Grep for `session_id | session_token | capability_token | authority_token` across `crates/codex1`: 0 matches.
+
+No handler accepts, mints, stores, or validates a capability/authority token. Mutating commands gate on `--expect-revision` (`core/error.rs:53-54`), which is a state-file revision counter, not a caller-identity credential.
+
+### CC-10: `docs/cli-contract-schemas.md` remains foundation-owned and untouched
+
+Per the contract at `docs/cli-contract-schemas.md:298-325`, `cli-contract-schemas.md` is Foundation-owned. This audit does not modify that file (nor any Rust source). `cargo build --release` on the audited tree succeeds unchanged.
+
+### CC-11: CLI does not ask semantic questions
+
+`crates/codex1/src/cli/plan/choose_level.rs:102-120` is the only interactive prompt in the entire CLI. It asks a single question: which of `light | medium | hard` to record. It does not ask semantic clarification questions about the mission; per `docs/codex1-rebuild-handoff/02-cli-contract.md:46` this is the explicitly sanctioned exception.
+
+All other commands are non-interactive and emit JSON.
+
+### CC-12: Visible mission files only
+
+`crates/codex1/src/core/paths.rs` resolves `PLANS/<mission>/{OUTCOME.md, PLAN.yaml, STATE.json, EVENTS.jsonl, specs/, reviews/, CLOSEOUT.md}`. Every mutating command uses these paths; no handler writes outside `PLANS/<mission>/`. There is no side-cache, side-state, or hidden dotfile.
+
+## Reading map
+
+Each anti-goal and the line where I verified it:
+
+| Anti-goal (handoff source) | Verified at |
+| --- | --- |
+| `00-why-and-lessons.md:82` – "No `.ralph` mission truth." | CC-1 |
+| `00-why-and-lessons.md:84` – "No caller identity checks." | CC-2 |
+| `00-why-and-lessons.md:86` – "No reviewer writeback authority systems." | CC-4 |
+| `00-why-and-lessons.md:87` – "No stored waves as editable truth." | CC-3, CC-8 |
+| `00-why-and-lessons.md:80` – "No hidden daemons." | CC-5 |
+| `00-why-and-lessons.md:81` – "No wrapper runtimes around Codex." | CC-5 |
+| `README.md:79` – "No `.ralph/` mission state directory." | CC-1 |
+| `README.md:78` – "CLI must not detect parent vs subagent." | CC-2 |
+| `README.md:89` – "No session-ID authority system." | CC-9 |
+| `README.md:91` – "No capability-token maze." | CC-9 |
+| `README.md:92` – "No reviewer writeback authority tokens." | CC-4 |
+| `README.md:93` – "No stored waves as canonical truth." | CC-3, CC-8 |
+| `README.md:95` – "A CLI that spawns subagents." | CC-6 |
+| `README.md:96` – "A CLI that asks semantic clarification questions." | CC-11 |
+| `02-cli-contract.md:99` – "Must not ask 'are you parent or subagent?'" | CC-2 |
+| `02-cli-contract.md:105` – "Must not use `.ralph` mission truth." | CC-1 |
+| `02-cli-contract.md:106` – "Must not store waves as editable truth." | CC-3, CC-8 |
+| `02-cli-contract.md:102` – "Must not spawn subagents." | CC-6 |
+| `01-product-flow.md:241` – "Ralph must not inspect plan/review files directly." | CC-7 |
+
+Every anti-goal was verified clean. No P0/P1/P2 findings.

--- a/docs/audits/skills-audit.md
+++ b/docs/audits/skills-audit.md
@@ -1,0 +1,156 @@
+# Skills Audit
+
+Branch audited: `integration/phase-b` @ `a9e9abc`
+Audited on: 2026-04-20 UTC
+Skill folders: `.codex/skills/{clarify,plan,execute,review-loop,close,autopilot}`.
+
+## Scope
+
+For every skill I verified:
+
+- `quick_validate.py` passes (script at `/Users/joel/.codex/skills/.system/skill-creator/scripts/quick_validate.py`).
+- Frontmatter has only `name` + `description` and `name` matches the folder.
+- `SKILL.md` body is under 500 lines and written in imperative form.
+- `agents/openai.yaml` exists and `interface.default_prompt` references `$<skill-name>` literally.
+- No `README.md`, `INSTALLATION_GUIDE.md`, or `CHANGELOG.md` inside the skill folder.
+- Body invokes the CLI commands the skill exists to drive.
+- Body does not invite behaviors the handoff forbids (caller-identity, reviewer writeback, stored waves, `.ralph/` state).
+
+## Summary
+
+0 P0, 0 P1, 0 P2. Every skill passes validation, has a clean frontmatter, points at the right CLI verbs, and honors the handoff anti-goals. A few observations are noted as informational (no severity) below, but none rise to a contract issue.
+
+## Findings
+
+None.
+
+## Informational (no finding)
+
+### I-1: `$close` invokes `codex1 close complete` — which is outside `$close`'s stated purpose
+
+- **Where:** `.codex/skills/close/SKILL.md:68-91` documents a "terminal close" workflow that calls `codex1 close complete`.
+- **Why this is OK (per handoff):** `docs/codex1-rebuild-handoff/01-product-flow.md:196-227` scopes `$close` to "discussion-mode" boundary only, but the file also says "`$close` is not mission completion." The skill body makes the same distinction and explicitly gates `close complete` behind `verdict == mission_close_review_passed` plus user confirmation. Skill is not instructing `$close` to skip mission-close review.
+- **Note:** If the product wants to lock `$close` to discussion-only, move the terminal-close documentation to `$autopilot` or a new `$complete` skill. Keeping it documented here but clearly separated is also defensible.
+
+### I-2: `$review-loop` invokes `codex1 close record-review` — tied to P1-2 in the CLI audit
+
+- **Where:** `.codex/skills/review-loop/SKILL.md:43-45`.
+- **Note:** The skill is correct relative to the implementation — `close record-review` is the only path to `MissionCloseReviewState::Passed`. The finding belongs to the CLI surface audit (P1-2 in `cli-contract-audit.md`), not to the skill.
+
+## Clean checks (no findings)
+
+### Per-skill validation (`quick_validate.py`)
+
+All six skills pass the installed validator:
+
+```text
+=== clarify ===      Skill is valid!
+=== plan ===         Skill is valid!
+=== execute ===      Skill is valid!
+=== review-loop ===  Skill is valid!
+=== close ===        Skill is valid!
+=== autopilot ===    Skill is valid!
+```
+
+### Frontmatter shape
+
+Every `SKILL.md` declares exactly two frontmatter keys, `name` and `description`. The `name` value matches the folder name.
+
+| Skill | Folder | `name:` in SKILL.md | Other frontmatter keys |
+| --- | --- | --- | --- |
+| clarify | `.codex/skills/clarify/` | `clarify` | none |
+| plan | `.codex/skills/plan/` | `plan` | none |
+| execute | `.codex/skills/execute/` | `execute` | none |
+| review-loop | `.codex/skills/review-loop/` | `review-loop` | none |
+| close | `.codex/skills/close/` | `close` | none |
+| autopilot | `.codex/skills/autopilot/` | `autopilot` | none |
+
+`quick_validate.py` also allows `license`, `allowed-tools`, and `metadata`; none are present. The description field is a single prose block in each skill, with no angle brackets and well under the 1024-character validator ceiling.
+
+### Body length (all < 500 lines)
+
+| Skill | Lines |
+| --- | --- |
+| clarify | 60 |
+| plan | 205 |
+| execute | 122 |
+| review-loop | 81 |
+| close | 112 |
+| autopilot | 133 |
+
+Bodies are imperative (each begins with verbs: `Turn a user's mission goal into…`, `Create a full Codex1 mission plan…`, `Run the next ready task…`, `Orchestrate reviewer subagents…`, `Pause the active Codex1 loop…`, `Take a Codex1 mission from start to terminal close…`).
+
+### `agents/openai.yaml` and `$<skill-name>` literal references
+
+Every skill ships an `agents/openai.yaml` whose `interface.default_prompt` mentions the skill literally as `$<name>`:
+
+| Skill | `default_prompt` excerpt | Literal `$<name>` found? |
+| --- | --- | --- |
+| clarify | `Use $clarify to fill and ratify OUTCOME.md before planning.` | Yes |
+| plan | `Use $plan to scaffold, fill, and lock PLAN.yaml for the active mission.` | Yes |
+| execute | `Use $execute to run the next ready task or wave for the active Codex1 mission.` | Yes |
+| review-loop | `Use $review-loop to run reviewer subagents and record clean/dirty findings.` | Yes |
+| close | `Use $close to pause the active loop so the user can talk without Ralph forcing continuation.` | Yes |
+| autopilot | `Use $autopilot to take a Codex1 mission from clarify to terminal close.` | Yes |
+
+All six yaml files also pin `policy.allow_implicit_invocation: true` as the only policy key.
+
+### No forbidden files inside skill folders
+
+```bash
+$ find .codex/skills -type f \( -name "README.md" -o -name "INSTALLATION_GUIDE.md" -o -name "CHANGELOG.md" \)
+# (no output)
+```
+
+Every skill folder contains only `SKILL.md`, `agents/openai.yaml`, and (for five of six) a `references/` directory; the handoff permits references but forbids README/INSTALLATION_GUIDE/CHANGELOG.
+
+### CLI commands each skill drives
+
+Every skill body invokes the CLI verbs it exists to orchestrate:
+
+- `$clarify` (`clarify/SKILL.md:19,37,39`): `codex1 status`, `codex1 outcome check`, `codex1 outcome ratify`. ✓ Matches task requirement that `$clarify` must mention `codex1 outcome check` and `codex1 outcome ratify`.
+- `$plan` (`plan/SKILL.md:29,45,138,146,147,191`): `codex1 plan choose-level`, `codex1 plan scaffold`, `codex1 plan check`, `codex1 plan graph`, `codex1 plan waves`, `codex1 replan record`.
+- `$execute` (`execute/SKILL.md:29,49,50,72`): `codex1 status`, `codex1 task next`, `codex1 task start`, `codex1 task packet`, `codex1 task finish`.
+- `$review-loop` (`review-loop/SKILL.md:19,21,28,31,39,43,45`): `codex1 review start`, `codex1 review packet`, `codex1 review record`, `codex1 close check`, `codex1 close record-review`.
+- `$close` (`close/SKILL.md:40,51,61,84`): `codex1 loop pause`, `codex1 loop resume`, `codex1 loop deactivate`, `codex1 close complete`, `codex1 status`.
+- `$autopilot` (`autopilot/SKILL.md:43,97,104,125`): `codex1 status`, `codex1 init`, `codex1 plan choose-level`, `codex1 close check`, `codex1 close complete`, plus composes the other five skills.
+
+### Handoff anti-goals honored
+
+- No skill body (or reference) mentions `.ralph/` as a live directory. The one hit is `close/SKILL.md:112`, which is an explicit prohibition: `- Do not edit .ralph/ files, STATE.json, or hooks to work around Ralph.` This is the handoff's intended framing (`.ralph` as anti-goal, not as storage).
+- No skill body instructs reviewer subagents to call any mutating CLI command. `review-loop/SKILL.md:11` ("The main thread is the sole writer of mission truth"), `review-loop/SKILL.md:63` ("Reviewer writeback is forbidden"), and `references/reviewer-profiles.md:8-15` (standing instructions: `Do not run codex1 mutating commands`) are all positive-worded prohibitions.
+- No skill body stores waves in `PLAN.yaml`. `plan/SKILL.md:199` explicitly says `Do not store waves inside PLAN.yaml. Waves are derived.` `plan/references/dag-quality.md:15` reinforces this.
+- No skill body asks the CLI to detect caller identity. `autopilot/SKILL.md:120-127` and `review-loop/SKILL.md:77-82` rely on prompt-governed role boundaries, consistent with the handoff.
+- Six consecutive dirty reviews triggering replan is documented in `review-loop/SKILL.md:4` and `execute/SKILL.md:107`.
+
+### Skill folders layout
+
+```
+.codex/skills/
+├── autopilot/
+│   ├── agents/openai.yaml
+│   ├── references/autopilot-state-machine.md
+│   └── SKILL.md
+├── clarify/
+│   ├── agents/openai.yaml
+│   ├── references/outcome-shape.md
+│   └── SKILL.md
+├── close/
+│   ├── agents/openai.yaml
+│   └── SKILL.md
+├── execute/
+│   ├── agents/openai.yaml
+│   ├── references/worker-packet-template.md
+│   └── SKILL.md
+├── plan/
+│   ├── agents/openai.yaml
+│   ├── references/dag-quality.md
+│   ├── references/hard-planning-evidence.md
+│   └── SKILL.md
+└── review-loop/
+    ├── agents/openai.yaml
+    ├── references/reviewer-profiles.md
+    └── SKILL.md
+```
+
+References contain prose the SKILL.md bodies intentionally don't duplicate — `clarify/references/outcome-shape.md` (field reference table), `plan/references/hard-planning-evidence.md` (spawn prompt templates for explorer/advisor/plan reviewer), `plan/references/dag-quality.md` (DAG heuristics), `execute/references/worker-packet-template.md` (packet substitution template), `review-loop/references/reviewer-profiles.md` (per-profile prompt templates), `autopilot/references/autopilot-state-machine.md` (dispatch table and pseudocode). None repeat SKILL.md content verbatim.


### PR DESCRIPTION
## Summary

- Three audit reports under `docs/audits/`: CLI contract audit (cli-contract-audit.md), skills audit (skills-audit.md), handoff cross-check (handoff-cross-check.md).
- Findings: 0 P0, 2 P1, 3 P2 (all in the CLI contract audit). Skills audit and handoff cross-check are clean.
- No Rust source changes. `cargo build --release` still succeeds.

## Key findings (CLI contract audit)

- P1-1: `plan choose-level` does not enforce `OUTCOME_NOT_RATIFIED` despite `docs/cli-reference.md:98` advertising that error. Doc/impl drift inside Phase B.
- P1-2: `close record-review` and `loop activate` ship in clap but are not listed in the handoff's minimal command surface.
- P2-1: `CliError::Other → "INTERNAL"` is an undocumented error code (dead variant today; schema drift if a handler ever propagates anyhow).
- P2-2: Error envelopes omit optional `hint`/`context` when null; schema example shows them present.
- P2-3: `doctor --help` is sparser than siblings (cosmetic).

## Clean checks (summary)

- 25/25 minimal-surface commands present; all have `--help`; all canonical error codes subset of `CliError`.
- `status` and `close check` agree on `verdict`/`close_ready`/`ready` across 7 synthetic states (fresh init, paused, continue_required, blocked by dirty review, ready_for_mission_close_review, mission_close_review_passed, terminal_complete).
- All 6 skills pass `quick_validate.py`; no `README.md`/`INSTALLATION_GUIDE.md`/`CHANGELOG.md` inside skill folders; frontmatter is `name`+`description` only; `$<skill-name>` literal in every `agents/openai.yaml`.
- No `.ralph/` live paths (only anti-goal prose); no caller-identity checks in Rust; no `waves:` YAML emission in `plan/scaffold.rs`; reviewer writeback positively forbidden in `review-loop/SKILL.md`+`reviewer-profiles.md`; no wrapper runtime/daemon/background process.

## Test plan

- [x] `cargo build --release` succeeds on `integration/phase-b` head.
- [x] `codex1 --help` lists every minimal-surface command.
- [x] Synthetic `STATE.json` fixtures exercised for `status`/`close check` agreement.
- [x] `python3 /Users/joel/.codex/skills/.system/skill-creator/scripts/quick_validate.py` passes for all six skills.
- [x] Grep-based anti-goal verification (`.ralph`, caller-identity, `waves:`, daemons) shows no live violations.

Audited branch: `integration/phase-b` @ `a9e9abc`. Reports are pure Markdown; no code or schema was changed.