### PR TITLE
iter4 audit: wave (post-5a16894)

### DIFF
--- a/docs/audits/iter4-cli-contract-audit.md
+++ b/docs/audits/iter4-cli-contract-audit.md
@@ -1,0 +1,224 @@
+# CLI Contract Audit — iter 4
+
+Branch audited: `main` @ `5a16894`
+Audited on: 2026-04-20 UTC
+Binary: `target/release/codex1 0.1.0` (built from `5a16894`).
+Worktree: `.claude/worktrees/agent-a23c02b0` (fresh checkout from commit `5a16894`, no source edits).
+
+## Scope
+
+Fresh pass on every command listed in `docs/codex1-rebuild-handoff/02-cli-contract.md` § Minimal Command Surface, plus the iter 4 verification list from the task prompt:
+
+- Minimal command surface wired in clap.
+- Success + error envelope shape stability.
+- Error codes ⊆ canonical `CliError` set (grep-and-verify).
+- `status` ↔ `close check` agreement across ≥5 hand-crafted STATE.json fixtures.
+- `readiness::tasks_complete` is the ONLY `tasks_complete`-style predicate (grep across `src/**/*.rs` for `tasks_complete|tasks_all_complete|all.*complete`).
+- `plan.task_ids` backfill on upgrade: a pre-F8 state (`locked=true`, `hash=X`, `task_ids=[]`) re-run through `codex1 plan check` must populate `task_ids` (revision +1) then a second re-run must be idempotent.
+- `close check` blocker list includes un-started DAG tasks explicitly (`TASK_NOT_READY: <id> has not started`).
+
+## Summary
+
+**FAIL — 0 P0, 1 P1, 0 P2.**
+
+Every iter-3 P0 regression (F8 semantic bug, F9 clippy, F10 fixtures, and the iter3-wave F3 parallel predicate) is resolved at `5a16894`. Build gate (fmt / clippy / test --release) is clean; 169 tests pass. `status` and `close check` agree on `verdict` across all eight hand-crafted fixtures I ran. The canonical error set is respected: no raw uppercase-code string outside `CliError::code()` appears anywhere under `crates/codex1/src/`.
+
+The single P1 is that iter 3's F11 "upgrade trap" fix was claimed by the commit message at `2ef3ce7` but was never actually applied to the short-circuit predicate in `cli/plan/check.rs`. The upgrade trap is empirically reproducible at `5a16894`: a mission locked with an empty `plan.task_ids` field stays stuck at `continue_required` forever, with zero blockers reported by `close check`, and `plan check` refuses to backfill.
+
+## Build evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS (silent) |
+| `cargo clippy --all-targets -- -D warnings` | PASS (0 errors, 0 warnings) |
+| `cargo test --release` | PASS (169 passed / 0 failed / 0 ignored) |
+
+## Findings
+
+### F1 (P1): `plan check` short-circuit silently swallows the pre-F8 upgrade case
+
+- **Severity:** P1. The task's verification list calls this out explicitly: a pre-F8 state (`locked=true`, `hash=X`, `task_ids=[]`) re-run through `codex1 plan check` MUST populate `task_ids` (revision +1) then subsequent re-runs must be idempotent. At `5a16894`, the first requirement is not met: no backfill occurs. The mission remains stuck.
+- **Where:** `crates/codex1/src/cli/plan/check.rs:61-84`:
+
+  ```rust
+  // Idempotent short-circuit: same hash on an already-locked plan → no mutation.
+  let current = state::load(&paths)?;
+  let already_locked_same =
+      current.plan.locked && current.plan.hash.as_deref() == Some(hash.as_str());
+
+  if ctx.dry_run || already_locked_same {
+      // ...returns the envelope without entering the mutation closure...
+      return Ok(());
+  }
+  ```
+
+  The predicate checks only `plan.locked` and `plan.hash`. It never consults `plan.task_ids`. A state file locked by a pre-F8 binary (no `task_ids` snapshot, field defaults to `[]` under `serde(default)` at `src/state/schema.rs:84-85`) matches `already_locked_same` and returns before the mutation closure at line 109 (`s.plan.task_ids.clone_from(&task_ids_to_record);`). No backfill, no revision bump, no event.
+- **Provenance of the regression:** Iter 3 commit `2ef3ce7` claims in its message to have fixed exactly this trap by "Tightened the short-circuit to require `!task_ids_missing` in addition to `hash_matches`". The diff contains no such predicate — only the `clone_from` clippy fix at the same site:
+
+  ```text
+  $ git show 2ef3ce7 -- crates/codex1/src/cli/plan/check.rs
+  @@ -106,7 +106,7 @@ pub fn run(ctx: &Ctx) -> CliResult<()> {
+               // can recognize "all DAG nodes done" without silently
+               // ignoring DAG nodes that were never started.
+  -            s.plan.task_ids = task_ids_to_record.clone();
+  +            s.plan.task_ids.clone_from(&task_ids_to_record);
+  ```
+
+  I confirmed by checking the corresponding lines in `git show 958d2f1:crates/codex1/src/cli/plan/check.rs` and `git show 2ef3ce7:crates/codex1/src/cli/plan/check.rs`: the `already_locked_same` block (lines 61-84) is byte-identical across `958d2f1`, `2ef3ce7`, and `5a16894`. No `task_ids_missing` / `task_ids.is_empty()` guard exists anywhere in the file:
+
+  ```text
+  $ grep -nE 'task_ids_missing|task_ids\.is_empty|task_ids_to_record\.is_empty' crates/codex1/src/cli/plan/check.rs
+  (no matches)
+  ```
+- **Empirical reproduction** (`target/release/codex1` built from `5a16894`):
+
+  1. Init and lock a valid 4-task plan the normal way. STATE.json ends with `revision: 1`, `plan.locked: true`, `plan.hash: sha256:5db3953e…`, `plan.task_ids: ["T1","T2","T3","T4"]`.
+  2. Simulate a pre-F8 lock by clearing `task_ids` in STATE.json only (hash + locked flag retained).
+  3. Re-run `codex1 plan check --mission demo`:
+
+     ```text
+     {
+       "ok": true,
+       "mission_id": "demo",
+       "revision": 1,
+       "data": { "locked": true, "plan_hash": "sha256:5db3953e…", "tasks": 4, ... }
+     }
+     ```
+
+     No revision bump. No event. On disk: `plan.task_ids == []`, `revision == 1`. The short-circuit fired.
+- **Downstream effect — the mission is silently stuck.** If a pre-F8 state has `plan.task_ids == []` but every task in `state.tasks` is `Complete`, `status --json` and `close check --json` both report:
+
+  ```text
+  verdict = continue_required
+  ready   = false
+  blockers = []   # <-- no TASK_NOT_READY, no CLOSE_NOT_READY, no anything
+  ```
+
+  The operator cannot tell what is wrong because `readiness::tasks_complete` returns `false` for any `plan.task_ids.is_empty()` (by design, per `state/readiness.rs:82-85`) AND the fallback branch of `close/check.rs::derive_blockers` (lines 100-108) only iterates tasks in `state.tasks` that are NOT complete — so there is nothing to report. The verdict-vs-blocker coupling has a fixpoint that assumes `plan.task_ids` is authoritative whenever the plan is locked, which is the exact assumption the upgrade trap breaks.
+- **Expected behavior:** Either (a) tighten the short-circuit to require `!current.plan.task_ids.is_empty() && task_ids_to_record == current.plan.task_ids` (one-shot backfill, then idempotent), or (b) surface a `PLAN_INVALID` hint when a locked plan has empty `task_ids` and the operator has not asked to re-lock. (a) is what the iter 3 commit message promised and is the least invasive fix — the next `plan check` mutates once, writes an event, increments revision, and subsequent re-runs short-circuit idempotently.
+- **Fix sketch:**
+
+  ```rust
+  let already_locked_same = current.plan.locked
+      && current.plan.hash.as_deref() == Some(hash.as_str())
+      && !current.plan.task_ids.is_empty();
+  ```
+
+  Behavior after fix (empirically reasoned): first re-run enters the mutation closure, writes `task_ids`, bumps revision → 2, appends one `plan.checked` event. Second re-run sees `task_ids` populated AND hash matches → short-circuit returns without mutation, idempotent.
+- **Why P1 not P0:** The upgrade trap is latent — no fresh mission started on `5a16894` encounters it. Nothing in the build gate reveals the regression (no test covers the scenario). But the task's iter 4 scope pins the requirement, and the commit `2ef3ce7` message positively asserts the fix exists when in fact it does not. That is a direct contract break against iter 3's own remediation claim.
+- **Contract reference:** Task's iter4-cli-contract check list, bullet 6 ("`plan.task_ids` backfill on upgrade: a pre-F8 state (locked=true, hash=X, task_ids=[]) re-run through `codex1 plan check` must populate task_ids (revision +1) then subsequent re-runs must be idempotent.").
+
+## Clean checks (no findings)
+
+### CC-1: Minimal command surface wired in clap
+
+All 25 minimal-surface commands resolve via `codex1 <group> <verb> --help`. Every leaf has clap-generated help text.
+
+| Group | Verbs | Source |
+| --- | --- | --- |
+| (root) | `init`, `status`, `doctor`, `hook snippet` | `cli/mod.rs:76-126`, `cli/init.rs`, `cli/status/mod.rs`, `cli/doctor.rs`, `cli/hook.rs` |
+| `outcome` | `check`, `ratify` | `cli/outcome/mod.rs:22-35` |
+| `plan` | `choose-level`, `scaffold`, `check`, `graph`, `waves` | `cli/plan/mod.rs:22-67` |
+| `task` | `next`, `start`, `finish`, `status`, `packet` | `cli/task/mod.rs:22-58` |
+| `review` | `start`, `packet`, `record`, `status` | `cli/review/mod.rs:23-81` |
+| `replan` | `check`, `record` | `cli/replan/mod.rs:18-37` |
+| `loop` | `pause`, `resume`, `deactivate`, `activate` | `cli/loop_/mod.rs:24-47` |
+| `close` | `check`, `complete`, `record-review` | `cli/close/mod.rs:43-73` |
+
+### CC-2: Stable success + error envelopes
+
+- Success envelope (`core/envelope.rs:20-29`): `{ ok: true, mission_id?, revision?, data }` — verified live on every command group via the fixture runs below.
+- Error envelope (`core/envelope.rs:67-78`): `{ ok: false, code, message, hint?, retryable, context? }` — verified live on `OUTCOME_INCOMPLETE`, `STATE_CORRUPT`, `PLAN_INVALID`, `TASK_NOT_READY`, `CLOSE_NOT_READY`. `hint` and `context` are `skip_serializing_if` optional; the shape remains stable when omitted (noted as an existing schema clarification in prior audits).
+
+### CC-3: Error codes ⊆ canonical `CliError` set
+
+- Canonical set (18 codes): `OUTCOME_INCOMPLETE`, `OUTCOME_NOT_RATIFIED`, `PLAN_INVALID`, `DAG_CYCLE`, `DAG_MISSING_DEP`, `TASK_NOT_READY`, `PROOF_MISSING`, `REVIEW_FINDINGS_BLOCK`, `REPLAN_REQUIRED`, `CLOSE_NOT_READY`, `STATE_CORRUPT`, `REVISION_CONFLICT`, `STALE_REVIEW_RECORD`, `TERMINAL_ALREADY_COMPLETE`, `CONFIG_MISSING`, `MISSION_NOT_FOUND`, `PARSE_ERROR`, `NOT_IMPLEMENTED` (`core/error.rs:80-103`).
+- `INTERNAL` from baseline P2-1 is gone (the `CliError::Other` variant and `From<anyhow::Error>` were removed); no handler can emit a non-canonical code.
+- Grep every raw uppercase-code string under `crates/codex1/src/` and filter to code-like literals:
+
+  ```text
+  $ grep -rnE '"[A-Z_]{4,}"' crates/codex1/src --include='*.rs'
+    | filter for strings that look like error codes
+  ```
+
+  Every hit is either: (a) a `CliError::code()` arm, (b) a `Blocker::new(code, …)` call in `cli/close/check.rs` using `OUTCOME_NOT_RATIFIED`, `PLAN_INVALID`, `REPLAN_REQUIRED`, `TASK_NOT_READY`, `REVIEW_FINDINGS_BLOCK`, `CLOSE_NOT_READY`, or (c) an `exit_with_validation_error` call in `cli/plan/check.rs` using `PLAN_INVALID`, `DAG_CYCLE`, `DAG_MISSING_DEP`. No bespoke code escapes the canonical set.
+
+### CC-4: `status` ↔ `close check` agreement (8 hand-crafted STATE.json fixtures)
+
+Each fixture below is a STATE.json written by hand to `/tmp/codex1-iter4-fx-<name>-*/PLANS/demo/STATE.json`, with matching stub `OUTCOME.md` + `PLAN.yaml` so both commands load. `status --mission demo` and `close check --mission demo` always returned the same verdict and `close_ready`/`ready` matched.
+
+| # | Fixture | `status.verdict` | `close.verdict` | `status.close_ready` | `close.ready` |
+| --- | --- | --- | --- | --- | --- |
+| 1 | fresh init (outcome unratified, plan unlocked) | `needs_user` | `needs_user` | false | false |
+| 2 | outcome ratified, plan unlocked | `needs_user` | `needs_user` | false | false |
+| 3 | plan locked, T1 complete + T2 in_progress | `continue_required` | `continue_required` | false | false |
+| 4 | all tasks complete, mission-close review not started | `ready_for_mission_close_review` | `ready_for_mission_close_review` | false | false |
+| 5 | mission-close review passed | `mission_close_review_passed` | `mission_close_review_passed` | **true** | **true** |
+| 6 | terminal (`close.terminal_at` set) | `terminal_complete` | `terminal_complete` | false | false |
+| 7 | loop paused mid-execute | `continue_required` | `continue_required` | false | false |
+| 8 | dirty review on T2 blocks progress | `blocked` | `blocked` | false | false |
+
+Both commands derive `verdict` through `state::readiness::derive_verdict` (`readiness.rs:40-66`), and `close_ready`/`ready` are both `matches!(verdict, MissionCloseReviewPassed)` — by construction they cannot diverge. The 24 in-process property fixtures in `tests/status_close_agreement.rs` plus the 21 snapshot fixtures elsewhere in the test binary (iter 2 / iter 3 carryover) all continue to pass against `5a16894`.
+
+### CC-5: `readiness::tasks_complete` is the ONLY `tasks_complete`-style predicate
+
+Grep across `crates/codex1/src/**/*.rs` for `tasks_complete|tasks_all_complete|all.*complete`:
+
+| File:line | Hit | Category |
+| --- | --- | --- |
+| `state/readiness.rs:80` | `pub fn tasks_complete(state: &MissionState) -> bool` | canonical definition |
+| `state/readiness.rs:57` | `if tasks_complete(state) {` | internal use inside `derive_verdict` |
+| `state/schema.rs:82` | `readiness::tasks_complete` (doc comment only) | doc reference |
+| `cli/close/check.rs:132` | `if readiness::tasks_complete(state) {` | uses canonical (iter3-wave-fix at `5a16894` replaced the parallel copy) |
+| `cli/status/next_action.rs:166` | doc comment `/// True when all 'depends_on' entries are complete/superseded AND …` | unrelated: per-task dep readiness predicate, not a mission-wide close predicate |
+| `cli/task/next.rs:26` | string literal `"all tasks complete or superseded"` | response field value, not a predicate |
+| `cli/task/lifecycle.rs:184` | doc comment `/// The current ready wave: the set of tasks whose deps are all complete` | unrelated: wave-readiness doc |
+| `cli/plan/waves.rs:6, 73, 89, 106` | `all_tasks_complete` in `plan waves --json` output and its local computation | derived JSON field for the waves projection, recomputed each call from `tasks[].depends_on` + current status; not used by `readiness` or `close check` |
+
+The iter3-wave-fix confirms: the parallel `tasks_all_complete` copy that used to live in `close/check.rs` is gone. `cli/close/check.rs:132` now calls `readiness::tasks_complete(state)`. There is no second home for the predicate.
+
+### CC-6: `close check` blocker list includes un-started DAG tasks explicitly
+
+Empirical check at `5a16894`. Fixture: `plan.task_ids = ["T1","T2","T99"]`, `state.tasks = {T1: complete, T2: in_progress}`.
+
+```text
+$ codex1 close check --mission demo --json
+{
+  ...
+  "data": {
+    "verdict": "continue_required",
+    "ready": false,
+    "blockers": [
+      { "code": "TASK_NOT_READY", "detail": "T2 is in_progress" },
+      { "code": "TASK_NOT_READY", "detail": "T99 has not started" }
+    ]
+  }
+}
+```
+
+Source: `crates/codex1/src/cli/close/check.rs:100-123`. When `plan.task_ids` is non-empty, the block iterates it and emits `TASK_NOT_READY: <id> has not started` for any id missing from `state.tasks`. The literal `"{id} has not started"` string lives at `cli/close/check.rs:119`.
+
+### CC-7: Error envelope stability
+
+Ran ~20 commands across success and error paths. Every envelope parses as stable JSON with the documented field set. No surprises.
+
+- `ok=true` flows: `doctor`, `init`, `status` (with and without mission), `outcome check` on complete OUTCOME, `plan choose-level`, `plan scaffold`, `plan check` (fresh + idempotent), `plan graph`, `plan waves`, `task next`, `task start`, `task status`, `task packet`, `review start`, `review packet`, `review record`, `replan check`, `loop pause`, `loop resume`, `close check`.
+- `ok=false` flows: `outcome check` on incomplete OUTCOME (`OUTCOME_INCOMPLETE`), `task start T99` with missing deps (`TASK_NOT_READY`), `close complete` before close review passes (`CLOSE_NOT_READY`), `STATE.json` with unknown variant (`STATE_CORRUPT`), `plan check` with marker still present (`PLAN_INVALID`).
+
+### CC-8: `close` has `check`, `complete`, `record-review`
+
+`close check` projects `state::readiness::derive_verdict` + `derive_blockers`; `close complete` is gated on `verdict == mission_close_review_passed`; `close record-review` is the only write path to `MissionCloseReviewState::Passed` (noted in iter 1 / iter 2 / iter 3 as a documentation addition request — the current iter 4 scope does not re-assess that).
+
+## Reading map — iter 4 verification list versus this audit
+
+| iter 4 scope line | Verified at |
+| --- | --- |
+| Minimal command surface wired in clap | CC-1 |
+| Envelopes (success + error) stable | CC-2, CC-7 |
+| Error codes ⊆ canonical `CliError` set (grep raw codes) | CC-3 |
+| `status` ↔ `close check` agree across ≥5 hand-crafted STATE.json fixtures | CC-4 (8 fixtures) |
+| `readiness::tasks_complete` is the ONLY `tasks_complete`-style predicate | CC-5 |
+| `plan.task_ids` backfill on upgrade | **F1 (P1)** — regression unfixed |
+| `close check` blocker list includes un-started DAG tasks explicitly | CC-6 |
+
+Every iter 4 scope line is exercised. Seven pass; one (the upgrade-trap backfill) fails with primary-source evidence in both the code diff and the empirical repro. No source was modified by this audit.

