### PR TITLE
iter1 audit: wave (post-6473650)

### DIFF
--- a/docs/audits/iter1-cli-contract-audit.md
+++ b/docs/audits/iter1-cli-contract-audit.md
@@ -1,0 +1,184 @@
+# CLI Contract Audit — iter1 (post-6473650)
+
+Branch audited: `audit-iter1-wave` (off `main`) @ `6473650`
+Audited on: 2026-04-20 UTC
+Binary: `target/release/codex1 0.1.0` (built from this tree).
+
+## Build / test evidence (iter1 header)
+
+| Gate | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS (no output) |
+| `cargo clippy --all-targets -- -D warnings` | **FAIL** — see new finding P2-1 below (`crates/codex1/tests/plan_scaffold.rs:38`). |
+| `cargo test --release` | PASS — 169 tests across 19 test binaries (steady-state). First run from a clean build flakes 7 tests in `tests/close.rs` because `cargo test --release` does not reliably build the bin crate before running integration tests that use `Command::cargo_bin("codex1")`; second and third runs are clean. Evidence captured under "Clean-checks § Test suite flake" below. |
+
+The commit message of `6473650` claims "cargo fmt + cargo clippy --all-targets -- -D warnings clean." Clippy is not clean; the claim is falsifiable on the same tree.
+
+## Summary
+
+**0 P0, 0 P1, 1 P2.** The five baseline `cli-contract-audit.md` findings are all fixed (verified live). The fresh pass surfaces one new P2 issue: a clippy warning that breaks the `-D warnings` gate promised by the commit message.
+
+## Re-verification of the 5 baseline findings
+
+### P1-1 (baseline): `plan choose-level` must return `OUTCOME_NOT_RATIFIED` when OUTCOME.md is unratified — **FIXED**
+
+Live-verified in `/tmp/codex1-iter1-p1-1`:
+
+```bash
+$ codex1 --json init --mission t1       # ok:true, outcome.ratified=false
+$ codex1 --json plan choose-level --mission t1 --level medium
+{
+  "ok": false,
+  "code": "OUTCOME_NOT_RATIFIED",
+  "message": "OUTCOME.md is not ratified",
+  "retryable": false
+}
+```
+
+Source: `crates/codex1/src/cli/plan/choose_level.rs:19-40` now loads STATE.json and returns `Err(CliError::OutcomeNotRatified)` before the mutation. Matches `docs/cli-reference.md:98`.
+
+### P1-2 (baseline): `close record-review` and `loop activate` listed in handoff + per-command schemas — **FIXED**
+
+- `docs/codex1-rebuild-handoff/02-cli-contract.md:55-94` § Minimal Command Surface lists `loop activate` (line 89) and `close record-review` (line 93). Explanatory paragraphs on lines 96-104 describe each.
+- `docs/cli-contract-schemas.md:320-337` documents `close record-review --clean|--findings-file`; `docs/cli-contract-schemas.md:339-346` documents `loop activate --mode`.
+
+Clap wiring confirmed: `codex1 loop --help` shows `activate` first; `codex1 close --help` shows `record-review` as a peer of `check` and `complete`.
+
+### P2-1 (baseline): `CliError::Other` / `"INTERNAL"` removed — **FIXED**
+
+- Grep `CliError::Other` across `crates/codex1/src/**/*.rs`: 0 matches.
+- Grep `"INTERNAL"` across `crates/codex1/src/**/*.rs`: 0 matches as a code string. The only hit is a doc comment at `crates/codex1/src/core/config.rs:29` ("error set stays closed — there is no `INTERNAL` escape hatch"), which is the positive framing of the removal.
+- `crates/codex1/src/core/error.rs:21-76` enumerates the canonical `CliError` variants; no `Other(anyhow::Error)` variant exists. Every variant's `code()` string (lines 80-103) is in `docs/cli-contract-schemas.md:46-63`.
+- `crates/codex1/src/core/config.rs:26-44` now returns `CliError::ParseError` / `CliError::ConfigMissing` directly rather than propagating `anyhow::Error`.
+
+### P2-2 (baseline): Error envelope `hint`/`context` documented as optional-when-null — **FIXED**
+
+`docs/cli-contract-schemas.md:36-40`:
+
+> **Optional fields.** `hint` and `context` are omitted from the serialized envelope when they are null / empty — the CLI uses `#[serde(skip_serializing_if = "…")]` for both. Callers MUST treat missing `hint`/`context` as equivalent to the empty value. `ok`, `code`, `message`, and `retryable` are always present.
+
+Matches the observed envelope shape (`crates/codex1/src/core/envelope.rs:72-77`).
+
+### P2-3 (baseline): `Commands::Doctor` doc comment expanded — **FIXED**
+
+`crates/codex1/src/cli/mod.rs:77-82`:
+
+```rust
+/// Report CLI health as a stable JSON envelope: `version`, `config`
+/// path + existence, `install` (binary-on-PATH + `~/.local/bin`
+/// writability), `auth` (always `required: false`), `cwd`, and any
+/// `warnings`. Never crashes on missing auth or config — returns
+/// `{ok: true, ...}` and surfaces problems as warnings instead.
+Doctor,
+```
+
+Surfaces `version`, `config`, `install`, `auth`, `cwd`, `warnings` — all the real envelope fields — instead of the one-liner flagged in the baseline audit.
+
+## Re-verification of e2e-walkthrough fixes relevant to the contract
+
+Although the task does not ask for a separate e2e re-audit, the E2E fixes touch CLI-contract surfaces. A fresh mission walkthrough under `/tmp/codex1-iter1-e2e` re-exercised all seven fixes:
+
+| Baseline finding | Fix location | Re-verified in walkthrough step |
+| --- | --- | --- |
+| F1 — status.next_action and task next disagreed after T2/T3 → AwaitingReview | `crates/codex1/src/cli/status/next_action.rs:159-175` (AwaitingReview excluded from ready set for non-review kinds) | After T3 finish: `task next` returned `run_review T4 targets:[T2,T3]` AND `status.next_action` returned `run_review T4 targets:[T2,T3]`, `ready_tasks: ["T4"]`. Agreement. |
+| F2 — status.review_required did not consult state.reviews | `crates/codex1/src/cli/status/next_action.rs:102-108` (`ready_reviews` filters out reviews with Clean verdict) | After T4 recorded clean: `status.review_required: []`. After mission close: still empty. |
+| F3 — review record clean did not create a TaskRecord for the review task | `crates/codex1/src/cli/review/record.rs:286-340` (clean record now upserts TaskRecord with `status: complete`) | After T4 clean: `codex1 task status T4` → `{ status: "complete", kind: "review", deps_status: {T2: complete, T3: complete} }`. |
+| F4 — review packet envelope renamed `target_proofs` → `proofs` | `crates/codex1/src/cli/review/packet.rs` | `codex1 review packet T4` data keys now include `proofs` (not `target_proofs`). Verified both positively and negatively. |
+| F5 — review-record envelope extras documented | `docs/cli-contract-schemas.md:274-291` | Documented `findings_file`, `replan_triggered`, `warnings` as additive. |
+| F6 — task-finish proof path resolution documented | `docs/cli-contract-schemas.md:83-98` (new "Per-command relative path resolution" section) | Resolver rule stated; contrasts with `review record`/`close record-review` which resolve relative to CWD. |
+| F7 — CLOSEOUT.md Tasks table omitted T4 | Downstream of F3 | T4 now appears in the Tasks table of the generated CLOSEOUT.md (verified on iter1 walkthrough CLOSEOUT at `/tmp/codex1-iter1-e2e/PLANS/demo/CLOSEOUT.md`). |
+
+## Findings
+
+### P0: none.
+
+### P1: none.
+
+### P2-1 (new, only): `cargo clippy --all-targets -- -D warnings` fails at `crates/codex1/tests/plan_scaffold.rs:38`
+
+- **Severity:** P2.
+- **Where:** `crates/codex1/tests/plan_scaffold.rs:38` uses `let outcome = r#"---"#;` (raw string with hashes) where `r"..."` suffices because the string contains no inner `"#`. Clippy's `needless_raw_string_hashes` lint (stable-default in the `rust-clippy 1.94.0` toolchain in use) rejects this under `-D warnings`.
+- **Observed:**
+  ```bash
+  $ cargo clippy --all-targets -- -D warnings
+  error: unnecessary hashes around raw string literal
+    --> crates/codex1/tests/plan_scaffold.rs:38:19
+     |
+  38 |       let outcome = r#"---
+  ... (67 lines elided)
+  68 | | "#;
+     |
+     = note: `-D clippy::needless-raw-string-hashes` implied by `-D warnings`
+
+  error: could not compile `codex1` (test "plan_scaffold") due to 1 previous error
+  ```
+- **Expected:** Clippy passes with `-D warnings`. The commit message of `6473650` states "cargo fmt + cargo clippy --all-targets -- -D warnings clean," which is falsifiable on the same tree. Either the raw string should be `r"---\n...\n"` (drop the `#` hashes), or the lint should be `#[allow]`-ed with a rationale.
+- **Contract reference:** Not a CLI-schema issue; a build-gate claim issue. The commit message creates a promise (the `-D warnings` gate is passing); re-verification shows it isn't. Left at P2 because no runtime behavior changes, but the gate-claim mismatch is real.
+- **Fix sketch:** Replace `r#"---\n...\n"#` with `r"---\n...\n"` (no hashes). Or add `#[allow(clippy::needless_raw_string_hashes)]` above `fn seed_valid_outcome` with a one-line rationale.
+- **Scope note:** The task explicitly forbids modifying existing test files; I did not apply the fix, only reported it.
+
+## Clean-checks (no findings)
+
+### Minimal command surface
+
+All 25 verbs from `docs/codex1-rebuild-handoff/02-cli-contract.md:55-94` resolve via clap:
+
+| Verb | clap site |
+| --- | --- |
+| `codex1 init` | `crates/codex1/src/cli/mod.rs:76`, `init.rs` |
+| `codex1 status` | `cli/mod.rs:124`, `status/mod.rs` |
+| `codex1 outcome check` / `ratify` | `outcome/mod.rs` |
+| `codex1 plan choose-level` / `scaffold` / `check` / `graph` / `waves` | `plan/mod.rs` |
+| `codex1 task next` / `start` / `finish` / `status` / `packet` | `task/mod.rs` |
+| `codex1 review start` / `packet` / `record` / `status` | `review/mod.rs` |
+| `codex1 replan record` / `check` | `replan/mod.rs` |
+| `codex1 loop pause` / `resume` / `deactivate` / `activate` | `loop_/mod.rs` |
+| `codex1 close check` / `complete` / `record-review` | `close/mod.rs` |
+
+Verified live by walking `codex1 <group> --help` for each group.
+
+### Every error code in `crates/codex1/src/**/*.rs` is canonical
+
+- `CliError` variant codes (`crates/codex1/src/core/error.rs:80-103`): `OUTCOME_INCOMPLETE`, `OUTCOME_NOT_RATIFIED`, `PLAN_INVALID`, `DAG_CYCLE`, `DAG_MISSING_DEP`, `TASK_NOT_READY`, `PROOF_MISSING`, `REVIEW_FINDINGS_BLOCK`, `REPLAN_REQUIRED`, `CLOSE_NOT_READY`, `STATE_CORRUPT`, `REVISION_CONFLICT`, `STALE_REVIEW_RECORD`, `TERMINAL_ALREADY_COMPLETE`, `CONFIG_MISSING`, `MISSION_NOT_FOUND`, `PARSE_ERROR`, `NOT_IMPLEMENTED`. All 18 appear in the canonical table at `docs/cli-contract-schemas.md:46-63`.
+- Raw-string codes constructed in handler source:
+  - `cli/plan/check.rs:504-515` (`exit_with_validation_error`) uses only `PLAN_INVALID`, `DAG_CYCLE`, `DAG_MISSING_DEP`.
+  - `cli/close/check.rs` `Blocker::new(...)` sites use only `OUTCOME_NOT_RATIFIED`, `PLAN_INVALID`, `REPLAN_REQUIRED`, `TASK_NOT_READY`, `REVIEW_FINDINGS_BLOCK`, `CLOSE_NOT_READY`.
+- No handler constructs a bespoke `JsonErr` with a non-canonical code.
+
+### `status` ↔ `close check` agreement across 6 synthetic STATE.json fixtures
+
+Six hand-authored STATE.json fixtures were dropped into `/tmp/codex1-iter1-fix-<N>/PLANS/m1/STATE.json` (with the same locked PLAN.yaml + OUTCOME.md), then `codex1 status` and `codex1 close check` were run against each.
+
+| Fixture | `status.verdict` | `status.close_ready` | `close check.verdict` | `close check.ready` |
+| --- | --- | --- | --- | --- |
+| 1. Fresh init (outcome unratified, plan unlocked) | `needs_user` | `false` | `needs_user` | `false` |
+| 2. Plan locked, T1 ready, no tasks started | `continue_required` | `false` | `continue_required` | `false` |
+| 3. All tasks complete, T2 review clean, mission-close not started | `ready_for_mission_close_review` | `false` | `ready_for_mission_close_review` | `false` |
+| 4. Mission-close review passed | `mission_close_review_passed` | `true` | `mission_close_review_passed` | `true` |
+| 5. Terminal (`close.terminal_at` set) | `terminal_complete` | `false` | `terminal_complete` | `false` |
+| 6. Replan triggered (`replan.triggered: true`) | `blocked` | `false` | `blocked` | `false` |
+
+`status.close_ready` equals `close check.ready` in every row. Both surfaces derive through `crates/codex1/src/state/readiness.rs::derive_verdict`, so disagreement would be a logic error in one of two consumers — none was observed.
+
+### Test suite flake (informational, not a finding)
+
+On a cold target cache, `cargo test --release` has been observed to fail 7 tests in `tests/close.rs` because `Command::cargo_bin("codex1")` looked up the release binary before cargo finished building the bin crate. Re-running `cargo test --release` without other changes yields 169 / 169 passing. Not a product bug; not a contract issue; documented here so the next reviewer can distinguish flake from regression.
+
+### Stable JSON envelopes
+
+- Success envelope (`crates/codex1/src/core/envelope.rs:20-29`): `{ ok: true, mission_id?, revision?, data }`. Verified live on `doctor`, `init`, `outcome ratify`, `plan choose-level`, `plan scaffold`, `plan check`, `plan waves`, `plan graph`, `task next`, `task start`, `task finish`, `review start`, `review packet`, `review record`, `close check`, `close record-review`, `close complete`, `status`.
+- Error envelope (`core/envelope.rs:67-78`): `{ ok: false, code, message, hint?, retryable, context? }`. Verified live on `plan choose-level` (OUTCOME_NOT_RATIFIED), `plan check` (PLAN_INVALID), `close check` (CLOSE_NOT_READY via blockers), `close complete` (TERMINAL_ALREADY_COMPLETE on re-run).
+
+### Global flags
+
+`--mission <ID>`, `--repo-root <PATH>`, `--json`, `--dry-run`, `--expect-revision <N>` are globals on every subcommand per `cli/mod.rs:43-69`. `codex1 <cmd> --help` renders all five on every leaf.
+
+## Reading map
+
+- `crates/codex1/src/cli/plan/choose_level.rs:19-40` — P1-1 fix landing site.
+- `docs/codex1-rebuild-handoff/02-cli-contract.md:55-104` — P1-2 fix landing site (handoff).
+- `docs/cli-contract-schemas.md:320-346` — P1-2 fix landing site (schemas).
+- `crates/codex1/src/core/error.rs`, `crates/codex1/src/core/config.rs:26-44` — P2-1 landing sites.
+- `docs/cli-contract-schemas.md:36-40` — P2-2 landing site.
+- `crates/codex1/src/cli/mod.rs:77-82` — P2-3 landing site.
+- `crates/codex1/tests/plan_scaffold.rs:38` — new P2-1 (iter1) finding.

