### PR TITLE
iter3 audit: wave (post-958d2f1)

### DIFF
--- a/docs/audits/iter3-cli-contract-audit.md
+++ b/docs/audits/iter3-cli-contract-audit.md
@@ -1,0 +1,328 @@
+# CLI Contract Audit — iter 3
+
+Branch audited: `main` @ `958d2f1`
+Audited on: 2026-04-20 UTC
+Binary: `target/release/codex1 0.1.0` (built from `958d2f1`).
+
+## Scope
+
+Fresh pass on every command listed in `docs/codex1-rebuild-handoff/02-cli-contract.md` § Minimal Command Surface. Re-ran the iter 2 checks (command surface, envelope, error codes, status ↔ close-check agreement) plus the iter 3 mandate to verify commit `958d2f1`'s F8 fix:
+
+- `plan.task_ids` field presence on `state::schema::PlanState`.
+- `plan check` writes `plan.task_ids` from the parsed PLAN.yaml DAG.
+- `readiness::tasks_complete` consults `state.plan.task_ids`, not `state.tasks.values()`.
+- No alternative "all tasks done" predicate anywhere else in the CLI bypasses the fix.
+- Every caller of `tasks_complete` is `derive_verdict`.
+
+## Summary
+
+**FAIL — 2 P0, 1 P1, 1 P2.**
+
+The iter 2 F8 fix (verdict path) correctly resolves the core semantic bug in `state::readiness::derive_verdict`. But the same commit introduced two build-evidence regressions (clippy-breaking line, test fixtures not updated) that the task's "Build evidence (required)" block treats as P0. A second, distinct `tasks_all_complete` predicate in `close/check.rs` still uses the buggy pattern and produces misleading blocker messages; this is the audit-scope question "is there an alternative `all tasks done` predicate anywhere else" answered with "yes." A latent migration hazard affects any `STATE.json` locked by a pre-`958d2f1` binary.
+
+## Build evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | **FAIL** (see F1) |
+| `cargo test --release --no-fail-fast` | **FAIL** — 167 passed / 2 failed / 169 total (see F2) |
+
+Verbatim clippy failure:
+
+```text
+error: assigning the result of `Clone::clone()` may be inefficient
+   --> crates/codex1/src/cli/plan/check.rs:109:13
+    |
+109 |             s.plan.task_ids = task_ids_to_record.clone();
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `s.plan.task_ids.clone_from(&task_ids_to_record)`
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#assigning_clones
+    = note: `-D clippy::assigning-clones` implied by `-D warnings`
+error: could not compile `codex1` (lib) due to 1 previous error
+```
+
+Verbatim test failures:
+
+```text
+test all_tasks_complete_reports_ready_for_mission_close_review ... FAILED
+test mission_close_review_passed_reports_close_next_action ... FAILED
+test result: FAILED. 12 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+## Findings
+
+### F1 (P0): clippy regression in the F8 fix itself
+
+- **Severity:** P0. The task's "Build evidence (required)" block explicitly requires `cargo clippy --all-targets -- -D warnings` to pass. It does not. The regression was introduced by the same commit (`958d2f1`) that was supposed to close iter 2's P0.
+- **Where:** `crates/codex1/src/cli/plan/check.rs:109`:
+  ```rust
+  s.plan.task_ids = task_ids_to_record.clone();
+  ```
+- **Lint:** `clippy::assigning_clones` — stable in Rust 1.78, enabled here by `-D warnings`.
+- **Expected:** `s.plan.task_ids.clone_from(&task_ids_to_record);` (per clippy's own fix hint).
+- **Fix sketch:** one-line replacement; the closure already holds a `&task_ids_to_record` capture, so `clone_from` works as-is. Alternatively move the value (the closure is a `FnOnce`, so `s.plan.task_ids = task_ids_to_record;` would compile after restructuring — but `clone_from` is the cleanest drop-in.)
+- **Evidence of provenance:** `git show 958d2f1 -- crates/codex1/src/cli/plan/check.rs` shows line 109 is part of this commit; iter 1 commit `271b2fc` touched a different file; `6473650` did not touch `plan/check.rs`. The regression is unique to iter 2's F8 fix.
+
+### F2 (P0): test regressions in the F8 fix
+
+- **Severity:** P0. `cargo test --release` is one of three required build-evidence commands. It fails on two tests.
+- **Where:**
+  - `crates/codex1/tests/status.rs:329` — `all_tasks_complete_reports_ready_for_mission_close_review`
+  - `crates/codex1/tests/status.rs:361` — `mission_close_review_passed_reports_close_next_action`
+- **Root cause:** Both fixtures set `plan.locked = true` and insert `T1..T4` into `state.tasks` with status `Complete`, but never populate `state.plan.task_ids`. After the F8 fix, `readiness::tasks_complete` consults `state.plan.task_ids` (empty → `return false`), so the verdict collapses to `continue_required` instead of `ready_for_mission_close_review` / `mission_close_review_passed`.
+- **Failing assertions:**
+  ```text
+  assertion `left == right` failed
+    left: String("continue_required")
+   right: "ready_for_mission_close_review"
+  (at crates/codex1/tests/status.rs:355)
+
+  assertion `left == right` failed
+    left: String("continue_required")
+   right: "mission_close_review_passed"
+  (at crates/codex1/tests/status.rs:388)
+  ```
+- **Why this is a real regression, not a stale test:** the F8 commit's diff (`git show 958d2f1 --stat`) updated fixtures in `crates/codex1/tests/close.rs` (via `StateBuilder::build()` that now auto-populates `task_ids`) and `crates/codex1/tests/status_close_agreement.rs` (explicit `s.plan.task_ids = dag.clone()` at every `plan.locked = true` site). The same pass failed to update `crates/codex1/tests/status.rs`, which hand-builds fixtures in-line without the builder. Both `status.rs` tests express valid contract expectations: the first says "all DAG tasks complete + close.NotStarted → `ready_for_mission_close_review`"; the second says "all DAG tasks complete + close.Passed → `mission_close_review_passed` + `close_ready: true`". Neither expectation changed; only the fixtures need the new `task_ids` field.
+- **Fix sketch (not applied — audit-only):** Add `state.plan.task_ids = vec!["T1".into(), "T2".into(), "T3".into(), "T4".into()];` alongside the `state.plan.locked = true` line in each of the two tests (lines 333 and 365). That matches the pattern the fix applied in `status_close_agreement.rs`.
+- **Scope note:** `status.rs` has 10 total sites that set `plan.locked = true`; only these two additionally require `tasks_complete == true` to satisfy their assertions. The other 8 tests correctly pin `continue_required` regardless of `task_ids`, so the regression is bounded to these two.
+
+### F3 (P1): alternative "all tasks done" predicate still uses the buggy pattern
+
+- **Severity:** P1. The audit scope explicitly asked: "Verify there is no alternative `all tasks done` predicate anywhere else in the CLI that could bypass the fix." There is one.
+- **Where:** `crates/codex1/src/cli/close/check.rs:132-140`:
+  ```rust
+  fn tasks_all_complete(state: &MissionState) -> bool {
+      if state.tasks.is_empty() {
+          return false;
+      }
+      state
+          .tasks
+          .values()
+          .all(|t| matches!(t.status, TaskStatus::Complete | TaskStatus::Superseded))
+  }
+  ```
+  Used at `close/check.rs:111` to gate the `CLOSE_NOT_READY` blocker emission. This is the exact pattern that iter 2 rewrote in `state::readiness::tasks_complete`, untouched.
+- **Observed live impact** (reproduction recorded below):
+
+  Setup: `plan.locked=true`, `plan.task_ids=["T1","T2","T3","T4"]`, `state.tasks={T1: Complete}`, `close.review_state = NotStarted`, full PLAN.yaml present.
+  ```bash
+  $ codex1 --json close check --mission demo
+  {
+    "ok": true,
+    "data": {
+      "blockers": [
+        { "code": "CLOSE_NOT_READY", "detail": "mission-close review has not started" }
+      ],
+      "ready": false,
+      "verdict": "continue_required"
+    }
+  }
+  ```
+  `verdict: continue_required` is correct (via the fixed `readiness::tasks_complete`). But the blocker list says "mission-close review has not started" — which is a false signal. The real blockers are T2, T3, T4 being un-started. The `for (task_id, record) in &state.tasks` loop at `check.rs:95` only iterates entries that exist in `state.tasks`; T2/T3/T4 are not in the map, so no `TASK_NOT_READY` blocker is emitted for them. Then `tasks_all_complete` looks only at `state.tasks.values()` (just T1: Complete) and returns true, so the code falls into the `match state.close.review_state` arm and emits `CLOSE_NOT_READY` as if mission-close review were the problem.
+
+  The same misleading detail reaches `close complete` via `ReadinessReport::blocker_summary()` (used at `cli/close/complete.rs:44`):
+  ```bash
+  $ codex1 --json close complete --mission demo
+  {
+    "ok": false,
+    "code": "CLOSE_NOT_READY",
+    "message": "Mission is not ready for close: CLOSE_NOT_READY: mission-close review has not started"
+  }
+  ```
+  The gate itself still holds (`ready = matches!(verdict, Verdict::MissionCloseReviewPassed)` at `check.rs:49`), so `close complete` still correctly refuses. The user just sees the wrong reason.
+- **Why P1, not P0:** `close complete`'s refusal gate (via `ready`) derives from the fixed `derive_verdict` path, so the bug does not allow a bad close to proceed. Impact is confined to misleading blocker messages — a user-facing correctness bug, not a contract break.
+- **Expected:** Route `tasks_all_complete` through the same DAG snapshot (`state.plan.task_ids`) as `readiness::tasks_complete`, or even better — delete the duplicate predicate and have `close/check.rs` use `readiness::tasks_complete` directly.
+- **Fix sketch (not applied):**
+  ```rust
+  fn tasks_all_complete(state: &MissionState) -> bool {
+      let dag = &state.plan.task_ids;
+      if dag.is_empty() {
+          return false;
+      }
+      dag.iter().all(|id| {
+          state
+              .tasks
+              .get(id)
+              .is_some_and(|t| matches!(t.status, TaskStatus::Complete | TaskStatus::Superseded))
+      })
+  }
+  ```
+  And also extend the blocker loop at `check.rs:95` to emit `TASK_NOT_READY` for any DAG node missing from `state.tasks`. Reference: the fixed `readiness::tasks_complete` at `state/readiness.rs:74-93`.
+- **Contract reference:** `docs/cli-contract-schemas.md:299-307` pins the `close check` blocker shape. The shape is honored — the codes are canonical — but the concrete content misleads.
+
+### F4 (P2): locked STATE.json from pre-`958d2f1` binaries cannot reach mission-close readiness under the new binary
+
+- **Severity:** P2. No shipping code is affected (project is pre-v1; all test fixtures have been migrated). But any `STATE.json` file locked by a binary built before commit `958d2f1` will deserialize with `plan.task_ids = Vec::new()` (via `#[serde(default)]` at `state/schema.rs:84`), and the `plan check` idempotent short-circuit at `cli/plan/check.rs:62-84` prevents a backfill.
+- **Reproduction:**
+  - Seed a STATE.json with `plan.locked=true`, `plan.hash="sha256:<real>"`, no `task_ids`, and every DAG task complete (`state.tasks = {T1:Complete, T2:Complete, T3:Complete, T4:Complete}`).
+  - Verified live: `status --json --mission demo` → `verdict: continue_required`, `close_ready: false`, `close check` → `CLOSE_NOT_READY` blocker.
+  - Running `plan check` on the unchanged PLAN.yaml would hit the idempotent short-circuit (same hash + already locked) and would not rewrite `task_ids`. The mission would stay stuck until the user either edits PLAN.yaml (to force a different hash, re-triggering the mutation closure which will then write `task_ids`), or the user hand-edits STATE.json (forbidden by the handoff). This branch is established by code inspection of `cli/plan/check.rs:62-84`; my live smoke test uses a synthetic hash and so does not itself replay the short-circuit path.
+- **Why P2, not P1:** There are no pre-`958d2f1` locked missions in flight — the project has no installed base. But the handoff's doc surface does not warn about the migration. A future packager or early user upgrading across this commit will hit a locked state with no clean CLI recourse.
+- **Fix sketch (not applied):** Two compatible options:
+  1. In `cli/plan/check.rs:62-84`, relax the idempotent short-circuit when `current.plan.task_ids.is_empty()` — i.e. still run the mutation (just to backfill the missing field) even on a hash match. The revision will bump by 1 but the closure idempotently writes the same non-`task_ids` fields, so the mission remains consistent.
+  2. Add a `codex1 plan migrate` one-shot that rewrites `task_ids` from PLAN.yaml without requiring a hash change. Less surgical than option 1.
+  Option 1 is strongly preferred because it makes the migration invisible: every legacy mission that runs `plan check` once under the new binary heals itself.
+- **Contract reference:** `docs/cli-contract-schemas.md:134-153` (mutation protocol) and `docs/codex1-rebuild-handoff/03-planning-artifacts.md` (plan-lock semantics) neither mention this migration step.
+
+## F8-specific verification (commit `958d2f1`)
+
+### `plan.task_ids` field presence
+
+`crates/codex1/src/state/schema.rs:71-86`:
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanState {
+    pub locked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_level: Option<PlanLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_level: Option<PlanLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(default)]
+    pub task_ids: Vec<TaskId>,
+}
+```
+Field is present, defaults to empty Vec when absent in an existing `STATE.json` (the `#[serde(default)]` makes old files forward-compatible but also enables F4).
+
+### `plan check` writes `plan.task_ids`
+
+`crates/codex1/src/cli/plan/check.rs:95-114`:
+```rust
+let task_ids_to_record = summary.task_ids.clone();
+let mutation = state::mutate(
+    &paths,
+    ctx.expect_revision,
+    "plan.checked",
+    event_payload,
+    |s| {
+        s.plan.locked = true;
+        s.plan.hash = Some(hash.clone());
+        s.plan.requested_level = Some(summary.requested_level.clone());
+        s.plan.effective_level = Some(summary.effective_level.clone());
+        s.plan.task_ids = task_ids_to_record.clone();    // ← F8 fix (also the site of F1 clippy regression)
+        if matches!(s.phase, Phase::Plan) {
+            s.phase = Phase::Execute;
+        }
+        Ok(())
+    },
+)?;
+```
+`Summary::task_ids` is computed by `validate_tasks` at `check.rs:240,316-342` and returned into `Summary` at `check.rs:312`. The IDs are collected in plan order from every `tasks[].id` pass.
+
+Caveat: the mutation closure is entered only on the non-short-circuit path. Idempotent re-runs (`already_locked_same`, `check.rs:62-84`) do not enter it — this is the root of F4.
+
+### `readiness::tasks_complete` consults `state.plan.task_ids`
+
+`crates/codex1/src/state/readiness.rs:74-93`:
+```rust
+fn tasks_complete(state: &MissionState) -> bool {
+    let dag = &state.plan.task_ids;
+    if dag.is_empty() {
+        return false;
+    }
+    dag.iter().all(|id| {
+        state
+            .tasks
+            .get(id)
+            .is_some_and(|t| matches!(t.status, TaskStatus::Complete | TaskStatus::Superseded))
+    })
+}
+```
+Correct — iterates the DAG snapshot, requires every node to have an entry in `state.tasks` with a terminal status. `state::mutate` never writes partial DAG views; `plan.task_ids` is written once, atomically, inside the `plan.checked` mutation closure.
+
+### Callers of `tasks_complete`
+
+Grep over the workspace for `tasks_complete` (the fixed helper):
+
+| Site | Kind |
+| --- | --- |
+| `crates/codex1/src/state/readiness.rs:74` | Definition |
+| `crates/codex1/src/state/readiness.rs:57` | Sole call site — `derive_verdict` |
+| `crates/codex1/src/state/schema.rs:82` | Doc comment ("`readiness::tasks_complete` can recognize …") |
+| `crates/codex1/tests/status_close_agreement.rs:162` | Test comment |
+| `crates/codex1/tests/status_close_agreement.rs:373` | Test comment |
+
+One caller. The fix's chokepoint (`derive_verdict` → `tasks_complete`) is honored.
+
+### Alternative "all tasks done" predicates in the CLI
+
+Grep over the workspace for `all_tasks_complete | all_tasks_done | tasks\.values\(\)\.all`:
+
+| Site | Status |
+| --- | --- |
+| `crates/codex1/src/cli/plan/waves.rs:89-98` | **Safe.** `let all_tasks_complete = !tasks.is_empty() && tasks.iter().all(…)` — `tasks` here is the parsed `ParsedTask` list loaded from PLAN.yaml (`load_plan_tasks` at `waves.rs:45-58`), NOT the on-disk state map. Structurally equivalent to the DAG snapshot; no bypass. |
+| `crates/codex1/src/cli/close/check.rs:132-140` | **F3 finding** — duplicate of the buggy pattern, still live. |
+| Tests in `tests/plan_waves.rs`, `tests/e2e_full_mission.rs`, etc. | Assertion-only; read the `all_tasks_complete` field emitted by `plan waves`. Not predicates. |
+
+There is exactly one alternative predicate (F3), and it is the one iter 2 missed.
+
+## Clean checks (iter 2 re-run)
+
+### Minimal command surface (28 verbs per `02-cli-contract.md` § Minimal Command Surface)
+
+All verbs exist in the clap dispatch tree and expose `--help`. The surface now formally includes `loop activate` and `close record-review` (iter 1 fix for baseline P1-2). Verified live against the compiled binary.
+
+| Verb | Source |
+| --- | --- |
+| `init`, `status`, `doctor`, `hook snippet` | `cli/mod.rs:76-125` |
+| `outcome check`, `outcome ratify` | `cli/outcome/mod.rs` |
+| `plan choose-level`, `plan scaffold`, `plan check`, `plan graph`, `plan waves` | `cli/plan/mod.rs:22-67` |
+| `task next`, `task start`, `task finish`, `task status`, `task packet` | `cli/task/mod.rs` |
+| `review start`, `review packet`, `review record`, `review status` | `cli/review/mod.rs` |
+| `replan check`, `replan record` | `cli/replan/mod.rs` |
+| `loop activate`, `loop pause`, `loop resume`, `loop deactivate` | `cli/loop_/mod.rs:24-47` |
+| `close check`, `close complete`, `close record-review` | `cli/close/mod.rs:43-61` |
+
+### Stable JSON envelopes
+
+- Success envelope: `{ ok: true, mission_id?, revision?, data }` per `core/envelope.rs:20-29`. Verified live on `doctor`, `init`, `status`, `hook snippet`, `outcome check`, `plan choose-level`, `plan waves`, `plan graph`, `task next`, `replan check`.
+- Error envelope: `{ ok: false, code, message, hint?, retryable, context? }` per `core/envelope.rs:67-78`. `hint` and `context` are optional-when-null (documented now at `docs/cli-contract-schemas.md:36-40`, iter 1 fix for baseline P2-2).
+
+### Error codes vs canonical `CliError` set
+
+- `CliError::Other / INTERNAL` is gone — iter 1 fix for baseline P2-1. `crates/codex1/src/core/error.rs` defines 20 variants, every one is a canonical string in `docs/cli-contract-schemas.md:42-63`. No `anyhow::Error` propagation remains.
+- Spot-checked raw-string code sites: `cli/plan/check.rs` `exit_with_validation_error` uses only `PLAN_INVALID` / `DAG_CYCLE` / `DAG_MISSING_DEP`. `cli/close/check.rs` `Blocker::new` uses only `OUTCOME_NOT_RATIFIED` / `PLAN_INVALID` / `REPLAN_REQUIRED` / `TASK_NOT_READY` / `REVIEW_FINDINGS_BLOCK` / `CLOSE_NOT_READY`. All canonical.
+
+### `plan choose-level` rejects unratified outcomes
+
+Verified live (iter 1 fix for baseline P1-1):
+```bash
+$ codex1 init --mission demo
+$ codex1 plan choose-level --level medium --mission demo
+{ "ok": false, "code": "OUTCOME_NOT_RATIFIED", "message": "OUTCOME.md is not ratified", "retryable": false }
+```
+Implemented at `cli/plan/choose_level.rs:25-28` (state load + early return).
+
+### `status` ↔ `close check` verdict agreement
+
+`state::readiness::derive_verdict` is the single source of truth for both (called from `cli/status/project.rs:19` and `cli/close/check.rs:47`). Seven hand-built STATE.json fixtures spanning needs_user, continue_required, blocked, ready_for_mission_close_review, mission_close_review_open, mission_close_review_passed, and terminal_complete all agree on `verdict` and `close_ready` / `ready`. The `close check` blocker *list* can misinform in the F3 scenario, but the verdict string itself does not disagree.
+
+Dedicated agreement property test at `tests/close.rs:726-773` (24 states) and `tests/status_close_agreement.rs:392-420` (21 fixtures, including the `one_task_done_out_of_four` regression fixture added alongside the F8 fix) remain passing.
+
+### `stop.allow` projection consistency
+
+- Paused → `allow: true, reason: "paused"`
+- Terminal → `allow: true, reason: "terminal"`
+- Loop inactive → `allow: true, reason: "idle"`
+- Active-unpaused + verdict allows stop → `allow: true, reason: "idle"`
+- Active-unpaused + verdict doesn't allow stop → `allow: false, reason: "active_loop"`
+- No mission resolvable → `allow: true, reason: "no_mission"` (graceful fallback at `cli/status/mod.rs:38-49`)
+
+Derived by `readiness::stop_allowed` (`readiness.rs:103-112`), projected by `cli/status/project.rs:72-99`. Ralph hook exit semantics (exit 2 iff allow=false, else exit 0) verified by `tests/ralph_hook.rs` (6/6 passing).
+
+### Global flags
+
+`--mission`, `--repo-root`, `--json`, `--dry-run`, `--expect-revision` are declared as globals at `cli/mod.rs:45-65` and appear in every `--help` output. Mission resolution precedence (`docs/cli-contract-schemas.md:76-82`) implemented in `core/mission::resolve_mission`.
+
+## Reading map — where I verified each iter 3 mandate
+
+| Mandate | Verified at |
+| --- | --- |
+| `plan.task_ids` field in `state::schema::PlanState` | `state/schema.rs:71-86` (shown above) |
+| `plan check` writes `plan.task_ids` | `cli/plan/check.rs:95-114` (shown above); `check.rs:240,312` (Summary.task_ids population) |
+| `readiness::tasks_complete` consults `plan.task_ids` | `state/readiness.rs:74-93` (shown above) |
+| Callers of `tasks_complete` | one: `derive_verdict` at `state/readiness.rs:57`; see table above |
+| No alternative `all tasks done` predicate that bypasses the fix | `close/check.rs:132-140` still uses the buggy pattern — F3 finding |
+| iter 2 checks (surface, envelope, codes, agreement) | sections above |