--- a/docs/audits/iter4-handoff-cross-check.md
+++ b/docs/audits/iter4-handoff-cross-check.md
@@ -1,0 +1,192 @@
+# Handoff Cross-Check — iter 4
+
+Branch audited: `main` @ `5a16894`
+Audited on: 2026-04-20 UTC.
+Worktree: `.claude/worktrees/agent-a23c02b0` (no source, skill, script, or doc edits).
+
+## Scope
+
+Cross-check the repository at `5a16894` against every "Non-Negotiable" and "Anti-Goal" declared in:
+
+- `docs/codex1-rebuild-handoff/00-why-and-lessons.md` § What To Reject.
+- `docs/codex1-rebuild-handoff/README.md` § Non-Negotiables and § Explicit Anti-Goals.
+- `docs/codex1-rebuild-handoff/02-cli-contract.md` § Important Non-Features.
+
+For each anti-goal I confirm whether it is honored in live code, skills, scripts, and documentation. The iter 4 audit adds these specific greps from the task prompt:
+
+- `.ralph/` only in anti-goal prose.
+- No caller-identity patterns in `crates/codex1/src/**/*.rs` (`is_parent|is_subagent|caller_type|reviewer_id|session_id|session_token|capability_token|authority_token`).
+- `plan scaffold` emits no `waves:` key.
+- Reviewer writeback is positively forbidden in the `$review-loop` skill.
+- No wrapper runtime / daemon / `Command::new("codex")` / `Command::new("claude")`.
+- Ralph hook runs only `codex1 status --json`.
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.**
+
+Every declared anti-goal is honored at `5a16894`. `.ralph/` appears only as anti-goal prose or explicit prohibition; caller-identity patterns do not exist in Rust source; `plan scaffold` emits no `waves:` key in PLAN.yaml output; reviewer writeback is positively forbidden in the `$review-loop` skill; no wrapper runtime or background daemon is invoked by any Rust code; the Ralph hook runs only `codex1 status --json`; no capability / session / authority token shape exists anywhere.
+
+## Build evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --release` | 169 passed / 0 failed / 0 ignored |
+
+## Clean checks (anti-goal by anti-goal)
+
+### CC-1: No `.ralph/` live directory, path, or import
+
+Full grep for `.ralph` at `5a16894`:
+
+| File | Line | Category |
+| --- | --- | --- |
+| `docs/codex1-rebuild-handoff/00-why-and-lessons.md` | 37, 82 | anti-goal prose |
+| `docs/codex1-rebuild-handoff/01-product-flow.md` | 241 | anti-goal prose |
+| `docs/codex1-rebuild-handoff/02-cli-contract.md` | 105, 117 | anti-goal prose |
+| `docs/codex1-rebuild-handoff/03-planning-artifacts.md` | 28, 31, 160 | anti-goal prose |
+| `docs/codex1-rebuild-handoff/05-build-prompt.md` | 36, 91 | anti-goal prose |
+| `docs/codex1-rebuild-handoff/README.md` | 79, 93 | anti-goal prose |
+| `docs/mission-anatomy.md` | 3 | "There is no hidden state directory, no `.ralph/`, no side-cache." |
+| `README.md` | 3 | "There is no hidden `.ralph/` state…" |
+| `scripts/README-hook.md` | 19 | "The hook does **not** read … `.ralph/` directories" |
+| `.codex/skills/close/SKILL.md` | 112 | prohibition: "Do not edit `.ralph/` files, `STATE.json`, or hooks to work around Ralph." |
+| `crates/codex1/src/lib.rs` | 9 | doc comment: "derived truth (waves), and never hides state in `.ralph/`." |
+| `docs/audits/*` | — | prior audit reports; anti-goal prose |
+
+No Rust source file, `scripts/*.sh`, skill body, or reference opens, reads, writes, or `Path::new`s a `.ralph/*` path. No `include_str!`/`include_bytes!`/`std::fs` call references it.
+
+### CC-2: No caller-identity patterns in Rust source
+
+Grep across `crates/codex1/src/**/*.rs` for the full pattern list in the task prompt:
+
+```text
+is_parent | is_subagent | caller_type | reviewer_id | session_id
+session_token | capability_token | authority_token
+```
+
+**Zero matches** in any `.rs` file.
+
+`crates/codex1/src/cli/mod.rs:124-140` defines `Ctx { mission, repo_root, json, dry_run, expect_revision }`; no caller-side identity is extracted or inspected. Every handler accepts the `Ctx` as-is and dispatches based on arguments + state-file contents. `crates/codex1/src/cli/review/mod.rs:2-4` makes the design explicit:
+
+> The CLI does not check caller identity; the main thread records review outcomes.
+
+### CC-3: `plan scaffold` emits no `waves:` key
+
+- `crates/codex1/src/cli/plan/scaffold.rs::render_skeleton` (lines 119-171) composes the skeleton. The emitted YAML contains `mission_id`, `planning_level`, `outcome_interpretation`, `architecture`, `planning_process`, `tasks`, `risks`, and `mission_close` — no `waves:` key.
+- Grep for `waves:` in `crates/codex1/src/cli/plan/scaffold.rs`: no matches.
+- Grep for `waves:` in `crates/codex1/src/cli/init.rs`: no matches (the `init` template only adds `planning_level`, `outcome_interpretation`, `architecture`, `planning_process`, `tasks`, `risks`, `mission_close`).
+- `crates/codex1/src/state/schema.rs::MissionState` (lines 176-194) has no `waves` field: `{ mission_id, revision, schema_version, phase, loop_, outcome, plan, tasks, reviews, replan, close, events_cursor }`.
+- Empirical check: `target/release/codex1 init --mission m1` followed by `plan choose-level --level medium` and `plan scaffold --level medium` writes a `PLAN.yaml` with zero `waves:` occurrences.
+- `codex1 plan waves --json` (`cli/plan/waves.rs:60-111`) derives waves on demand from `tasks[].depends_on` + current state; its output JSON contains a `"waves"` key, but that is a derived projection, not a stored `waves:` field. The command is read-only (no `state::mutate`, `fs::write`, or `atomic_write` in the file).
+
+### CC-4: Reviewer writeback is positively forbidden in `$review-loop`
+
+Three positive-worded prohibitions in the skill body:
+
+- `.codex/skills/review-loop/SKILL.md:11`:
+  > The main thread is the sole writer of mission truth: it records clean/dirty via `codex1 review record` (planned review) or `codex1 close record-review` (mission close).
+- `.codex/skills/review-loop/SKILL.md:63`:
+  > Every spawn prompt must begin with the standing reviewer block in `references/reviewer-profiles.md` (findings-only, no edits, no `codex1` mutations, no repairs, no marking clean anywhere). The main thread is the sole writer of mission truth. Reviewer writeback is forbidden.
+- `.codex/skills/review-loop/SKILL.md:79`:
+  > Record review results from inside a reviewer subagent — only the main thread records.
+
+The standing reviewer block in `.codex/skills/review-loop/references/reviewer-profiles.md:8-15` repeats the prohibition in the prompt each reviewer receives:
+
+```text
+Do not edit files.
+Do not invoke Codex1 skills.
+Do not run codex1 mutating commands (no `review record`, `task finish`, `close *`, etc.).
+Do not record mission truth.
+```
+
+`.codex/skills/execute/SKILL.md:117` reinforces from the orchestrator side: "Do not spawn reviewers, run `codex1 review record`, or write to `reviews/`."
+
+### CC-5: No wrapper runtime / daemon / `Command::new("codex")` / `Command::new("claude")`
+
+- Grep for `Command::new` inside `crates/codex1/src`: **0 matches**.
+- Grep for `daemon`, `spawn_process`, `wrapper_runtime`, `tokio::spawn`: **0 matches**.
+- `crates/codex1/src/cli/doctor.rs:63-72` probes for a `codex1` binary on `PATH` via `std::env::split_paths` + `candidate.is_file()` (a file-existence check, not an invocation).
+- `scripts/ralph-stop-hook.sh:25` invokes `$CODEX1 status --json` exactly once and exits; no background process is spawned. The hook drains stdin, probes for the binary, runs one command, parses `.data.stop.allow`, and exits 0 or 2.
+
+The Codex1 binary is a one-shot CLI on every invocation. Nothing in the repo starts, manages, or talks to a long-running helper process.
+
+### CC-6: Ralph hook runs only `codex1 status --json`
+
+Full audit of `scripts/ralph-stop-hook.sh` (60 lines):
+
+| Line | Behavior |
+| --- | --- |
+| 14 | Drains stdin so the pipe does not stall. |
+| 16 | `CODEX1=${CODEX1_BIN:-codex1}` — respects `$CODEX1_BIN` override. |
+| 18-21 | If `codex1` not on PATH, allow Stop (exit 0). |
+| 25 | `status_json="$("$CODEX1" status --json 2>/dev/null || true)"` — the sole CLI invocation. |
+| 36-45 | Parses `.data.stop.allow` / `.reason` / `.message` with `jq`, or a degraded grep fallback. |
+| 47-60 | Exit 0 on `allow=true`, exit 2 on `allow=false` (blocks Stop), exit 0 on parse failure (fail-open). |
+
+The hook never reads `PLAN.yaml`, `STATE.json`, `EVENTS.jsonl`, `specs/`, `reviews/`, or `.ralph/`. It never spawns another process. `scripts/README-hook.md:19` makes the promise explicit.
+
+`crates/codex1/src/cli/hook.rs` only prints wiring JSON (`codex1 hook snippet`); it does not install or invoke anything.
+
+### CC-7: No capability / session / authority tokens
+
+Grep across `crates/codex1/src` for `session_id | session_token | capability_token | authority_token | session_owner`: **0 matches**.
+
+No handler accepts, mints, stores, or validates an authority token. Mutating commands gate on `--expect-revision` (`core/error.rs:53-54`), which is a state-file revision counter, not a caller-identity credential.
+
+### CC-8: Stored waves are not treated as editable truth
+
+- `crates/codex1/src/state/schema.rs::MissionState` (lines 176-194) has no `waves` field.
+- `crates/codex1/src/cli/plan/waves.rs` derives waves on demand; no `state::mutate` call inside the file.
+- `docs/cli-contract-schemas.md` pins the Rust types for `MissionState`; no `waves:` collection is listed.
+- `.codex/skills/plan/SKILL.md:199` positively forbids storing waves: "Do not store waves inside `PLAN.yaml`. Waves are derived."
+
+### CC-9: CLI does not spawn subagents or ask semantic questions
+
+- `crates/codex1/src/cli/**/*.rs` contains no `Command::new("codex")` / `Command::new("claude")` / model invocation.
+- No handler reads from stdin except `cli/plan/choose_level.rs:110` (TTY-only level prompt), which is the explicitly sanctioned exception at `docs/codex1-rebuild-handoff/02-cli-contract.md:46`.
+- `codex1 task packet` (`cli/task/packet.rs`) and `codex1 review packet` (`cli/review/packet.rs`) emit prompt strings for the main thread to paste into a subagent; neither spawns anything.
+
+### CC-10: Visible mission files only — no hidden state
+
+`crates/codex1/src/core/paths.rs` resolves every mutating command to `PLANS/<mission>/{OUTCOME.md, PLAN.yaml, STATE.json, EVENTS.jsonl, specs/, reviews/, CLOSEOUT.md}`. No handler writes outside `PLANS/<mission>/`. There is no side-cache, side-state, or hidden dotfile.
+
+### CC-11: `plan choose-level` is the only interactive prompt, and it asks a structured question
+
+`crates/codex1/src/cli/plan/choose_level.rs:110` (interactive TTY branch) asks exactly one question: which of `light | medium | hard | 1 | 2 | 3` to record. It does not ask semantic clarification about the mission. This is the sanctioned exception at `02-cli-contract.md:46`. All other commands are non-interactive and emit JSON.
+
+## Reading map — task bullets versus this audit
+
+| Task iter 4 scope line | Verified at |
+| --- | --- |
+| `.ralph/` only in anti-goal prose | CC-1 |
+| No caller-identity patterns in `crates/codex1/src/**/*.rs` | CC-2 |
+| `plan scaffold` emits no `waves:` key | CC-3 |
+| Reviewer writeback positively forbidden in `$review-loop` | CC-4 |
+| No wrapper runtime / daemon / `Command::new("codex"\|"claude")` | CC-5 |
+| Ralph hook runs only `codex1 status --json` | CC-6 |
+
+| Handoff source | Anti-goal | Verified at |
+| --- | --- | --- |
+| `00-why-and-lessons.md:82` | No `.ralph` mission truth | CC-1 |
+| `00-why-and-lessons.md:84` | No caller-identity checks | CC-2 |
+| `00-why-and-lessons.md:86` | No reviewer writeback authority | CC-4 |
+| `00-why-and-lessons.md:87` | No stored waves as editable truth | CC-3, CC-8 |
+| `00-why-and-lessons.md:80-81` | No hidden daemons / wrapper runtimes | CC-5 |
+| `README.md:78` | CLI must not detect parent vs subagent | CC-2 |
+| `README.md:79` | No `.ralph/` mission state directory | CC-1 |
+| `README.md:89` | No session-ID authority system | CC-7 |
+| `README.md:91` | No capability-token maze | CC-7 |
+| `README.md:92` | No reviewer writeback authority tokens | CC-4, CC-7 |
+| `README.md:93` | No stored waves as canonical truth | CC-3, CC-8 |
+| `README.md:95` | A CLI that spawns subagents (rejected) | CC-5, CC-9 |
+| `README.md:96` | A CLI that asks semantic clarification (rejected) | CC-11 |
+| `02-cli-contract.md:99` | Must not ask "are you parent or subagent?" | CC-2 |
+| `02-cli-contract.md:102` | Must not spawn subagents | CC-9 |
+| `02-cli-contract.md:105` | Must not use `.ralph` mission truth | CC-1 |
+| `02-cli-contract.md:106` | Must not store waves as editable truth | CC-3, CC-8 |
+| `01-product-flow.md:241` | Ralph must not inspect plan/review files directly | CC-6 |
+
+Every anti-goal is honored in code, skills, scripts, and docs. No findings.