--- a/docs/audits/iter1-handoff-cross-check.md
+++ b/docs/audits/iter1-handoff-cross-check.md
@@ -1,0 +1,173 @@
+# Handoff Cross-Check — iter1 (post-6473650)
+
+Branch audited: `audit-iter1-wave` (off `main`) @ `6473650`
+Audited on: 2026-04-20 UTC.
+
+## Build / test evidence (iter1 header)
+
+| Gate | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | FAIL (see `iter1-cli-contract-audit.md` P2-1; not a handoff issue) |
+| `cargo test --release` | PASS — 169 tests across 19 test binaries (steady-state). Cold-cache flake documented in the CLI audit. |
+
+Clippy failure is in a test file, not a handoff artifact; reported in the CLI contract audit.
+
+## Scope
+
+Cross-checks every "Non-Negotiable" and "Anti-Goal" declared in:
+
+- `docs/codex1-rebuild-handoff/00-why-and-lessons.md` § What To Reject.
+- `docs/codex1-rebuild-handoff/README.md` § Non-Negotiables and § Explicit Anti-Goals.
+- `docs/codex1-rebuild-handoff/02-cli-contract.md` § Important Non-Features.
+
+For each anti-goal I verified whether it is honored in live code, skills, scripts, and docs.
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.** Every declared anti-goal is still honored post-6473650. `.ralph/` only appears as an explicit prohibition in documentation, scripts, and skill prose; caller-identity patterns do not exist in Rust source; `plan scaffold` does not emit a `waves:` key; reviewer writeback is positively forbidden in `$review-loop`; no wrapper runtime, daemon, or subagent-spawning process is invoked by the CLI; Ralph's Stop hook only calls `codex1 status --json`.
+
+## Findings
+
+None.
+
+## Clean checks (anti-goal by anti-goal)
+
+### CC-1: No `.ralph/` live directory, path, or import
+
+- `/Users/joel/codex1/.ralph/` does not exist as a filesystem entry (`ls -la` returns `No such file or directory`).
+- All 20-ish matches for the substring `.ralph` in the repo (excluding `target/**`) are either (a) inside handoff docs where `.ralph` is defined as an anti-goal, (b) inline prohibitions in skill prose, (c) assertions in iter1 / baseline audit files, or (d) a doc-comment in `crates/codex1/src/lib.rs:9`. Key live-code/script citations:
+
+| File | Line(s) | Kind |
+| --- | --- | --- |
+| `crates/codex1/src/lib.rs` | 9 | Doc-comment ("never hides state in `.ralph/`.") |
+| `.codex/skills/close/SKILL.md` | 112 | Positive prohibition |
+| `scripts/README-hook.md` | 19 | Hook scope ("hook does not read `.ralph/` directories") |
+| `README.md` | 3 | Anti-goal prose |
+| `docs/mission-anatomy.md` | 3 | Anti-goal prose |
+| `docs/codex1-rebuild-handoff/**` | multiple | Anti-goal doc lines |
+
+No `std::fs`, `Path::new`, `PathBuf`, `include_str!`, `include_bytes!`, or shell invocation in the repo references a `.ralph` path.
+
+### CC-2: No caller-identity checks in Rust source
+
+Grep over `crates/codex1/src/**/*.rs` for:
+
+```text
+is_parent | is_subagent | caller_type | reviewer_id | session_id |
+session_token | capability_token | authority_token
+```
+
+**0 matches** across all Rust source.
+
+`crates/codex1/src/cli/mod.rs:128-134` defines `Ctx` with only `{ mission, repo_root, json, dry_run, expect_revision }`; no caller-side identity is extracted or inspected. The comment at `crates/codex1/src/cli/review/mod.rs` is explicit: "The CLI does not check caller identity; the main thread records review outcomes."
+
+### CC-3: No `waves:` key emitted by `plan scaffold`
+
+- `crates/codex1/src/cli/plan/scaffold.rs:119-171` (`render_skeleton`) composes the PLAN.yaml skeleton. The output contains `mission_id`, `planning_level`, `outcome_interpretation`, `architecture`, `planning_process`, `tasks`, `risks`, and `mission_close` — no `waves:` key.
+- Grep for `waves:` as a YAML key emission across the repo: 0 hits.
+- `codex1 plan waves --json` (at `crates/codex1/src/cli/plan/waves.rs`) recomputes waves from `tasks[].depends_on` + state on each call. No persisted `waves:` collection is read from any artifact.
+- `crates/codex1/src/state/schema.rs:170-188` defines `MissionState` with no `waves` field.
+
+### CC-4: Reviewer writeback is positively forbidden
+
+`$review-loop`'s skill body and references explicitly state that the main thread records, not the reviewer:
+
+- `.codex/skills/review-loop/SKILL.md:11`: "The main thread is the sole writer of mission truth: it records clean/dirty via `codex1 review record` (planned review) or `codex1 close record-review` (mission close)."
+- `.codex/skills/review-loop/SKILL.md:63`: "Every spawn prompt must begin with the standing reviewer block in `references/reviewer-profiles.md` (findings-only, no edits, no `codex1` mutations, no repairs, no marking clean anywhere). The main thread is the sole writer of mission truth. Reviewer writeback is forbidden."
+- `.codex/skills/review-loop/SKILL.md:79`: "Record review results from inside a reviewer subagent — only the main thread records."
+- `.codex/skills/review-loop/references/reviewer-profiles.md` (standing reviewer instructions): "Do not edit files. Do not invoke Codex1 skills. Do not run codex1 mutating commands (no `review record`, `task finish`, `close *`, etc.). Do not record mission truth."
+- `.codex/skills/execute/SKILL.md:117`: "Do not spawn reviewers, run `codex1 review record`, or write to `reviews/`."
+
+Positive and negative forms are both present — exactly what the handoff asks for.
+
+### CC-5: No wrapper runtime / `codex1-runtime` / `ralph-daemon`
+
+Grep over the repo for `codex1-runtime | ralph-daemon | wrapper_runtime`:
+
+```bash
+$ grep -rI --exclude-dir=target "codex1-runtime\|ralph-daemon\|wrapper_runtime" .
+# (only matches are inside audit docs describing the anti-goal)
+```
+
+Grep for `Command::new("codex")` / `Command::new("claude")` / `spawn_process`:
+
+- `crates/codex1/src/cli/doctor.rs` probes for a `codex1` binary on `PATH` (non-invocation — it only checks path existence).
+- `scripts/ralph-stop-hook.sh:25` runs exactly one command: `"$CODEX1" status --json`.
+- No `std::process::Command::spawn` / `tokio::spawn` is used to launch any background worker, daemon, or helper process.
+
+The binary is a one-shot CLI on every invocation. No wrapper runtime exists.
+
+### CC-6: CLI does not spawn subagents or read hidden chat state
+
+- `crates/codex1/src/cli/**/*.rs` contains no `Command::new("codex")`, `Command::new("claude")`, or AI-model invocation.
+- The only stdin consumer is `crates/codex1/src/cli/plan/choose_level.rs:102-120`, and only when stdin is a TTY (the documented interactive level prompt).
+- `codex1 task packet` and `codex1 review packet` emit prompt strings for the main thread to paste into a subagent; neither spawns anything itself.
+
+### CC-7: Ralph is status-only
+
+`scripts/ralph-stop-hook.sh` (60 lines):
+
+- Drains stdin.
+- Probes for `codex1` on `PATH` (or via `$CODEX1_BIN`).
+- Runs exactly one command: `codex1 status --json` (line 25).
+- Parses `.data.stop.allow` with `jq` (or a degraded grep fallback).
+- Exits 2 iff `allow == false`, else 0.
+
+It never reads `PLAN.yaml`, `STATE.json`, `EVENTS.jsonl`, reviews, specs, or `.ralph/`. It never spawns another process. `scripts/README-hook.md:19-22` makes this promise explicit.
+
+`codex1 hook snippet` (`crates/codex1/src/cli/hook.rs`) only prints wiring JSON; it does not install, probe, or invoke anything.
+
+### CC-8: Stored waves are not treated as editable truth
+
+- `crates/codex1/src/state/schema.rs:170-188` (`MissionState`) has no `waves` field.
+- `crates/codex1/src/cli/plan/waves.rs` derives waves on demand from plan tasks + state.
+- `docs/cli-contract-schemas.md:100-119` pins the Rust types for `MissionState`; no `waves:` collection is listed.
+
+### CC-9: No capability tokens / authority tokens / session-id authority
+
+Grep for `session_id | session_token | capability_token | authority_token` across `crates/codex1`: 0 matches.
+
+No handler accepts, mints, stores, or validates any capability/authority token. Mutating commands gate on `--expect-revision` (a state-file revision counter), not on any caller-identity credential.
+
+### CC-10: `docs/cli-contract-schemas.md` remains foundation-owned
+
+The file's own declaration at `docs/cli-contract-schemas.md:369-385` pins it Foundation-owned. This audit does not modify it (nor any Rust source or existing doc).
+
+Commit `6473650` legitimately expanded `cli-contract-schemas.md` to fix baseline P1-2, P2-2, F4, F5, F6 — those are Foundation-level changes documented in the commit message.
+
+### CC-11: CLI does not ask semantic questions
+
+`crates/codex1/src/cli/plan/choose_level.rs:102-120` is the only interactive prompt in the entire CLI. It asks a single question: which of `light | medium | hard` to record. It does not ask semantic clarification questions about the mission. Per `docs/codex1-rebuild-handoff/02-cli-contract.md:45-46` this is the explicitly sanctioned exception.
+
+All other commands are non-interactive and emit JSON.
+
+### CC-12: Visible mission files only
+
+`crates/codex1/src/core/paths.rs` resolves `PLANS/<mission>/{OUTCOME.md, PLAN.yaml, STATE.json, EVENTS.jsonl, specs/, reviews/, CLOSEOUT.md}`. Every mutating command uses these paths; no handler writes outside `PLANS/<mission>/`. There is no side-cache, side-state, or hidden dotfile.
+
+## Reading map
+
+| Anti-goal (handoff source) | Verified at |
+| --- | --- |
+| `00-why-and-lessons.md:82` – "No `.ralph` mission truth." | CC-1 |
+| `00-why-and-lessons.md:84` – "No caller identity checks." | CC-2 |
+| `00-why-and-lessons.md:86` – "No reviewer writeback authority systems." | CC-4 |
+| `00-why-and-lessons.md:87` – "No stored waves as editable truth." | CC-3, CC-8 |
+| `00-why-and-lessons.md:80` – "No hidden daemons." | CC-5 |
+| `00-why-and-lessons.md:81` – "No wrapper runtimes around Codex." | CC-5 |
+| `README.md:79` – "No `.ralph/` mission state directory." | CC-1 |
+| `README.md:78` – "CLI must not detect parent vs subagent." | CC-2 |
+| `README.md:89` – "No session-ID authority system." | CC-9 |
+| `README.md:91` – "No capability-token maze." | CC-9 |
+| `README.md:92` – "No reviewer writeback authority tokens." | CC-4 |
+| `README.md:93` – "No stored waves as canonical truth." | CC-3, CC-8 |
+| `README.md:95` – "A CLI that spawns subagents." | CC-6 |
+| `README.md:96` – "A CLI that asks semantic clarification questions." | CC-11 |
+| `02-cli-contract.md:112` – "Must not ask 'are you parent or subagent?'" | CC-2 |
+| `02-cli-contract.md:117` – "Must not use `.ralph` mission truth." | CC-1 |
+| `02-cli-contract.md:118` – "Must not store waves as editable truth." | CC-3, CC-8 |
+| `02-cli-contract.md:115` – "Must not spawn subagents." | CC-6 |
+| `01-product-flow.md` – "Ralph must not inspect plan/review files directly." | CC-7 |
+
+Every anti-goal was verified clean. No P0/P1/P2 findings.