--- a/docs/audits/iter3-handoff-cross-check.md
+++ b/docs/audits/iter3-handoff-cross-check.md
@@ -1,0 +1,181 @@
+# Handoff Cross-Check — iter 3
+
+Branch audited: `main` @ `958d2f1`
+Audited on: 2026-04-20 UTC.
+
+## Scope
+
+Cross-check the repository against every "Non-Negotiable" and "Anti-Goal" declared in:
+
+- `docs/codex1-rebuild-handoff/00-why-and-lessons.md` § What To Reject.
+- `docs/codex1-rebuild-handoff/README.md` § Non-Negotiables and § Explicit Anti-Goals.
+- `docs/codex1-rebuild-handoff/02-cli-contract.md` § Important Non-Features.
+
+For each anti-goal I report whether it is honored in live code, skills, scripts, and docs. The check was re-run from scratch against `958d2f1`; no doc-file finding from prior iterations recurred.
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.**
+
+Every declared anti-goal is honored. `.ralph/` only appears as an explicit prohibition in documentation and scripts; caller-identity patterns do not exist in Rust source; `plan scaffold` does not emit a `waves:` key; reviewer writeback is positively forbidden in the skill bodies; no wrapper runtime or background daemon is invoked by the CLI.
+
+## Findings
+
+None.
+
+## Clean checks (anti-goal by anti-goal)
+
+### CC-1: No `.ralph/` live directory, path, or import
+
+All 13 hits for the substring `.ralph` in the repository are either (a) inside handoff docs where `.ralph` is defined as an anti-goal or (b) inline prohibitions. Zero Rust sources create, read, or write under `.ralph/`.
+
+| File | Line(s) | Kind |
+| --- | --- | --- |
+| `docs/codex1-rebuild-handoff/00-why-and-lessons.md` | 82 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/01-product-flow.md` | 241 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/02-cli-contract.md` | 117 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/03-planning-artifacts.md` | 28, 160 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/05-build-prompt.md` | 36, 91 | Anti-goal doc |
+| `docs/codex1-rebuild-handoff/README.md` | 79 | Anti-goal doc |
+| `docs/mission-anatomy.md` | 3 | Anti-goal prose |
+| `README.md` | 3 | Anti-goal prose |
+| `scripts/README-hook.md` | 19 | Ralph-hook scope ("The hook does **not** read … `.ralph/`") |
+| `.codex/skills/close/SKILL.md` | 112 | Prohibition ("Do not edit `.ralph/` …") |
+| `crates/codex1/src/lib.rs` | 9 | Doc comment ("never hides state in `.ralph/`") |
+| `docs/audits/skills-audit.md` | 120 | Audit reference |
+| `docs/audits/handoff-cross-check.md` | 30-42 | Audit table |
+
+Grep for `std::fs`, `Path::new`, `PathBuf`, `include_str!`, `include_bytes!`, shell invocation, or `fs_atomic::atomic_write` touching anything with `.ralph` → **zero matches** in all of `crates/codex1/src/**/*.rs`.
+
+### CC-2: No caller-identity checks in Rust source
+
+Grep over `crates/codex1` for:
+
+```
+is_parent | is_subagent | caller_type | reviewer_id | parent_id | subagent_type
+session_owner | caller_identity | session_id | session_token | capability_token
+authority_token
+```
+
+Zero matches in any `.rs` file.
+
+`crates/codex1/src/cli/mod.rs:127-144` defines `Ctx` with only `{ mission, repo_root, json, dry_run, expect_revision }`; no caller-side identity is extracted or inspected. Every handler accepts `Ctx` as-is and dispatches based on arguments + state file contents.
+
+The comment at `crates/codex1/src/cli/review/mod.rs:2-4` makes this explicit:
+
+> The CLI does not check caller identity; the main thread records review
+> outcomes.
+
+### CC-3: No `waves:` key emitted by `plan scaffold`
+
+- `crates/codex1/src/cli/plan/scaffold.rs:119-171` (`render_skeleton`) composes the `PLAN.yaml` skeleton. The output contains `mission_id`, `planning_level`, `outcome_interpretation`, `architecture`, `planning_process`, `tasks`, `risks`, and `mission_close` — and no `waves:` key.
+- Grep for `waves:` at start-of-line across the repo finds zero YAML emissions. The only Rust hits are `use super::waves::{…}` imports (module references), not YAML.
+- `codex1 plan waves --json` recomputes waves from `tasks[].depends_on` + current task state on each call (`cli/plan/waves.rs`), never from a stored `waves:` list.
+
+### CC-4: Reviewer writeback — main thread records (positive prohibition)
+
+`$review-loop`'s skill body and references explicitly say the main thread records, not the reviewer:
+
+- `.codex/skills/review-loop/SKILL.md:11` — "The main thread is the sole writer of mission truth: it records clean/dirty via `codex1 review record` (planned review) or `codex1 close record-review` (mission close)."
+- `.codex/skills/review-loop/SKILL.md:63` — "Every spawn prompt must begin with the standing reviewer block … (findings-only, no edits, no `codex1` mutations, no repairs, no marking clean anywhere). The main thread is the sole writer of mission truth. Reviewer writeback is forbidden."
+- `.codex/skills/review-loop/SKILL.md:79` — "Record review results from inside a reviewer subagent — only the main thread records."
+- `.codex/skills/review-loop/references/reviewer-profiles.md:8-15` (standing reviewer block): "Do not edit files. / Do not invoke Codex1 skills. / Do not run codex1 mutating commands (no `review record`, `task finish`, `close *`, etc.). / Do not record mission truth."
+
+`$execute/SKILL.md:117` reinforces from the orchestration side: "Do not spawn reviewers, run `codex1 review record`, or write to `reviews/`."
+
+### CC-5: No wrapper runtime / `codex1-runtime` / `ralph-daemon`
+
+Grep over the repo for `codex1-runtime | ralph-daemon | wrapper_runtime`:
+
+```bash
+$ grep -rI --exclude-dir=target "codex1-runtime\|ralph-daemon\|wrapper_runtime" .
+# (no matches outside this audit file)
+```
+
+Grep for `Command::new(...)` in source:
+
+- `crates/codex1/tests/e2e_ralph_contract.rs:62,92` and `crates/codex1/tests/ralph_hook.rs:60,91` — four instances of `Command::new("bash")` used to invoke `scripts/ralph-stop-hook.sh` from integration tests. Test-only; not production code paths.
+- `crates/codex1/src/cli/doctor.rs:64-66` — probes for a `codex1` binary on `PATH` (non-invocation; `candidate.is_file()` check only, never spawned).
+- `scripts/ralph-stop-hook.sh` runs `codex1 status --json` once per invocation and exits — no background process.
+
+Grep for `std::process::Command::spawn | tokio::spawn | daemon`:
+
+- `daemon` — one hit in `.codex/skills/plan/references/dag-quality.md:19` used in an illustrative example ("a daemon port" as an example of a shared resource), not a prescription to run a daemon.
+- `std::process::Command::spawn` / `tokio::spawn` — zero matches outside test helpers.
+
+No background worker, daemon, or helper process is ever launched. The binary is a one-shot CLI on every invocation.
+
+### CC-6: CLI does not spawn subagents or read hidden chat state
+
+- `crates/codex1/src/cli/**/*.rs` contains no `Command::new("codex")` / `Command::new("claude")` / AI-model invocation.
+- No handler reads from stdin except `plan choose-level` (`cli/plan/choose_level.rs:110-128`), and only when stdin is a TTY — i.e. for the documented interactive level prompt.
+- `codex1 task packet` and `codex1 review packet` emit prompt strings for the main thread to paste into a subagent; neither spawns anything.
+
+### CC-7: Ralph is status-only
+
+`scripts/ralph-stop-hook.sh` (60 lines):
+
+- Drains stdin.
+- Probes for `codex1` on `PATH` (or via `$CODEX1_BIN`).
+- Runs exactly one command: `codex1 status --json`.
+- Parses `.data.stop.allow` with `jq` (or a degraded grep fallback).
+- Exits 2 iff `allow == false`, else 0.
+
+It never reads `PLAN.yaml`, `STATE.json`, `EVENTS.jsonl`, reviews, specs, or `.ralph/`. It never spawns another process.
+
+`codex1 hook snippet` (`crates/codex1/src/cli/hook.rs:24-50`) only prints wiring JSON; it does not install, probe, or invoke anything.
+
+### CC-8: Stored waves are not treated as editable truth
+
+- `crates/codex1/src/state/schema.rs:176-194` defines `MissionState`. The struct contains `tasks`, `reviews`, `replan`, `close`, etc. — no `waves` field.
+- `PlanState` (`schema.rs:71-86`) holds `locked`, `requested_level`, `effective_level`, `hash`, and `task_ids` (the DAG task-id snapshot added in commit `958d2f1` to fix iter 2's P0 F8). `task_ids` is a flat ordered list of `T<n>` ids, not a wave structure; it is consulted read-only by `readiness::tasks_complete`.
+- `crates/codex1/src/cli/plan/waves.rs` derives waves on demand from plan tasks + state.
+- `docs/cli-contract-schemas.md:104-119` pins the Rust types for `MissionState`; no `waves:` collection is listed.
+
+### CC-9: Capability tokens / authority tokens / session-id authority
+
+Grep for `session_id | session_token | capability_token | authority_token` across `crates/codex1`: **zero matches.**
+
+No handler accepts, mints, stores, or validates a capability/authority token. Mutating commands gate on `--expect-revision` (`core/error.rs:53-54`), which is a state-file revision counter, not a caller-identity credential.
+
+### CC-10: `docs/cli-contract-schemas.md` remains foundation-owned and untouched by this audit
+
+Per the contract at `docs/cli-contract-schemas.md:1-10`, the schemas file is Foundation-owned. This audit does not modify that file (nor any Rust source).
+
+### CC-11: CLI does not ask semantic questions
+
+`crates/codex1/src/cli/plan/choose_level.rs:110-128` is the only interactive prompt in the entire CLI. It asks a single question: which of `light | medium | hard` to record, and only when stdin is a TTY. It does not ask semantic clarification questions about the mission; per `docs/codex1-rebuild-handoff/02-cli-contract.md:46` this is the explicitly sanctioned exception.
+
+All other commands are non-interactive and emit JSON.
+
+### CC-12: Visible mission files only
+
+`crates/codex1/src/core/paths.rs` resolves `PLANS/<mission>/{OUTCOME.md, PLAN.yaml, STATE.json, EVENTS.jsonl, specs/, reviews/, CLOSEOUT.md}`. Every mutating command uses these paths; no handler writes outside `PLANS/<mission>/`. There is no side-cache, side-state, or hidden dotfile.
+
+## Reading map
+
+Each anti-goal and the line where I verified it.
+
+| Anti-goal (handoff source) | Verified at |
+| --- | --- |
+| `00-why-and-lessons.md:82` – "No `.ralph` mission truth." | CC-1 |
+| `00-why-and-lessons.md:84` – "No caller identity checks." | CC-2 |
+| `00-why-and-lessons.md:86` – "No reviewer writeback authority systems." | CC-4 |
+| `00-why-and-lessons.md:87` – "No stored waves as editable truth." | CC-3, CC-8 |
+| `00-why-and-lessons.md:80` – "No hidden daemons." | CC-5 |
+| `00-why-and-lessons.md:81` – "No wrapper runtimes around Codex." | CC-5 |
+| `README.md:79` – "No `.ralph/` mission state directory." | CC-1 |
+| `README.md:78` – "CLI must not detect parent vs subagent." | CC-2 |
+| `README.md:89` – "No session-ID authority system." | CC-9 |
+| `README.md:91` – "No capability-token maze." | CC-9 |
+| `README.md:92` – "No reviewer writeback authority tokens." | CC-4 |
+| `README.md:93` – "No stored waves as canonical truth." | CC-3, CC-8 |
+| `README.md:95` – "A CLI that spawns subagents." | CC-6 |
+| `README.md:96` – "A CLI that asks semantic clarification questions." | CC-11 |
+| `02-cli-contract.md:113` – "Must not ask 'are you parent or subagent?'" | CC-2 |
+| `02-cli-contract.md:117` – "Must not use `.ralph` mission truth." | CC-1 |
+| `02-cli-contract.md:118` – "Must not store waves as editable truth." | CC-3, CC-8 |
+| `02-cli-contract.md:115` – "Must not spawn subagents." | CC-6 |
+| `01-product-flow.md:241` – "Ralph must not inspect plan/review files directly." | CC-7 |
+
+Every anti-goal was verified clean. No P0/P1/P2 findings. The `plan.task_ids` field added by the F8 fix (`state/schema.rs:80-85`) is a flat DAG id snapshot, not a stored-waves construct; it does not re-introduce the anti-goal.

--- a/docs/audits/iter3-skills-audit.md
+++ b/docs/audits/iter3-skills-audit.md
@@ -1,0 +1,147 @@
+# Skills Audit — iter 3
+
+Branch audited: `main` @ `958d2f1`
+Audited on: 2026-04-20 UTC
+Skill folders: `.codex/skills/{clarify,plan,execute,review-loop,close,autopilot}`.
+
+## Scope
+
+For every skill I verified:
+
+- `quick_validate.py` passes (script at `/Users/joel/.codex/skills/.system/skill-creator/scripts/quick_validate.py`).
+- Frontmatter contains only `name` + `description`; `name` matches the folder.
+- `SKILL.md` body is under 500 lines and written in imperative form.
+- `agents/openai.yaml` exists and `interface.default_prompt` mentions `$<skill-name>` literally.
+- No `README.md`, `INSTALLATION_GUIDE.md`, or `CHANGELOG.md` inside the skill folder.
+- Body invokes the CLI verbs the skill exists to drive.
+- Body does not invite behaviors the handoff forbids (caller-identity, reviewer writeback, stored waves, `.ralph/` as live state).
+
+No skill file was modified between iter 2's audit (`271b2fc`) and this audit (`958d2f1`) — `git diff --stat 271b2fc 958d2f1 -- .codex/skills/` is empty. This audit re-ran every check from scratch regardless.
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.**
+
+Every skill passes validation, has a clean frontmatter, points at the right CLI verbs, and honors the handoff's anti-goals. Nothing regressed between iter 2 and iter 3.
+
+## Findings
+
+None.
+
+## Clean checks
+
+### Per-skill validation (`quick_validate.py`)
+
+All six skills pass the installed validator:
+
+```text
+=== autopilot ===    Skill is valid!
+=== clarify ===      Skill is valid!
+=== close ===        Skill is valid!
+=== execute ===      Skill is valid!
+=== plan ===         Skill is valid!
+=== review-loop ===  Skill is valid!
+```
+
+### Frontmatter shape
+
+Every `SKILL.md` declares exactly two frontmatter keys, `name` and `description`. The `name` value matches the folder name.
+
+| Skill | Folder | `name:` in SKILL.md | Other frontmatter keys |
+| --- | --- | --- | --- |
+| clarify | `.codex/skills/clarify/` | `clarify` | none |
+| plan | `.codex/skills/plan/` | `plan` | none |
+| execute | `.codex/skills/execute/` | `execute` | none |
+| review-loop | `.codex/skills/review-loop/` | `review-loop` | none |
+| close | `.codex/skills/close/` | `close` | none |
+| autopilot | `.codex/skills/autopilot/` | `autopilot` | none |
+
+`quick_validate.py` also allows `license`, `allowed-tools`, and `metadata`; none are present. Description fields are single prose blocks with no angle brackets, well under the 1024-character validator ceiling.
+
+### Body length (all < 500 lines)
+
+| Skill | Lines |
+| --- | --- |
+| clarify | 60 |
+| plan | 205 |
+| execute | 122 |
+| review-loop | 81 |
+| close | 112 |
+| autopilot | 133 |
+
+Bodies are imperative (each opens with verbs: `Turn a user's mission goal into…`, `Create a full Codex1 mission plan…`, `Run the next ready task…`, `Orchestrate reviewer subagents…`, `Pause the active Codex1 loop…`, `Take a Codex1 mission from start to terminal close…`).
+
+### `agents/openai.yaml` and `$<skill-name>` literal references
+
+Every skill ships an `agents/openai.yaml` whose `interface.default_prompt` mentions the skill literally as `$<name>`:
+
+| Skill | `default_prompt` excerpt | Literal `$<name>` found? |
+| --- | --- | --- |
+| clarify | `Use $clarify to fill and ratify OUTCOME.md before planning.` | Yes |
+| plan | `Use $plan to scaffold, fill, and lock PLAN.yaml for the active mission.` | Yes |
+| execute | `Use $execute to run the next ready task or wave for the active Codex1 mission.` | Yes |
+| review-loop | `Use $review-loop to run reviewer subagents and record clean/dirty findings.` | Yes |
+| close | `Use $close to pause the active loop so the user can talk without Ralph forcing continuation.` | Yes |
+| autopilot | `Use $autopilot to take a Codex1 mission from clarify to terminal close.` | Yes |
+
+All six yaml files pin `policy.allow_implicit_invocation: true` as the only policy key.
+
+### No forbidden files inside skill folders
+
+```bash
+$ find .codex/skills -type f \( -name "README.md" -o -name "INSTALLATION_GUIDE.md" -o -name "CHANGELOG.md" \)
+# (no output)
+```
+
+Each skill folder contains only `SKILL.md`, `agents/openai.yaml`, and (five of six) a `references/` directory.
+
+### CLI commands each skill drives
+
+Every skill body invokes the CLI verbs it exists to orchestrate:
+
+- `$clarify` (`clarify/SKILL.md:19,37,39`): `codex1 status`, `codex1 outcome check`, `codex1 outcome ratify`.
+- `$plan` (`plan/SKILL.md:29,45,138,146,147,191`): `codex1 plan choose-level`, `codex1 plan scaffold`, `codex1 plan check`, `codex1 plan graph`, `codex1 plan waves`, `codex1 replan record`.
+- `$execute` (`execute/SKILL.md:29,49,50,72`): `codex1 status`, `codex1 task next`, `codex1 task start`, `codex1 task packet`, `codex1 task finish`.
+- `$review-loop` (`review-loop/SKILL.md:19,21,28,31,39,43,45`): `codex1 review start`, `codex1 review packet`, `codex1 review record`, `codex1 close check`, `codex1 close record-review`.
+- `$close` (`close/SKILL.md:40,51,61,84`): `codex1 loop pause`, `codex1 loop resume`, `codex1 loop deactivate`, `codex1 close complete`, `codex1 status`.
+- `$autopilot` (`autopilot/SKILL.md:43,97,104,125`): `codex1 status`, `codex1 init`, `codex1 plan choose-level`, `codex1 close check`, `codex1 close complete`, plus composes the other five skills.
+
+### Handoff anti-goals honored
+
+- **`.ralph/`:** no skill body treats `.ralph/` as live directory. The one hit is `close/SKILL.md:112`, a positive prohibition: `- Do not edit .ralph/ files, STATE.json, or hooks to work around Ralph.` This is the handoff's intended framing.
+- **Reviewer writeback:** `review-loop/SKILL.md:11` says "The main thread is the sole writer of mission truth"; `SKILL.md:63` says "Reviewer writeback is forbidden"; `references/reviewer-profiles.md:8-15` lists the standing reviewer block with explicit prohibitions on running `codex1` mutating commands or marking clean anywhere. `execute/SKILL.md:117` reinforces from the orchestrator side.
+- **Waves as stored truth:** `plan/SKILL.md:199` says "Do not store waves inside `PLAN.yaml`. Waves are derived." `plan/references/dag-quality.md:15` reinforces.
+- **Caller identity:** `autopilot/SKILL.md:120-127` and `review-loop/SKILL.md:77-82` rely on prompt-governed role boundaries. No skill instructs the CLI to check caller identity.
+- **Six-dirty-triggers-replan:** documented in `review-loop/SKILL.md:4` and `execute/SKILL.md:107`.
+
+### Skill folders layout
+
+```
+.codex/skills/
+├── autopilot/
+│   ├── agents/openai.yaml
+│   ├── references/autopilot-state-machine.md
+│   └── SKILL.md
+├── clarify/
+│   ├── agents/openai.yaml
+│   ├── references/outcome-shape.md
+│   └── SKILL.md
+├── close/
+│   ├── agents/openai.yaml
+│   └── SKILL.md
+├── execute/
+│   ├── agents/openai.yaml
+│   ├── references/worker-packet-template.md
+│   └── SKILL.md
+├── plan/
+│   ├── agents/openai.yaml
+│   ├── references/dag-quality.md
+│   ├── references/hard-planning-evidence.md
+│   └── SKILL.md
+└── review-loop/
+    ├── agents/openai.yaml
+    ├── references/reviewer-profiles.md
+    └── SKILL.md
+```
+
+References contain prose the SKILL.md bodies intentionally don't duplicate. None repeat SKILL.md content verbatim.


### PR DESCRIPTION
## Summary

iter 3 audit on commit 958d2f1 (iter 2 fix for baseline F8).

- **iter3-cli-contract-audit.md:** FAIL — 2 P0, 1 P1, 1 P2. The F8 fix resolved the verdict-path bug but introduced two build-evidence regressions (clippy + 2 test failures) and left a parallel `tasks_all_complete` predicate in `close/check.rs` using the old pattern; a latent migration hazard also affects pre-958d2f1 locked states.
- **iter3-skills-audit.md:** 0 P0, 0 P1, 0 P2. All six skills pass validation and honor anti-goals.
- **iter3-handoff-cross-check.md:** 0 P0, 0 P1, 0 P2. Every declared anti-goal is honored across code, skills, scripts, and docs.

## Findings (cli-contract)

- **F1 (P0)** — `crates/codex1/src/cli/plan/check.rs:109` trips `clippy::assigning_clones`; `cargo clippy --all-targets -- -D warnings` fails. Fix: `s.plan.task_ids.clone_from(&task_ids_to_record);`
- **F2 (P0)** — `crates/codex1/tests/status.rs:329,361` fixtures do not populate `plan.task_ids`; `cargo test --release --no-fail-fast` reports 167/169. Fix: add `state.plan.task_ids = vec![...]` to match the pattern used in the other fixtures.
- **F3 (P1)** — `crates/codex1/src/cli/close/check.rs:132-140` still uses `state.tasks.values().all(...)`; produces misleading CLOSE_NOT_READY blocker messages. The close-complete gate still holds correctly via the fixed verdict path; impact is user-facing confusion only. Answers the audit-scope question "is there an alternative `all tasks done` predicate?" — yes.
- **F4 (P2)** — `plan.task_ids` has `#[serde(default)]`; pre-958d2f1 locked states can't backfill because `plan check`'s idempotent short-circuit fires on unchanged PLAN.yaml. No shipping impact (no installed base) but future upgraders would hit it.

## Build evidence (at 958d2f1)

```
cargo fmt --check                         → PASS
cargo clippy --all-targets -- -D warnings → FAIL (F1)
cargo test --release --no-fail-fast       → 167 passed / 2 failed / 169 total (F2)
```

## Test plan

- [ ] Review each audit report's citations against the tree at 958d2f1.
- [ ] Confirm F1 fix (`clone_from`) clears `cargo clippy --all-targets -- -D warnings`.
- [ ] Confirm F2 fix (test fixtures) clears `cargo test --release --no-fail-fast`.
- [ ] Confirm F3 fix (route `close/check.rs::tasks_all_complete` through `readiness::tasks_complete` or the DAG snapshot) clears the misleading-blocker reproduction.
- [ ] Decide severity / patch for F4 migration before any shipping user upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)