--- a/docs/audits/iter4-skills-audit.md
+++ b/docs/audits/iter4-skills-audit.md
@@ -1,0 +1,141 @@
+# Skills Audit — iter 4
+
+Branch audited: `main` @ `5a16894`
+Audited on: 2026-04-20 UTC
+Skill folders: `.codex/skills/{clarify,plan,execute,review-loop,close,autopilot}`.
+Worktree: `.claude/worktrees/agent-a23c02b0` (no skill edits).
+
+## Scope
+
+For every skill I verified (re-running every iter-3 check against the `5a16894` tree):
+
+- `quick_validate.py` passes (script at `/Users/joel/.codex/skills/.system/skill-creator/scripts/quick_validate.py`).
+- Frontmatter has only `name` + `description`; `name` matches the folder name.
+- `SKILL.md` body is under 500 lines and written in imperative form.
+- `agents/openai.yaml` exists and `interface.default_prompt` references `$<skill-name>` literally.
+- No `README.md`, `INSTALLATION_GUIDE.md`, or `CHANGELOG.md` inside the skill folder.
+- Body invokes the CLI verbs the skill exists to drive.
+- Body does not positively invite behaviors the handoff forbids (caller-identity detection, reviewer writeback, stored waves as editable truth, `.ralph/` as live state, capability/session tokens).
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.** Every skill passes the installed validator, has a clean two-key frontmatter, stays under the 500-line body cap, ships a matching `agents/openai.yaml` with a literal `$<skill-name>` in its `default_prompt`, and contains no forbidden filenames. Bodies invoke the CLI verbs the task prompt requires for each skill. Every handoff anti-goal is either silent (caller identity, session/capability tokens) or positively forbidden in prose.
+
+No findings.
+
+## Build evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --release` | 169 passed / 0 failed / 0 ignored |
+
+The skills folder is not exercised by cargo; these are reported for cross-check consistency with the other two iter-4 reports, since the task's build gate applies to the whole audit pass.
+
+## Clean checks (no findings)
+
+### Per-skill `quick_validate.py` output (literal)
+
+```text
+=== autopilot ===      Skill is valid!
+=== clarify ===        Skill is valid!
+=== close ===          Skill is valid!
+=== execute ===        Skill is valid!
+=== plan ===           Skill is valid!
+=== review-loop ===    Skill is valid!
+```
+
+### Frontmatter shape (only `name` + `description`)
+
+| Skill | `name:` value | frontmatter keys |
+| --- | --- | --- |
+| autopilot | `autopilot` | `name`, `description` |
+| clarify   | `clarify`   | `name`, `description` |
+| close     | `close`     | `name`, `description` |
+| execute   | `execute`   | `name`, `description` |
+| plan      | `plan`      | `name`, `description` |
+| review-loop | `review-loop` | `name`, `description` |
+
+Validator also allows `license`, `allowed-tools`, `metadata`; none are present anywhere. Description fields are single prose blocks under the 1024-character validator ceiling.
+
+### Body length (all under 500 lines)
+
+| Skill | `SKILL.md` line count |
+| --- | --- |
+| autopilot | 133 |
+| clarify | 60 |
+| close | 112 |
+| execute | 122 |
+| plan | 205 |
+| review-loop | 81 |
+
+Bodies are imperative (each opens with a verb phrase: `Turn a user's mission goal into…`, `Create a full Codex1 mission plan…`, `Run the next ready task…`, `Orchestrate reviewer subagents…`, `Pause the active Codex1 loop…`, `Take a Codex1 mission from start to terminal close…`).
+
+### `agents/openai.yaml` — `default_prompt` references `$<name>` literally
+
+| Skill | `default_prompt` excerpt | Literal `$<name>` present? |
+| --- | --- | --- |
+| autopilot   | `Use $autopilot to take a Codex1 mission from clarify to terminal close.` | Yes |
+| clarify     | `Use $clarify to fill and ratify OUTCOME.md before planning.` | Yes |
+| close       | `Use $close to pause the active loop so the user can talk without Ralph forcing continuation.` | Yes |
+| execute     | `Use $execute to run the next ready task or wave for the active Codex1 mission.` | Yes |
+| plan        | `Use $plan to scaffold, fill, and lock PLAN.yaml for the active mission.` | Yes |
+| review-loop | `Use $review-loop to run reviewer subagents and record clean/dirty findings.` | Yes |
+
+All six yaml files also pin `policy.allow_implicit_invocation: true` as the only policy key.
+
+### No forbidden files inside skill folders
+
+```text
+$ find .codex/skills -type f \( -iname 'README.md' -o -iname 'INSTALLATION_GUIDE.md' -o -iname 'CHANGELOG.md' \)
+(no output)
+```
+
+Every skill folder contains only `SKILL.md`, `agents/openai.yaml`, and (for five of six) a `references/` directory:
+
+```text
+.codex/skills/
+├── autopilot/{agents/openai.yaml, references/autopilot-state-machine.md, SKILL.md}
+├── clarify/{agents/openai.yaml, references/outcome-shape.md, SKILL.md}
+├── close/{agents/openai.yaml, SKILL.md}
+├── execute/{agents/openai.yaml, references/worker-packet-template.md, SKILL.md}
+├── plan/{agents/openai.yaml, references/dag-quality.md, references/hard-planning-evidence.md, SKILL.md}
+└── review-loop/{agents/openai.yaml, references/reviewer-profiles.md, SKILL.md}
+```
+
+### Body invokes the CLI verbs the skill exists to drive
+
+| Skill | CLI verbs mentioned in `SKILL.md` |
+| --- | --- |
+| clarify | `codex1 init --mission`, `codex1 status --json`, `codex1 outcome check`, `codex1 outcome ratify` |
+| plan | `codex1 plan choose-level`, `codex1 plan scaffold`, `codex1 plan check`, `codex1 plan graph`, `codex1 plan waves`, `codex1 replan record` |
+| execute | `codex1 task next`, `codex1 task start`, `codex1 task packet`, `codex1 task finish`, `codex1 status --json` |
+| review-loop | `codex1 review start`, `codex1 review packet`, `codex1 review record`, `codex1 close check`, `codex1 close record-review` |
+| close | `codex1 loop pause`, `codex1 loop resume`, `codex1 loop deactivate`, `codex1 close check`, `codex1 close complete`, `codex1 status` |
+| autopilot | `codex1 status --json`, `codex1 init --mission`, `codex1 plan choose-level`, `codex1 close check`, `codex1 close complete` (and composes the other five skills) |
+
+### Handoff anti-goals honored (positive prohibitions where the handoff asks for them)
+
+- **No skill body or reference treats `.ralph/` as a live storage directory.** The one hit inside a skill body is `close/SKILL.md:112`:
+  > Do not edit `.ralph/` files, `STATE.json`, or hooks to work around Ralph. Use the `loop` commands.
+- **No skill body instructs reviewer subagents to mutate mission truth.** `review-loop/SKILL.md:11` ("The main thread is the sole writer of mission truth"), `review-loop/SKILL.md:63` ("Reviewer writeback is forbidden"), `review-loop/SKILL.md:79` ("Record review results from inside a reviewer subagent — only the main thread records"), and `review-loop/references/reviewer-profiles.md:8-15` (standing reviewer block: `Do not edit files. / Do not invoke Codex1 skills. / Do not run codex1 mutating commands`) all speak the positive prohibition the handoff requires. `execute/SKILL.md:117` reinforces from the orchestrator side: `Do not spawn reviewers, run codex1 review record, or write to reviews/`.
+- **No skill body stores waves in `PLAN.yaml` or treats them as editable truth.** `plan/SKILL.md:199` positively forbids it:
+  > Do not store waves inside `PLAN.yaml`. Waves are derived.
+  `plan/references/dag-quality.md:15` reinforces.
+- **No skill asks the CLI to detect caller identity.** No hits for `parent.*subagent|subagent.*parent|caller.*identity|session.*token|capability.*token|authority.*token` inside any `SKILL.md`. `autopilot/SKILL.md` relies on prompt-governed role boundaries; `review-loop/SKILL.md:63-82` enforces reviewer behavior via spawn-prompt prose, not by asking the CLI to gate on identity.
+- **Six consecutive dirty reviews triggering replan** is documented at `review-loop/SKILL.md:4` and `execute/SKILL.md:107`, matching `handoff/01-product-flow.md`.
+
+## Reading map — iter 4 skills checklist versus this audit
+
+| iter 4 scope line | Verified in |
+| --- | --- |
+| `quick_validate.py` on every skill folder | § Per-skill validator output |
+| Frontmatter = only `name` + `description` | § Frontmatter shape |
+| Body < 500 lines; imperative | § Body length |
+| `agents/openai.yaml::default_prompt` mentions `$<skill-name>` literally | § default_prompt references |
+| No `README.md` / `INSTALLATION_GUIDE.md` / `CHANGELOG.md` inside skill folders | § No forbidden files |
+| Body invokes relevant CLI verbs | § Body invokes the CLI verbs |
+| No anti-goal invitations | § Handoff anti-goals honored |
+
+Every iter 4 skills check passes. No source, skill, or doc was modified by this audit.