--- a/docs/audits/iter1-skills-audit.md
+++ b/docs/audits/iter1-skills-audit.md
@@ -1,0 +1,147 @@
+# Skills Audit — iter1 (post-6473650)
+
+Branch audited: `audit-iter1-wave` (off `main`) @ `6473650`
+Audited on: 2026-04-20 UTC
+Skill folders: `.codex/skills/{autopilot,clarify,close,execute,plan,review-loop}`
+
+## Build / test evidence (iter1 header)
+
+| Gate | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | FAIL (see `iter1-cli-contract-audit.md` P2-1; not a skills issue) |
+| `cargo test --release` | PASS — 169 tests across 19 test binaries (steady-state); first run on cold cache flakes tests that invoke `Command::cargo_bin("codex1")`, clears on re-run. |
+
+Clippy failure is unrelated to skill content; scoped to the CLI-contract audit.
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.** Every skill still passes `quick_validate.py`, has exactly `name` + `description` frontmatter, bodies under 500 lines, proper `agents/openai.yaml` with literal `$<skill-name>` default prompts, no forbidden files, invokes the CLI verbs it exists to drive, and honors every declared anti-goal (no `.ralph/` usage, no reviewer writeback, no stored waves, no caller-identity prose).
+
+## Findings
+
+None.
+
+## Per-skill validation (`quick_validate.py`)
+
+```text
+=== autopilot ===    Skill is valid!
+=== clarify ===      Skill is valid!
+=== close ===        Skill is valid!
+=== execute ===      Skill is valid!
+=== plan ===         Skill is valid!
+=== review-loop ===  Skill is valid!
+```
+
+Script run: `python3 /Users/joel/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>` for each.
+
+## Frontmatter shape
+
+Every `SKILL.md` declares exactly `name` + `description`. `name` matches the folder name.
+
+| Skill | Folder | `name:` in SKILL.md | Other frontmatter keys |
+| --- | --- | --- | --- |
+| autopilot | `.codex/skills/autopilot/` | `autopilot` | none |
+| clarify | `.codex/skills/clarify/` | `clarify` | none |
+| close | `.codex/skills/close/` | `close` | none |
+| execute | `.codex/skills/execute/` | `execute` | none |
+| plan | `.codex/skills/plan/` | `plan` | none |
+| review-loop | `.codex/skills/review-loop/` | `review-loop` | none |
+
+`quick_validate.py` accepts `license`, `allowed-tools`, and `metadata`; none appear. Descriptions are single prose blocks with no angle brackets and well under the 1024-character validator ceiling.
+
+## Body length (all < 500 lines)
+
+| Skill | SKILL.md lines |
+| --- | --- |
+| autopilot | 133 |
+| clarify | 60 |
+| close | 112 |
+| execute | 122 |
+| plan | 205 |
+| review-loop | 81 |
+
+Unchanged from the baseline audit.
+
+## `agents/openai.yaml` literal `$<skill-name>` references
+
+Every skill ships an `agents/openai.yaml` whose `interface.default_prompt` mentions the skill literally as `$<name>`:
+
+| Skill | `default_prompt` excerpt | Literal `$<name>`? |
+| --- | --- | --- |
+| autopilot | `Use $autopilot to take a Codex1 mission from clarify to terminal close.` | Yes |
+| clarify | `Use $clarify to fill and ratify OUTCOME.md before planning.` | Yes |
+| close | `Use $close to pause the active loop so the user can talk without Ralph forcing continuation.` | Yes |
+| execute | `Use $execute to run the next ready task or wave for the active Codex1 mission.` | Yes |
+| plan | `Use $plan to scaffold, fill, and lock PLAN.yaml for the active mission.` | Yes |
+| review-loop | `Use $review-loop to run reviewer subagents and record clean/dirty findings.` | Yes |
+
+All six yaml files also pin `policy.allow_implicit_invocation: true` as the only policy key.
+
+## No forbidden files inside skill folders
+
+```bash
+$ find .codex/skills -type f \( -name "README.md" -o -name "INSTALLATION_GUIDE.md" -o -name "CHANGELOG.md" \)
+# (no output)
+```
+
+Every skill folder contains only `SKILL.md`, `agents/openai.yaml`, and (for five of six) a `references/` directory.
+
+## CLI commands each skill drives
+
+Every skill body invokes the CLI verbs it exists to orchestrate:
+
+| Skill | `codex1` verbs cited in SKILL.md | Notes |
+| --- | --- | --- |
+| `$clarify` | `codex1 init --mission`, `codex1 status`, `codex1 outcome check`, `codex1 outcome ratify` | Matches mission to ratify OUTCOME.md. |
+| `$plan` | `codex1 plan choose-level`, `codex1 plan scaffold`, `codex1 plan check`, `codex1 plan graph`, `codex1 plan waves`, `codex1 replan record --supersedes`, plus status hand-off references. |
+| `$execute` | `codex1 status`, `codex1 task next`, `codex1 task start`, `codex1 task packet`, `codex1 task finish` | Explicitly forbids `codex1 review record`. |
+| `$review-loop` | `codex1 task next`, `codex1 review start`, `codex1 review packet`, `codex1 review record`, `codex1 close check`, `codex1 close record-review` | Reads `data.proofs` (post-F4 canonical name). |
+| `$close` | `codex1 loop pause`, `codex1 loop resume`, `codex1 loop deactivate`, `codex1 close complete`, `codex1 status` | |
+| `$autopilot` | `codex1 init`, `codex1 status`, `codex1 plan choose-level`, `codex1 close check`, `codex1 close complete`, plus composes the other five skills. |
+
+## Handoff anti-goals honored
+
+- **No live `.ralph/` directory.** The single skill mention is `close/SKILL.md:112` — a positive prohibition (`- Do not edit .ralph/ files, STATE.json, or hooks to work around Ralph.`). No skill body stores, reads, or creates `.ralph/` state.
+- **No reviewer writeback.** `review-loop/SKILL.md:11, 63, 79` all explicitly state "The main thread is the sole writer of mission truth" / "Reviewer writeback is forbidden" / "Record review results from inside a reviewer subagent — only the main thread records." `references/reviewer-profiles.md` restates the ban in the standing reviewer block. `execute/SKILL.md:117` reinforces it from the orchestration side.
+- **No stored waves.** `plan/SKILL.md:199` says `Do not store waves inside PLAN.yaml. Waves are derived.` `references/dag-quality.md:15` reinforces. Grep across `.codex/skills/` for `waves:` matches only prose about derivation, never a YAML key emission.
+- **No caller-identity semantics.** No skill body asks the CLI to detect caller identity. Role separation is prompt-governed; `review-loop/SKILL.md:77-82` and `autopilot/SKILL.md:120-127` rely on prompt templates rather than CLI checks.
+- **Six-consecutive-dirty replan rule is canonical.** `review-loop/SKILL.md:35` ("Inspect `data.replan_triggered`") and `execute/SKILL.md:107` both defer replan decisions to the CLI's counter, not to local bookkeeping.
+
+## Skill folders layout
+
+```
+.codex/skills/
+├── autopilot/
+│   ├── agents/openai.yaml
+│   ├── references/autopilot-state-machine.md
+│   └── SKILL.md
+├── clarify/
+│   ├── agents/openai.yaml
+│   ├── references/outcome-shape.md
+│   └── SKILL.md
+├── close/
+│   ├── agents/openai.yaml
+│   └── SKILL.md
+├── execute/
+│   ├── agents/openai.yaml
+│   ├── references/worker-packet-template.md
+│   └── SKILL.md
+├── plan/
+│   ├── agents/openai.yaml
+│   ├── references/dag-quality.md
+│   ├── references/hard-planning-evidence.md
+│   └── SKILL.md
+└── review-loop/
+    ├── agents/openai.yaml
+    ├── references/reviewer-profiles.md
+    └── SKILL.md
+```
+
+Unchanged from the baseline audit; no new skills were added and none were removed.
+
+## Fresh pass notes (no findings)
+
+1. `review-loop/SKILL.md:21` reads `data.proofs` explicitly, matching the F4 fix in the binary. No skill references the old `target_proofs` field name anywhere. If a skill still referenced `target_proofs`, it would silently break against the post-6473650 CLI; none does.
+2. `$close` continues to document both the pause-for-discussion path and the terminal-close path (`close complete`). The handoff-level split between "discussion boundary" and "mission completion" is carried through the skill body's "Terminal close" section (`close/SKILL.md:68-91`), gated on `verdict == mission_close_review_passed` plus explicit user confirmation. Informational, not a finding.
+3. `$review-loop` correctly invokes `codex1 close record-review` for the mission-close boundary. Baseline P1-2 (CLI audit) added this verb to the handoff's minimal surface; the skill's invocation is now consistent with the handoff.


