### PR TITLE
iter5 audit: wave (post-c5e07ad)

### DIFF
--- a/docs/audits/iter5-cli-contract-audit.md
+++ b/docs/audits/iter5-cli-contract-audit.md
@@ -1,0 +1,232 @@
+# CLI Contract Audit — iter 5
+
+Branch audited: `main` @ `c5e07ad`
+Audited on: 2026-04-20 UTC
+Binary: `target/release/codex1 0.1.0` (built from `c5e07ad`).
+Worktree: `.claude/worktrees/agent-a8f65e5b` (fresh checkout at `c5e07ad`, no source/test/skill/doc edits).
+
+## Scope
+
+Fresh pass on every command listed in `docs/codex1-rebuild-handoff/02-cli-contract.md` § Minimal Command Surface, plus the iter 5 verification list from the task prompt:
+
+- Minimal command surface wired in clap (all 29 leaves).
+- Success + error envelope shape stability.
+- Error codes ⊆ canonical `CliError` set (grep + filter).
+- `status` ↔ `close check` agreement across ≥5 hand-crafted STATE.json fixtures.
+- One `tasks_complete`-style predicate (grep `tasks_complete|tasks_all_complete|fn.*all.*complete` across `src/**/*.rs`).
+- F11 upgrade trap guard: `cli/plan/check.rs` contains `let task_ids_missing = …` AND the short-circuit predicate AND is negated (`!task_ids_missing`).
+- `close check` blocker list emits `TASK_NOT_READY: <id> has not started` for un-started DAG nodes when `plan.task_ids` is populated.
+- F11 regression test exists in `crates/codex1/tests/plan_check.rs`.
+- The regression test passes when run in isolation (`cargo test --release --test plan_check plan_check_backfills`).
+
+## Summary
+
+**PASS — 0 P0, 0 P1, 0 P2.**
+
+The iter 4 audit (`docs/audits/iter4-cli-contract-audit.md`) closed with one open P1 (F1: the F11 upgrade trap predicate was missing from `cli/plan/check.rs` despite iter-3 claiming to have added it). Commits `b212ca8` (iter4-fix) and `c5e07ad` (iter4-fix-followup) resolve that finding:
+
+- `crates/codex1/src/cli/plan/check.rs:70-72` now reads
+
+  ```rust
+  let hash_matches = current.plan.locked && current.plan.hash.as_deref() == Some(hash.as_str());
+  let task_ids_missing = current.plan.task_ids.is_empty();
+  let already_locked_same = hash_matches && !task_ids_missing;
+  ```
+
+  exactly the predicate iter 4 asked for.
+- `crates/codex1/tests/plan_check.rs:661` defines `plan_check_backfills_missing_task_ids_and_then_stays_idempotent`, the regression guard.
+- Empirical repro of the iter 4 scenario: first `plan check` locks at revision 3 with `task_ids=["T1","T2"]`; stripping `task_ids` to `[]` and re-running `plan check` now backfills (rev 3 → 4, one new `plan.checked` event); a third run is idempotent (rev stays 4, no event).
+
+Every other iter 4 clean-check (CC-1 through CC-8) continues to hold at `c5e07ad`. The build gate is clean. All 170 tests pass (up from iter 4's 169 because of the new regression test).
+
+## Build evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS (silent) |
+| `cargo clippy --all-targets -- -D warnings` | PASS (0 errors, 0 warnings) |
+| `cargo test --release` | PASS (170 passed / 0 failed / 0 ignored) |
+
+### F11 regression test — isolated run
+
+```text
+$ cargo test --release --test plan_check plan_check_backfills
+    Finished `release` profile [optimized] target(s) in 15.02s
+     Running tests/plan_check.rs (target/release/deps/plan_check-…)
+
+running 1 test
+test plan_check_backfills_missing_task_ids_and_then_stays_idempotent ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.71s
+```
+
+## Findings
+
+None.
+
+## Clean checks
+
+### CC-1: F1 (P1, iter 4) is resolved
+
+- **Primary-source evidence — predicate landed.** `git show c5e07ad:crates/codex1/src/cli/plan/check.rs | grep task_ids_missing` (equivalently `git show origin/main:…`; note the worktree's local `main` branch is pinned elsewhere but `origin/main` and `c5e07ad` are the same commit) returns:
+
+  ```text
+  71:    let task_ids_missing = current.plan.task_ids.is_empty();
+  72:    let already_locked_same = hash_matches && !task_ids_missing;
+  ```
+
+  `cli/plan/check.rs:61-72` (the short-circuit block) now reads:
+
+  ```rust
+  // Idempotent short-circuit: same hash on an already-locked plan → no mutation.
+  //
+  // Exception — upgrade-in-place: if a previously-locked state has no
+  // `plan.task_ids` snapshot (pre-F8 binary, or hand-edited state),
+  // fall through so the mutation closure backfills it. Without this
+  // guard, an upgraded binary would perpetually re-enter the
+  // short-circuit and `status` / `close check` would be stuck with
+  // `verdict=continue_required` and no actionable blockers.
+  let current = state::load(&paths)?;
+  let hash_matches = current.plan.locked && current.plan.hash.as_deref() == Some(hash.as_str());
+  let task_ids_missing = current.plan.task_ids.is_empty();
+  let already_locked_same = hash_matches && !task_ids_missing;
+  ```
+
+  This is exactly the fix iter 4 prescribed (`iter4-cli-contract-audit.md` § F1, "Fix sketch"). The short-circuit now additionally requires `!task_ids_missing`, so an upgraded binary seeing a pre-F8 lock falls through into the mutation closure at line 104 and backfills `plan.task_ids`.
+- **Primary-source evidence — regression test landed.**
+
+  ```text
+  $ grep -l plan_check_backfills_missing_task_ids_and_then_stays_idempotent crates/codex1/tests/*.rs
+  crates/codex1/tests/plan_check.rs
+  ```
+
+  The test (`tests/plan_check.rs:660-710`) locks a 4-task mission, strips `plan.task_ids` to `[]`, re-runs `plan check`, asserts the revision bumped and `task_ids` repopulated to `["T1","T2","T3","T4"]`, then re-runs again and asserts the revision did not bump (idempotent).
+- **Empirical repro** (`target/release/codex1` built from `c5e07ad`, scratch mission at `/tmp/codex1-iter5-f11test`):
+
+  1. Ran `init`, wrote valid OUTCOME + PLAN, ratified OUTCOME, chose level `light`, ran `plan check` → `ok=true`, `revision=3`, `plan.task_ids=["T1","T2"]`.
+  2. Stripped `task_ids` to `[]` on disk (simulating a pre-F8 lock). STATE.json still shows `revision=3` and `plan.locked=true`.
+  3. Re-ran `plan check` → `ok=true`, `revision=4`, `plan.task_ids=["T1","T2"]` repopulated. `EVENTS.jsonl` now contains a second `plan.checked` entry.
+  4. Re-ran `plan check` → `ok=true`, `revision=4` (unchanged). No new event. Idempotent.
+
+  This is the exact "first call mutates, second call is idempotent" cycle iter 4 asked for.
+
+### CC-2: Minimal command surface wired in clap (29 leaves)
+
+Every minimal-surface command resolves via `codex1 <group> <verb> --help`. Verified by invoking each leaf with `--help`:
+
+| Group | Verbs | Source |
+| --- | --- | --- |
+| (root) | `init`, `status`, `doctor`, `hook snippet` | `cli/mod.rs:76-124`, `cli/init.rs`, `cli/status/mod.rs`, `cli/doctor.rs`, `cli/hook.rs` |
+| `outcome` | `check`, `ratify` | `cli/outcome/mod.rs` |
+| `plan` | `choose-level`, `scaffold`, `check`, `graph`, `waves` | `cli/plan/mod.rs` |
+| `task` | `next`, `start`, `finish`, `status`, `packet` | `cli/task/mod.rs` |
+| `review` | `start`, `packet`, `record`, `status` | `cli/review/mod.rs` |
+| `replan` | `check`, `record` | `cli/replan/mod.rs` |
+| `loop` | `pause`, `resume`, `deactivate`, `activate` | `cli/loop_/mod.rs` |
+| `close` | `check`, `complete`, `record-review` | `cli/close/mod.rs` |
+
+All 29 leaves return clap help without error. Total matches the `iter4-cli-contract-audit.md § CC-1` table (25 group-qualified plus 4 root verbs).
+
+### CC-3: Success + error envelopes stable
+
+- Success envelope (`core/envelope.rs`): `{ ok: true, mission_id?, revision?, data }`. Verified live on every command group during fixture runs below.
+- Error envelope (`core/envelope.rs`): `{ ok: false, code, message, hint?, retryable, context? }`. `hint`, `message_context`-style `context`, and `retryable` fields serialize exactly once; `hint` and `context` use `skip_serializing_if` so the shape remains stable when absent.
+- Sample error bodies seen live at `c5e07ad`: `OUTCOME_INCOMPLETE` (missing YAML frontmatter), `PLAN_INVALID` (bad task kind, missing section), `STATE_CORRUPT` (unknown Phase variant), `CLOSE_NOT_READY` (via `close check` payload not via error; see CC-5).
+
+### CC-4: Error codes ⊆ canonical `CliError` set
+
+- Canonical set (18 codes) at `core/error.rs:82-102`: `OUTCOME_INCOMPLETE`, `OUTCOME_NOT_RATIFIED`, `PLAN_INVALID`, `DAG_CYCLE`, `DAG_MISSING_DEP`, `TASK_NOT_READY`, `PROOF_MISSING`, `REVIEW_FINDINGS_BLOCK`, `REPLAN_REQUIRED`, `CLOSE_NOT_READY`, `STATE_CORRUPT`, `REVISION_CONFLICT`, `STALE_REVIEW_RECORD`, `TERMINAL_ALREADY_COMPLETE`, `CONFIG_MISSING`, `MISSION_NOT_FOUND`, `PARSE_ERROR`, `NOT_IMPLEMENTED`.
+- Grep across `crates/codex1/src/**/*.rs` for double-quoted uppercase tokens matched `"[A-Z_]{4,}"`; every hit that looks like an error code is one of:
+  - A `CliError::code()` arm in `core/error.rs`.
+  - A `Blocker::new("<CODE>", …)` call in `cli/close/check.rs` using `OUTCOME_NOT_RATIFIED`, `PLAN_INVALID`, `REPLAN_REQUIRED`, `TASK_NOT_READY`, `REVIEW_FINDINGS_BLOCK`, `CLOSE_NOT_READY`.
+  - An `exit_with_validation_error("<CODE>", …)` call in `cli/plan/check.rs` using `PLAN_INVALID`, `DAG_CYCLE`, `DAG_MISSING_DEP`.
+  - A documentation / doc-comment reference (`core/envelope.rs:10`).
+- No non-canonical code escapes. `INTERNAL`-style and `Other`-style variants are absent (previously dropped; no regression at `c5e07ad`).
+
+### CC-5: `status` ↔ `close check` agreement across 10 hand-crafted fixtures
+
+Each fixture below is a `STATE.json` written by hand to `/tmp/codex1-iter5-fx<name>/PLANS/demo/STATE.json`, with matching stub `OUTCOME.md` + `PLAN.yaml` so both commands load. `status --mission demo --json` and `close check --mission demo --json` were both invoked against the same `--repo-root`.
+
+| # | Fixture | `status.verdict` | `close.verdict` | `status.close_ready` | `close.ready` |
+| --- | --- | --- | --- | --- | --- |
+| 1 | fresh `init` (outcome unratified, plan unlocked) | `needs_user` | `needs_user` | false | false |
+| 2 | outcome ratified, plan unlocked | `needs_user` | `needs_user` | false | false |
+| 3 | plan locked, T1 complete + T2 in_progress | `continue_required` | `continue_required` | false | false |
+| 4 | all tasks complete, mission-close review not started | `ready_for_mission_close_review` | `ready_for_mission_close_review` | false | false |
+| 5 | mission-close review passed | `mission_close_review_passed` | `mission_close_review_passed` | **true** | **true** |
+| 6 | terminal (`close.terminal_at` set) | `terminal_complete` | `terminal_complete` | false | false |
+| 7 | DAG with `T99` never started (plan locked) | `continue_required` | `continue_required` | false | false |
+| 8 | dirty review on T2 blocks progress | `blocked` | `blocked` | false | false |
+| 9 | replan.triggered=true | `blocked` | `blocked` | false | false |
+| 10 | mission-close review open | `mission_close_review_open` | `mission_close_review_open` | false | false |
+
+For every fixture: (a) `status.data.verdict == close.data.verdict`, (b) `status.data.close_ready == close.data.ready`. By construction both commands call `state::readiness::derive_verdict`, and `status` computes `close_ready` as `matches!(verdict, MissionCloseReviewPassed)` at `cli/status/mod.rs`, identical to `close check`'s `ready` at `cli/close/check.rs:49`.
+
+Fixture 7 also exercises the `has not started` blocker branch (see CC-8). Fixtures 4, 5, 6, 9, 10 each produce a uniquely-named verdict string — they exercise distinct `derive_verdict` arms.
+
+### CC-6: `tasks_complete` is the only `tasks_complete`-style predicate
+
+Grep across `crates/codex1/src/**/*.rs`:
+
+| File:line | Hit | Category |
+| --- | --- | --- |
+| `state/readiness.rs:80` | `pub fn tasks_complete(state: &MissionState) -> bool` | canonical definition |
+| `state/readiness.rs:57` | `if tasks_complete(state) {` | internal use inside `derive_verdict` |
+| `state/schema.rs:82` | `readiness::tasks_complete` (doc comment only) | doc reference |
+| `cli/close/check.rs:132` | `if readiness::tasks_complete(state) {` | delegates to canonical predicate |
+| `cli/plan/waves.rs:6, 73, 89, 106` | `all_tasks_complete` in the `plan waves --json` projection | derived JSON field recomputed each call; not a close-readiness predicate |
+
+`cli/plan/waves.rs` uses `all_tasks_complete` as the JSON field name for a wave-list projection, and it is computed locally from `tasks[].depends_on` + `state.tasks` — not a mission-close predicate and never consulted by `status` / `close check`. Confirmed read-only: no `state::mutate`, `atomic_write`, or `fs::write` in `cli/plan/waves.rs`.
+
+No parallel `tasks_all_complete` copy exists. The iter 3 wave-fix is intact at `c5e07ad`.
+
+### CC-7: F11 upgrade trap guard is present and correct
+
+- Primary-source evidence at `cli/plan/check.rs:71-72`:
+  ```rust
+  let task_ids_missing = current.plan.task_ids.is_empty();
+  let already_locked_same = hash_matches && !task_ids_missing;
+  ```
+  Verified with `git show main:crates/codex1/src/cli/plan/check.rs | grep task_ids_missing` (two matches, at lines 71 and 72).
+- The mutation closure at `cli/plan/check.rs:109-122` backfills `s.plan.task_ids.clone_from(&task_ids_to_record)` whenever the short-circuit is skipped.
+- Empirical behavior at `c5e07ad`: see CC-1 for the full three-step repro. `plan.task_ids` backfills on the first re-run, and a second re-run is idempotent.
+
+### CC-8: `close check` blocker list includes un-started DAG tasks
+
+Empirical fixture (fx7): `plan.task_ids = ["T1","T2","T99"]`, `state.tasks = { T1: complete, T2: in_progress }`. `codex1 close check --json` returns:
+
+```json
+{
+  "ok": true,
+  "mission_id": "demo",
+  "revision": 4,
+  "data": {
+    "blockers": [
+      { "code": "TASK_NOT_READY", "detail": "T2 is in_progress" },
+      { "code": "TASK_NOT_READY", "detail": "T99 has not started" }
+    ],
+    "ready": false,
+    "verdict": "continue_required"
+  }
+}
+```
+
+Source: `cli/close/check.rs:109-123`. When `plan.task_ids` is non-empty, the block iterates each id and emits `TASK_NOT_READY: <id> has not started` for any id missing from `state.tasks`. The literal `"{id} has not started"` string lives at `cli/close/check.rs:119`.
+
+The empty-`task_ids` fallback (lines 100-108) iterates `state.tasks` directly and emits per-task `TASK_NOT_READY`, preserving early-phase signal before `plan check` has locked.
+
+## Reading map — iter 5 verification list versus this audit
+
+| iter 5 scope line | Verified at |
+| --- | --- |
+| Minimal command surface wired | CC-2 |
+| Envelopes (success + error) stable | CC-3 |
+| Error codes ⊆ canonical `CliError` set | CC-4 |
+| `status` ↔ `close check` agree across ≥5 hand-crafted STATE.json fixtures | CC-5 (10 fixtures) |
+| One `tasks_complete`-style predicate | CC-6 |
+| F11 upgrade trap guard actually in `cli/plan/check.rs` | CC-1, CC-7 |
+| `close check` blocker list includes `TASK_NOT_READY: <id> has not started` | CC-8 |
+| F11 regression test exists | CC-1 |
+| The regression test passes | CC-1, build evidence |
+
+Every iter 5 scope line passes. No source, test, skill, or existing doc was modified by this audit.

--- a/docs/audits/iter5-handoff-cross-check.md
+++ b/docs/audits/iter5-handoff-cross-check.md
@@ -1,0 +1,201 @@
+# Handoff Cross-Check — iter 5
+
+Branch audited: `main` @ `c5e07ad`
+Audited on: 2026-04-20 UTC.
+Worktree: `.claude/worktrees/agent-a8f65e5b` (no source, skill, script, or doc edits).
+
+## Scope
+
+Cross-check the repository at `c5e07ad` against every "Non-Negotiable" and "Anti-Goal" declared in:
+
+- `docs/codex1-rebuild-handoff/00-why-and-lessons.md` § What To Reject.
+- `docs/codex1-rebuild-handoff/README.md` § Non-Negotiables and § Explicit Anti-Goals.
+- `docs/codex1-rebuild-handoff/02-cli-contract.md` § Important Non-Features.
+
+For each anti-goal I confirm whether it is honored in live code, skills, scripts, and documentation. The iter 5 audit specifically verifies:
+
+- `.ralph/` only appears in anti-goal prose.
+- No caller-identity patterns in `crates/codex1/src/**/*.rs` (`is_parent|is_subagent|caller_type|reviewer_id|session_id|session_token|capability_token|authority_token`).
+- `plan scaffold` emits no `waves:` key.
+- Reviewer writeback is positively forbidden in the `$review-loop` skill.
+- No wrapper runtime / daemon / `Command::new("codex")` / `Command::new("claude")`.
+- Ralph hook runs only `codex1 status --json`.
+- No session / capability / authority token shape.
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.**
+
+Every declared anti-goal is honored at `c5e07ad`. `.ralph/` appears only as anti-goal prose or explicit prohibition; caller-identity patterns do not exist in Rust source; `plan scaffold` emits no `waves:` key in PLAN.yaml output; reviewer writeback is positively forbidden in the `$review-loop` skill; no wrapper runtime or background daemon is invoked by any Rust code; the Ralph hook runs only `codex1 status --json`; no capability / session / authority token shape exists anywhere. No regression since iter 4; `c5e07ad` is purely a `plan/check.rs` guard tightening + regression test over `5a16894`.
+
+## Build evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --release` | 170 passed / 0 failed / 0 ignored |
+
+## Clean checks (anti-goal by anti-goal)
+
+### CC-1: No `.ralph/` live directory, path, or import
+
+Full `.ralph` grep across the tree:
+
+| File | Category |
+| --- | --- |
+| `docs/codex1-rebuild-handoff/00-why-and-lessons.md` | anti-goal prose |
+| `docs/codex1-rebuild-handoff/01-product-flow.md` | anti-goal prose |
+| `docs/codex1-rebuild-handoff/02-cli-contract.md` | anti-goal prose |
+| `docs/codex1-rebuild-handoff/03-planning-artifacts.md` | anti-goal prose |
+| `docs/codex1-rebuild-handoff/05-build-prompt.md` | anti-goal prose |
+| `docs/codex1-rebuild-handoff/README.md` | anti-goal prose |
+| `docs/mission-anatomy.md` | "There is no hidden state directory, no `.ralph/`, no side-cache." |
+| `README.md` | "There is no hidden `.ralph/` state …" |
+| `scripts/README-hook.md:19` | "The hook does **not** read plan files, subagent state, `.ralph/` directories, …" |
+| `.codex/skills/close/SKILL.md:112` | prohibition: "Do not edit `.ralph/` files, `STATE.json`, or hooks to work around Ralph." |
+| `crates/codex1/src/lib.rs:9` | doc comment: "derived truth (waves), and never hides state in `.ralph/`." |
+| `docs/audits/*` | prior audit reports; anti-goal prose |
+
+No Rust source file, `scripts/*.sh`, skill body, or reference opens, reads, writes, or `Path::new`s a `.ralph/*` path. No `include_str!`/`include_bytes!`/`std::fs` call references it.
+
+### CC-2: No caller-identity patterns in Rust source
+
+Grep across `crates/codex1/src/**/*.rs` for the full pattern list:
+
+```text
+is_parent | is_subagent | caller_type | reviewer_id | session_id
+session_token | capability_token | authority_token
+```
+
+**Zero matches** in any `.rs` file.
+
+`crates/codex1/src/cli/mod.rs:127-134` defines `Ctx { mission, repo_root, json, dry_run, expect_revision }`; no caller-side identity is extracted or inspected. Every handler accepts the `Ctx` as-is and dispatches based on arguments + state-file contents.
+
+### CC-3: `plan scaffold` emits no `waves:` key
+
+- `crates/codex1/src/cli/plan/scaffold.rs::render_skeleton` (lines 119-171) composes the skeleton. The emitted YAML contains `mission_id`, `planning_level`, `outcome_interpretation`, `architecture`, `planning_process`, `tasks`, `risks`, and `mission_close` — no `waves:` key.
+- Grep for `waves:` in `crates/codex1/src/cli/plan/scaffold.rs`: **no matches**.
+- Grep for `waves:` in `crates/codex1/src/cli/init.rs`: **no matches** (init's OUTCOME/PLAN template does not include waves).
+- `crates/codex1/src/state/schema.rs::MissionState` (lines 176-194) has no `waves` field: `{ mission_id, revision, schema_version, phase, loop_, outcome, plan, tasks, reviews, replan, close, events_cursor }`.
+- `codex1 plan waves --json` (`cli/plan/waves.rs`) derives waves on demand from `tasks[].depends_on` + current state; its output JSON contains a `"waves"` key, but that is a derived projection, not a stored `waves:` field. The command is read-only (no `state::mutate`, `fs::write`, or `atomic_write` in the file — grep-verified at `c5e07ad`).
+
+### CC-4: Reviewer writeback is positively forbidden in `$review-loop`
+
+Three positive-worded prohibitions in the skill body:
+
+- `.codex/skills/review-loop/SKILL.md:11`:
+  > The main thread is the sole writer of mission truth: it records clean/dirty via `codex1 review record` (planned review) or `codex1 close record-review` (mission close).
+- `.codex/skills/review-loop/SKILL.md:63`:
+  > Every spawn prompt must begin with the standing reviewer block in `references/reviewer-profiles.md` (findings-only, no edits, no `codex1` mutations, no repairs, no marking clean anywhere). The main thread is the sole writer of mission truth. Reviewer writeback is forbidden.
+- `.codex/skills/review-loop/SKILL.md:79`:
+  > Record review results from inside a reviewer subagent — only the main thread records.
+
+The standing reviewer block in `.codex/skills/review-loop/references/reviewer-profiles.md:8-15` repeats the prohibition in the prompt each reviewer receives:
+
+```text
+Do not edit files.
+Do not invoke Codex1 skills.
+Do not run codex1 mutating commands (no `review record`, `task finish`, `close *`, etc.).
+Do not record mission truth.
+```
+
+`.codex/skills/execute/SKILL.md:117` reinforces from the orchestrator side: "Do not spawn reviewers, run `codex1 review record`, or write to `reviews/`."
+
+### CC-5: No wrapper runtime / daemon / `Command::new("codex")` / `Command::new("claude")`
+
+- Grep for `Command::new` inside `crates/codex1/src`: **0 matches**.
+- Grep for `daemon`, `wrapper_runtime`, `tokio::spawn` inside `crates/codex1/src`: **0 matches**.
+- `crates/codex1/src/cli/doctor.rs` probes for a `codex1` binary on `PATH` via `std::env::split_paths` + file-existence check (not an invocation).
+- `scripts/ralph-stop-hook.sh:25` invokes `"$CODEX1" status --json` exactly once and exits; no background process is spawned.
+
+The Codex1 binary is a one-shot CLI on every invocation. Nothing in the repo starts, manages, or talks to a long-running helper process.
+
+### CC-6: Ralph hook runs only `codex1 status --json`
+
+Full audit of `scripts/ralph-stop-hook.sh` (60 lines):
+
+| Line | Behavior |
+| --- | --- |
+| 14 | Drains stdin so the pipe does not stall. |
+| 16 | `CODEX1=${CODEX1_BIN:-codex1}` — respects `$CODEX1_BIN` override. |
+| 18-21 | If `codex1` not on PATH, allow Stop (exit 0). |
+| 25 | `status_json="$("$CODEX1" status --json 2>/dev/null || true)"` — the sole CLI invocation. |
+| 36-45 | Parses `.data.stop.allow` / `.reason` / `.message` with `jq`, or a degraded grep fallback. |
+| 47-60 | Exit 0 on `allow=true`, exit 2 on `allow=false` (blocks Stop), exit 0 on parse failure (fail-open). |
+
+The hook never reads `PLAN.yaml`, `STATE.json`, `EVENTS.jsonl`, `specs/`, `reviews/`, or `.ralph/`. It never spawns another process. `scripts/README-hook.md:19` makes the promise explicit.
+
+`crates/codex1/src/cli/hook.rs` only prints wiring JSON (`codex1 hook snippet`); it does not install or invoke anything.
+
+### CC-7: No capability / session / authority tokens
+
+Grep across `crates/codex1/src` for `session_id | session_token | capability_token | authority_token | session_owner`: **0 matches**.
+
+No handler accepts, mints, stores, or validates an authority token. Mutating commands gate on `--expect-revision` (`core/error.rs:53-54`), which is a state-file revision counter, not a caller-identity credential.
+
+### CC-8: Stored waves are not treated as editable truth
+
+- `crates/codex1/src/state/schema.rs::MissionState` (lines 176-194) has no `waves` field.
+- `crates/codex1/src/cli/plan/waves.rs` derives waves on demand; no `state::mutate` or file-write call inside the file.
+- `docs/cli-contract-schemas.md` pins the Rust types for `MissionState`; no `waves:` collection is listed.
+- `.codex/skills/plan/SKILL.md:199` positively forbids storing waves: "Do not store waves inside `PLAN.yaml`. Waves are derived."
+- `.codex/skills/plan/references/dag-quality.md:15`: "Waves are derived by `codex1 plan waves` from `depends_on`."
+
+### CC-9: CLI does not spawn subagents or ask semantic clarification
+
+- `crates/codex1/src/cli/**/*.rs` contains no `Command::new("codex")` / `Command::new("claude")` / model invocation.
+- No handler reads from stdin except `cli/plan/choose_level.rs` (TTY-only level prompt), which is the explicitly sanctioned exception at `docs/codex1-rebuild-handoff/02-cli-contract.md`.
+- `codex1 task packet` (`cli/task/packet.rs`) and `codex1 review packet` (`cli/review/packet.rs`) emit prompt strings for the main thread to paste into a subagent; neither spawns anything.
+
+### CC-10: Visible mission files only — no hidden state
+
+`crates/codex1/src/core/paths.rs` resolves every mutating command to `PLANS/<mission>/{OUTCOME.md, PLAN.yaml, STATE.json, EVENTS.jsonl, specs/, reviews/, CLOSEOUT.md}`. No handler writes outside `PLANS/<mission>/`. There is no side-cache, side-state, or hidden dotfile.
+
+### CC-11: `plan choose-level` is the only interactive prompt, and it asks a structured question
+
+`crates/codex1/src/cli/plan/choose_level.rs` (interactive TTY branch) asks exactly one question: which of `light | medium | hard | 1 | 2 | 3` to record. It does not ask semantic clarification about the mission. This is the sanctioned exception at `02-cli-contract.md`. All other commands are non-interactive and emit JSON.
+
+## Reading map — task bullets versus this audit
+
+| Task iter 5 scope line | Verified at |
+| --- | --- |
+| `.ralph/` only in anti-goal prose | CC-1 |
+| No caller-identity patterns in `crates/codex1/src/**/*.rs` | CC-2 |
+| `plan scaffold` emits no `waves:` key | CC-3 |
+| Reviewer writeback positively forbidden in `$review-loop` | CC-4 |
+| No wrapper runtime / daemon / `Command::new("codex"\|"claude")` | CC-5 |
+| Ralph hook runs only `codex1 status --json` | CC-6 |
+| No session/capability/authority token shape | CC-7 |
+
+| Handoff source | Anti-goal | Verified at |
+| --- | --- | --- |
+| `00-why-and-lessons.md:80` | Hidden daemons | CC-5 |
+| `00-why-and-lessons.md:81` | Wrapper runtimes around Codex | CC-5 |
+| `00-why-and-lessons.md:82` | `.ralph` as mission truth | CC-1 |
+| `00-why-and-lessons.md:84` | Caller identity checks | CC-2 |
+| `00-why-and-lessons.md:85` | Capability token mazes | CC-7 |
+| `00-why-and-lessons.md:86` | Reviewer writeback authority systems | CC-4 |
+| `00-why-and-lessons.md:87` | Stored waves as editable truth | CC-3, CC-8 |
+| `00-why-and-lessons.md:90` | Autopilot as a separate hidden runtime | CC-5 |
+| `README.md:78` | CLI must not detect parent vs subagent | CC-2 |
+| `README.md:79` | No `.ralph/` mission state directory | CC-1 |
+| `README.md:86` | Wrapper runtime | CC-5 |
+| `README.md:87` | Giant state machine hidden in hooks | CC-5, CC-6 |
+| `README.md:89` | Caller identity checks | CC-2 |
+| `README.md:90` | Capability-token maze | CC-7 |
+| `README.md:91` | Session-ID authority system | CC-7 |
+| `README.md:92` | Reviewer writeback authority tokens | CC-4, CC-7 |
+| `README.md:93` | Stored waves as canonical truth | CC-3, CC-8 |
+| `README.md:95` | A CLI that spawns subagents (rejected) | CC-5, CC-9 |
+| `README.md:96` | A CLI that asks semantic clarification (rejected) | CC-11 |
+| `02-cli-contract.md:112` | "are you the parent or subagent?" | CC-2 |
+| `02-cli-contract.md:113` | Detect reviewer/worker/explorer/advisor/main-thread identity | CC-2 |
+| `02-cli-contract.md:114` | Block reviewer commands on identity | CC-2, CC-4 |
+| `02-cli-contract.md:115` | Spawn subagents | CC-9 |
+| `02-cli-contract.md:116` | Read hidden chat state | CC-10 |
+| `02-cli-contract.md:117` | Use `.ralph` mission truth | CC-1 |
+| `02-cli-contract.md:118` | Store waves as editable truth | CC-3, CC-8 |
+| `02-cli-contract.md:119` | Giant workflow daemon | CC-5 |
+
+Every anti-goal is honored in code, skills, scripts, and docs. No findings.

--- a/docs/audits/iter5-skills-audit.md
+++ b/docs/audits/iter5-skills-audit.md
@@ -1,0 +1,150 @@
+# Skills Audit — iter 5
+
+Branch audited: `main` @ `c5e07ad`
+Audited on: 2026-04-20 UTC
+Skill folders: `.codex/skills/{clarify,plan,execute,review-loop,close,autopilot}`.
+Worktree: `.claude/worktrees/agent-a8f65e5b` (no skill edits).
+
+## Scope
+
+For every skill I verified:
+
+- `quick_validate.py` passes (script at `/Users/joel/.codex/skills/.system/skill-creator/scripts/quick_validate.py`).
+- Frontmatter has only `name` + `description`; `name` matches the folder name.
+- `SKILL.md` body is under 500 lines and written in imperative/descriptive form.
+- `agents/openai.yaml` exists and `interface.default_prompt` references `$<skill-name>` literally.
+- No `README.md`, `INSTALLATION_GUIDE.md`, or `CHANGELOG.md` inside the skill folder.
+- Body invokes the CLI verbs the skill exists to drive.
+- Body does not positively invite behaviors the handoff forbids (caller-identity detection, reviewer writeback, stored waves as editable truth, `.ralph/` as live state, capability/session tokens).
+
+## Summary
+
+**0 P0, 0 P1, 0 P2.**
+
+Every skill passes the installed validator, has a clean two-key frontmatter, stays under the 500-line body cap, ships a matching `agents/openai.yaml` with a literal `$<skill-name>` in its `default_prompt`, and contains no forbidden filenames. Bodies invoke the CLI verbs the task prompt requires for each skill. Every handoff anti-goal is either silent (caller identity, session/capability tokens) or positively forbidden in prose. No change since iter 4 — `c5e07ad` only touched `crates/codex1/src/cli/plan/check.rs` and `crates/codex1/tests/plan_check.rs` on top of `5a16894`.
+
+## Build evidence
+
+| Command | Result |
+| --- | --- |
+| `cargo fmt --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --release` | 170 passed / 0 failed / 0 ignored |
+
+The skills folder is not exercised by cargo; these are reported for cross-check consistency with the other two iter-5 reports, since the task's build gate applies to the whole audit pass.
+
+## Clean checks
+
+### CC-1: Per-skill `quick_validate.py` output (literal)
+
+```text
+$ python3 /Users/joel/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/<name>
+=== autopilot ===      Skill is valid!
+=== clarify ===        Skill is valid!
+=== close ===          Skill is valid!
+=== execute ===        Skill is valid!
+=== plan ===           Skill is valid!
+=== review-loop ===    Skill is valid!
+```
+
+The validator enforces the two-key frontmatter + name match + description-length ceiling. All six pass.
+
+### CC-2: Frontmatter shape (only `name` + `description`)
+
+| Skill | `name:` value | frontmatter keys |
+| --- | --- | --- |
+| autopilot   | `autopilot`   | `description`, `name` |
+| clarify     | `clarify`     | `description`, `name` |
+| close       | `close`       | `description`, `name` |
+| execute     | `execute`     | `description`, `name` |
+| plan        | `plan`        | `description`, `name` |
+| review-loop | `review-loop` | `description`, `name` |
+
+Validator also allows `license`, `allowed-tools`, `metadata`; none are present anywhere. Description fields are single prose blocks under the 1024-character validator ceiling.
+
+### CC-3: Body length (all under 500 lines)
+
+| Skill | `SKILL.md` line count |
+| --- | --- |
+| autopilot   | 133 |
+| clarify     | 60 |
+| close       | 112 |
+| execute     | 122 |
+| plan        | 205 |
+| review-loop | 81 |
+
+Bodies read as descriptive-imperative (each opens with a declarative sentence about what the skill does: `$autopilot drives a Codex1 mission …`, `Turn a user's mission goal into a ratified OUTCOME.md …`, `$close is a discussion-mode pause.`, `$execute runs one step at a time against the locked DAG …`, `$plan produces a full mission plan …`, `$review-loop orchestrates reviewer subagents …`). All are under the 500-line cap.
+
+### CC-4: `agents/openai.yaml` — `default_prompt` references `$<name>` literally
+
+| Skill | `default_prompt` | Literal `$<name>` present? |
+| --- | --- | --- |
+| autopilot   | `Use $autopilot to take a Codex1 mission from clarify to terminal close.` | Yes |
+| clarify     | `Use $clarify to fill and ratify OUTCOME.md before planning.` | Yes |
+| close       | `Use $close to pause the active loop so the user can talk without Ralph forcing continuation.` | Yes |
+| execute     | `Use $execute to run the next ready task or wave for the active Codex1 mission.` | Yes |
+| plan        | `Use $plan to scaffold, fill, and lock PLAN.yaml for the active mission.` | Yes |
+| review-loop | `Use $review-loop to run reviewer subagents and record clean/dirty findings.` | Yes |
+
+All six yaml files also pin `policy.allow_implicit_invocation: true` as the only policy key.
+
+### CC-5: No forbidden files inside skill folders
+
+```text
+$ find .codex/skills -type f \( -iname 'README.md' -o -iname 'INSTALLATION_GUIDE.md' -o -iname 'CHANGELOG.md' \)
+(no output)
+```
+
+Every skill folder contains only `SKILL.md`, `agents/openai.yaml`, and (for five of six) a `references/` directory:
+
+```text
+.codex/skills/
+├── autopilot/{agents/openai.yaml, references/autopilot-state-machine.md, SKILL.md}
+├── clarify/{agents/openai.yaml, references/outcome-shape.md, SKILL.md}
+├── close/{agents/openai.yaml, SKILL.md}
+├── execute/{agents/openai.yaml, references/worker-packet-template.md, SKILL.md}
+├── plan/{agents/openai.yaml, references/dag-quality.md, references/hard-planning-evidence.md, SKILL.md}
+└── review-loop/{agents/openai.yaml, references/reviewer-profiles.md, SKILL.md}
+```
+
+`close/` is the one skill without a `references/` directory; its body is self-contained.
+
+### CC-6: Body invokes the CLI verbs the skill exists to drive
+
+Extracted via `grep -oE 'codex1 [a-z]+(-[a-z]+)?( [a-z-]+)?'` against each `SKILL.md`, then filtered to the skill's own scope (mentions of other skills' terminal commands, e.g. `codex1 close complete` inside `execute/SKILL.md:116`, are anti-statements about boundaries and are expected):
+
+| Skill | CLI verbs the skill owns |
+| --- | --- |
+| clarify     | `codex1 init --mission`, `codex1 status --json`, `codex1 outcome check`, `codex1 outcome ratify` |
+| plan        | `codex1 plan choose-level`, `codex1 plan check`, `codex1 replan record` (plus references to `plan scaffold`/`plan graph`/`plan waves` throughout the body) |
+| execute     | `codex1 task next`, `codex1 task start`/`finish`/`packet`, `codex1 status --json` |
+| review-loop | `codex1 review record`, `codex1 close record-review`, `codex1 close check`, `codex1 task next` |
+| close       | `codex1 loop pause`, `codex1 loop resume`, `codex1 loop deactivate`, `codex1 close complete` |
+| autopilot   | `codex1 status --json`, `codex1 init --mission`, `codex1 plan choose-level`, `codex1 close check`, `codex1 close complete` (and composes the other five skills) |
+
+Each skill's CLI verb list matches the minimal command surface slice the skill is responsible for.
+
+### CC-7: Handoff anti-goals honored (positive prohibitions where the handoff asks for them)
+
+- **No skill body or reference treats `.ralph/` as a live storage directory.** The one hit inside a skill body is `close/SKILL.md:112`:
+  > Do not edit `.ralph/` files, `STATE.json`, or hooks to work around Ralph. Use the `loop` commands.
+- **No skill body instructs reviewer subagents to mutate mission truth.** `review-loop/SKILL.md:11` ("The main thread is the sole writer of mission truth"), `review-loop/SKILL.md:63` ("Reviewer writeback is forbidden"), `review-loop/SKILL.md:79` ("Record review results from inside a reviewer subagent — only the main thread records"), and `review-loop/references/reviewer-profiles.md:8-15` (standing reviewer block: `Do not edit files. / Do not invoke Codex1 skills. / Do not run codex1 mutating commands`) all speak the positive prohibition the handoff requires. `execute/SKILL.md:117` reinforces from the orchestrator side: "Do not spawn reviewers, run codex1 review record, or write to reviews/".
+- **No skill body stores waves in `PLAN.yaml` or treats them as editable truth.** `plan/SKILL.md:199` positively forbids it:
+  > Do not store waves inside `PLAN.yaml`. Waves are derived.
+  `plan/references/dag-quality.md:15` reinforces: "Waves are derived by `codex1 plan waves` from `depends_on`."
+- **No skill asks the CLI to detect caller identity.** No hits for `parent.*subagent|subagent.*parent|caller.*identity|session.*token|capability.*token|authority.*token` across `.codex/skills/`. `autopilot/SKILL.md` relies on prompt-governed role boundaries; `review-loop/SKILL.md:63-82` enforces reviewer behavior via spawn-prompt prose, not by asking the CLI to gate on identity.
+- **Six consecutive dirty reviews trigger replan** is documented at `review-loop/SKILL.md:4` and `execute/SKILL.md:107`, matching `docs/codex1-rebuild-handoff/01-product-flow.md`.
+
+## Reading map — iter 5 skills checklist versus this audit
+
+| iter 5 scope line | Verified in |
+| --- | --- |
+| `quick_validate.py` on every skill folder | CC-1 |
+| Frontmatter = only `name` + `description` | CC-2 |
+| Body < 500 lines; imperative | CC-3 |
+| `agents/openai.yaml::default_prompt` mentions `$<skill-name>` literally | CC-4 |
+| No `README.md` / `INSTALLATION_GUIDE.md` / `CHANGELOG.md` inside skill folders | CC-5 |
+| Body invokes relevant CLI verbs | CC-6 |
+| No anti-goal invitations | CC-7 |
+
+Every iter 5 skills check passes. No source, skill, or doc was modified by this audit.


### PR DESCRIPTION
## Summary
- Fresh independent re-audit at `main @ c5e07ad` across CLI contract, skills, and handoff anti-goals.
- **0 P0 / 0 P1 / 0 P2** in all three reports. iter 4's single open P1 (F1 — missing upgrade-trap predicate) is fixed at `cli/plan/check.rs:71-72` and guarded by a regression test at `tests/plan_check.rs:661`.
- Adds three reports under `docs/audits/iter5-*.md`. No source/skill/test/existing-doc edits.

## Key evidence
- Build gate clean: `cargo fmt --check` silent, `cargo clippy --all-targets -- -D warnings` clean, `cargo test --release` 170/0/0.
- F11 regression test (`plan_check_backfills_missing_task_ids_and_then_stays_idempotent`) runs in 0.71s and passes in isolation.
- Empirical F11 repro: revision 3 → strip `task_ids` → revision 4 (backfill, 1 new `plan.checked` event) → revision 4 (idempotent).
- `status` ↔ `close check` agree across 10 hand-crafted fixtures (fresh init, outcome-ratified, continue_required, ready_for_mission_close_review, mission_close_review_passed, terminal_complete, T99-never-started, dirty review, replan triggered, mission_close_review_open).
- One `tasks_complete` predicate only (`state/readiness.rs:80`).
- Zero caller-identity patterns in Rust source; no `Command::new` / daemon / wrapper runtime; Ralph hook reads only `codex1 status --json`; no `waves:` key in plan scaffold output.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --release`
- [x] `cargo test --release --test plan_check plan_check_backfills`
- [x] 10 hand-crafted `status` ↔ `close check` fixtures
- [x] Empirical F11 upgrade-trap repro with the release binary
- [x] `quick_validate.py` on every skill folder
- [x] `git status` shows only three new files in `docs/audits/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)