### PR DESCRIPTION
## Summary

Fresh iter-4 audit of Codex1 v3 rebuild against `main @ 5a16894` (iter3-wave-fix commit).

- **cli-contract: 0 P0 / 1 P1 / 0 P2** — F11 upgrade trap regression. iter3 commit `2ef3ce7` claimed a fix ("Tightened the short-circuit to require `!task_ids_missing` in addition to `hash_matches`") but the diff contains only the clippy `clone_from` fix. The `already_locked_same` predicate in `crates/codex1/src/cli/plan/check.rs:61-84` is byte-identical across `958d2f1`, `2ef3ce7`, `5a16894`. Empirical repro confirms: a pre-F8 state (`locked=true`, `hash=X`, `task_ids=[]`) re-run through `codex1 plan check` returns `ok=true, revision` unchanged, no event, no backfill. Downstream: a mission with all tasks complete but empty `task_ids` reports `verdict=continue_required` with zero blockers — the operator is blind to why close is blocked.
- **skills: 0/0/0** — `quick_validate.py` clean on all six, frontmatter is `name`+`description` only, every body <500 lines and imperative, `openai.yaml::default_prompt` references `$<skill-name>` literally, no forbidden files, every skill drives its CLI verbs, reviewer-writeback positively forbidden in `$review-loop`.
- **handoff: 0/0/0** — `.ralph/` only in anti-goal prose, zero caller-identity patterns in Rust source, `plan scaffold` emits no `waves:` key, no wrapper runtime / `Command::new("codex"|"claude")` / daemon, Ralph hook runs exactly `codex1 status --json`.

## Build evidence (at `5a16894`)

- `cargo fmt --check` — PASS
- `cargo clippy --all-targets -- -D warnings` — PASS (0 errors, 0 warnings)
- `cargo test --release` — 169 passed / 0 failed / 0 ignored

## Files added

- `docs/audits/iter4-cli-contract-audit.md` (F1 finding + 8 status-vs-close-check fixtures + full grep evidence)
- `docs/audits/iter4-skills-audit.md` (six-skill clean sweep)
- `docs/audits/iter4-handoff-cross-check.md` (every anti-goal cross-checked)

No source, skill, script, test, or pre-existing doc was modified.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --release` — 169/169 green
- [x] F11 upgrade trap reproduced empirically; diff at `2ef3ce7` inspected as primary-source evidence
- [x] 8 hand-crafted STATE.json fixtures exercised through the compiled binary; status and close check agree on verdict + `close_ready`/`ready`
- [x] `close check` blocker for un-started DAG task emits `TASK_NOT_READY: T99 has not started`
- [x] All six skills pass `quick_validate.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)