### PR DESCRIPTION
Re-audit after commit 6473650 fixes. See docs/audits/iter1-*.md.

## Summary

- iter1-cli-contract: 0 P0, 0 P1, 1 P2 (new clippy finding)
- iter1-skills:       0 P0, 0 P1, 0 P2
- iter1-handoff:      0 P0, 0 P1, 0 P2

Every baseline P1/P2 finding from cli-contract-audit.md, skills-audit.md, handoff-cross-check.md, and e2e-walkthrough-audit.md was re-verified against the post-6473650 tree. All fixes hold.

The single new P2: commit 6473650's message claims `cargo clippy --all-targets -- -D warnings` is clean, but the same tree fails at `crates/codex1/tests/plan_scaffold.rs:38` (needless raw-string hashes). Reported only — test files are out of scope for this audit.

## Test plan

- [x] `cargo fmt --check` — PASS
- [x] `cargo test --release` — 169 tests PASS (steady-state; cold-cache flake in close.rs documented as informational)
- [x] `cargo clippy --all-targets -- -D warnings` — FAIL at `crates/codex1/tests/plan_scaffold.rs:38` (the one new finding)
- [x] Live `/tmp` re-verification of P1-1 (OUTCOME_NOT_RATIFIED gate)
- [x] 6 synthetic STATE.json fixtures confirm `status` ↔ `close check` agreement on `close_ready`
- [x] End-to-end mission walkthrough confirms F1-F7 fixes stick (status/task-next agreement, review_required filtering, review TaskRecord creation, `proofs` field rename, CLOSEOUT.md T4 inclusion)
- [x] 6/6 skills pass `quick_validate.py`; frontmatter clean; bodies < 500 lines; no forbidden files; literal `$<skill-name>` in every `agents/openai.yaml`
- [x] Handoff anti-goals: no live `.ralph/`, no caller-identity grep hits, no `waves:` key in `plan scaffold`, reviewer writeback positively forbidden, hook only calls `codex1 status --json`