### PR TITLE
Harden mission event log inspection and path safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ The mission ID is intentionally boring: ASCII letters, digits, `-`, and `_` only
   PROOFS/
   .codex1/
     LOOP.json
+    events.jsonl
     receipts/
 ```
 
 `init` creates the folders only. Interviews write content when Codex has enough answers.
+
+Codex1 also keeps `.codex1/events.jsonl` as a mission-local forensic trail of mechanical command metadata. It is usually ignored unless Codex or a human needs to debug unusual mission history. It is not status, not proof, and not mission truth.
 
 ## Answers Files
 

--- a/docs/artifact-model.md
+++ b/docs/artifact-model.md
@@ -34,4 +34,6 @@ The artifact tree is the durable product. Files are human-facing markdown with m
 
 `.codex1/receipts/` stores optional audit receipts. Receipts are not replay authority.
 
+`.codex1/events.jsonl` stores automatic forensic command metadata. Events help explain mechanical command history during debugging, but they are not durable content truth, not receipts, not workflow state, and not replay authority. Normal planning and execution should ignore events unless mission archaeology is needed.
+
 There is no authoritative `STATE.json`.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -14,6 +14,21 @@ codex1 --json --repo-root <path> --mission <id> <command>
 { "ok": true, "data": {} }
 ```
 
+Successful mutating commands may include forensic warnings without becoming failures:
+
+```json
+{
+  "ok": true,
+  "data": {},
+  "warnings": [
+    {
+      "code": "EVENT_LOG_APPEND_FAILED",
+      "message": "..."
+    }
+  ]
+}
+```
+
 Errors use:
 
 ```json
@@ -47,6 +62,18 @@ Error codes are mechanical: `ARGUMENT_ERROR`, `MISSION_PATH_ERROR`, `ARTIFACT_VA
 `ralph stop-hook` reads Stop-hook JSON from stdin and fails open unless explicit loop state says to block.
 
 `doctor` runs fast diagnostics for template registration, path validation basics, loop schema version, the installed-command JSON envelope, and a loop/Ralph smoke check.
+
+## Mission Event Log
+
+Codex1 keeps a mission-local forensic event log at `.codex1/events.jsonl` inside each mission directory. It records automatic metadata for mutating command outcomes such as initialization, artifact writes, subplan moves, receipt appends, and loop changes.
+
+The log is append-only, best-effort, and non-authoritative. If appending an event fails after the real mutation succeeds, the command still succeeds and reports a warning in JSON mode or stderr in human mode. If a mutating command fails after a safe mission layout was resolved, Codex1 may append a small failure event and still returns the original command error.
+
+Read-only commands do not append events: `template list`, `template show`, `inspect`, `doctor`, `loop status`, and `ralph stop-hook` stay read-only.
+
+Event records contain small mechanical metadata: schema version, timestamp, mission id, command name, event kind, result, optional duration, artifact kind, template version, overwrite flag, lifecycle folders, booleans for message or reason presence, error code, and mission-relative paths. They do not contain raw argv, absolute paths, answer payloads, artifact body text, loop messages, receipt messages, review finding text, stdout, stderr, sequence numbers, or semantic status fields.
+
+`inspect` reports only the count of parseable event entries and shallow mechanical warnings for malformed event log lines. It does not summarize last activity or infer progress, readiness, review state, close state, or next action from events.
 
 ## Path Safety
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -405,26 +405,30 @@ fn cmd_loop(cli: &Cli, command: LoopCommand) -> Result<()> {
             let state = match LoopState::start(mode, message, &layout) {
                 Ok(state) => state,
                 Err(error) => {
+                    if should_log_failure_event(&error) {
+                        let record = event::EventRecord::loop_start_failed(
+                            &layout,
+                            &mode_for_event,
+                            message_present,
+                            error.code().as_str(),
+                            started.elapsed(),
+                        );
+                        let _ = event::append_best_effort(&layout, &record);
+                    }
+                    return Err(error);
+                }
+            };
+            if let Err(error) = loop_state::write(&layout, &state) {
+                if should_log_failure_event(&error) {
                     let record = event::EventRecord::loop_start_failed(
                         &layout,
-                        &mode_for_event,
+                        &state.mode,
                         message_present,
                         error.code().as_str(),
                         started.elapsed(),
                     );
                     let _ = event::append_best_effort(&layout, &record);
-                    return Err(error);
                 }
-            };
-            if let Err(error) = loop_state::write(&layout, &state) {
-                let record = event::EventRecord::loop_start_failed(
-                    &layout,
-                    &state.mode,
-                    message_present,
-                    error.code().as_str(),
-                    started.elapsed(),
-                );
-                let _ = event::append_best_effort(&layout, &record);
                 return Err(error);
             }
             let record = event::EventRecord::loop_started(
@@ -445,13 +449,15 @@ fn cmd_loop(cli: &Cli, command: LoopCommand) -> Result<()> {
             let state = match loop_state::pause(&layout, reason) {
                 Ok(state) => state,
                 Err(error) => {
-                    let record = event::EventRecord::loop_pause_failed(
-                        &layout,
-                        reason_present,
-                        error.code().as_str(),
-                        started.elapsed(),
-                    );
-                    let _ = event::append_best_effort(&layout, &record);
+                    if should_log_failure_event(&error) {
+                        let record = event::EventRecord::loop_pause_failed(
+                            &layout,
+                            reason_present,
+                            error.code().as_str(),
+                            started.elapsed(),
+                        );
+                        let _ = event::append_best_effort(&layout, &record);
+                    }
                     return Err(error);
                 }
             };
@@ -466,12 +472,14 @@ fn cmd_loop(cli: &Cli, command: LoopCommand) -> Result<()> {
             let state = match loop_state::resume(&layout) {
                 Ok(state) => state,
                 Err(error) => {
-                    let record = event::EventRecord::loop_resume_failed(
-                        &layout,
-                        error.code().as_str(),
-                        started.elapsed(),
-                    );
-                    let _ = event::append_best_effort(&layout, &record);
+                    if should_log_failure_event(&error) {
+                        let record = event::EventRecord::loop_resume_failed(
+                            &layout,
+                            error.code().as_str(),
+                            started.elapsed(),
+                        );
+                        let _ = event::append_best_effort(&layout, &record);
+                    }
                     return Err(error);
                 }
             };
@@ -488,13 +496,15 @@ fn cmd_loop(cli: &Cli, command: LoopCommand) -> Result<()> {
             let state = match loop_state::stop(&layout, reason) {
                 Ok(state) => state,
                 Err(error) => {
-                    let record = event::EventRecord::loop_stop_failed(
-                        &layout,
-                        reason_present,
-                        error.code().as_str(),
-                        started.elapsed(),
-                    );
-                    let _ = event::append_best_effort(&layout, &record);
+                    if should_log_failure_event(&error) {
+                        let record = event::EventRecord::loop_stop_failed(
+                            &layout,
+                            reason_present,
+                            error.code().as_str(),
+                            started.elapsed(),
+                        );
+                        let _ = event::append_best_effort(&layout, &record);
+                    }
                     return Err(error);
                 }
             };
@@ -789,6 +799,9 @@ fn log_artifact_write_failed(
     error: &Codex1Error,
     duration: std::time::Duration,
 ) {
+    if !should_log_failure_event(error) {
+        return;
+    }
     let record = event::EventRecord::artifact_write_failed(
         layout,
         kind,
@@ -806,6 +819,9 @@ fn log_subplan_move_failed(
     error: &Codex1Error,
     duration: std::time::Duration,
 ) {
+    if !should_log_failure_event(error) {
+        return;
+    }
     let record = event::EventRecord::subplan_move_failed(
         layout,
         target_state,
@@ -820,8 +836,15 @@ fn log_receipt_append_failed(
     error: &Codex1Error,
     duration: std::time::Duration,
 ) {
+    if !should_log_failure_event(error) {
+        return;
+    }
     let record = event::EventRecord::receipt_append_failed(layout, error.code().as_str(), duration);
     let _ = event::append_best_effort(layout, &record);
+}
+
+fn should_log_failure_event(error: &Codex1Error) -> bool {
+    !matches!(error, Codex1Error::MissionPath(_))
 }
 
 fn run_installed_command_check(current_exe: &Path) -> Result<Value> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,6 +3,7 @@ use std::fs::{self, OpenOptions};
 use std::io::{self, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode, Output};
+use std::time::Instant;
 
 use chrono::Utc;
 use clap::error::ErrorKind;
@@ -16,6 +17,7 @@ use crate::cli::{
 };
 use crate::envelope;
 use crate::error::{Codex1Error, IoContext, Result};
+use crate::event;
 use crate::inspect;
 use crate::interview;
 use crate::layout::{descriptors, ArtifactKind, MissionLayout, SubplanState};
@@ -79,8 +81,15 @@ fn run_cli(cli: Cli) -> Result<()> {
 }
 
 fn cmd_init(cli: &Cli) -> Result<()> {
+    let started = Instant::now();
     let layout = explicit_layout(cli)?;
     layout.create_dirs()?;
+    let warnings: Vec<_> = event::append_best_effort(
+        &layout,
+        &event::EventRecord::mission_initialized(&layout, started.elapsed()),
+    )
+    .into_iter()
+    .collect();
     let data = json!({
         "mission_id": layout.mission_id,
         "repo_root": layout.repo_root,
@@ -88,8 +97,9 @@ fn cmd_init(cli: &Cli) -> Result<()> {
         "artifacts": descriptors(&layout),
     });
     if cli.json {
-        print_json(&envelope::success(data));
+        print_json(&envelope::success_with_warnings(data, warnings));
     } else {
+        print_event_warnings(&warnings);
         println!("Initialized mission {}", layout.mission_id);
         println!("{}", layout.mission_dir.display());
     }
@@ -136,6 +146,7 @@ fn cmd_template(cli: &Cli, command: TemplateCommand) -> Result<()> {
 }
 
 fn cmd_interview(cli: &Cli, args: InterviewArgs) -> Result<()> {
+    let started = Instant::now();
     let layout = resolve_layout(cli)?;
     if cli.json && args.answers.is_none() {
         return Err(Codex1Error::Argument(
@@ -154,19 +165,57 @@ fn cmd_interview(cli: &Cli, args: InterviewArgs) -> Result<()> {
         }
     };
     let content = render_markdown(&template, &answers)?;
-    let path = artifact_write_path(&layout, kind, &answers, args.overwrite)?;
-    write_new_or_overwrite(
+    let path = match artifact_write_path(&layout, kind, &answers, args.overwrite) {
+        Ok(path) => path,
+        Err(error) => {
+            log_artifact_write_failed(
+                &layout,
+                kind,
+                template.version,
+                args.overwrite,
+                &error,
+                started.elapsed(),
+            );
+            return Err(error);
+        }
+    };
+    if let Err(error) = write_new_or_overwrite(
         &layout,
         &path,
         &content,
         args.overwrite || !kind.is_singleton(),
-    )?;
+    ) {
+        log_artifact_write_failed(
+            &layout,
+            kind,
+            template.version,
+            args.overwrite,
+            &error,
+            started.elapsed(),
+        );
+        return Err(error);
+    }
+    let mut warnings = Vec::new();
+    if let Ok(record) = event::EventRecord::artifact_written(
+        &layout,
+        kind,
+        template.version,
+        args.overwrite,
+        &path,
+        started.elapsed(),
+    ) {
+        if let Some(warning) = event::append_best_effort(&layout, &record) {
+            warnings.push(warning);
+        }
+    }
+    let data = json!({
+        "kind": kind,
+        "path": path,
+    });
     if cli.json {
-        print_json(&envelope::success(json!({
-            "kind": kind,
-            "path": path,
-        })));
+        print_json(&envelope::success_with_warnings(data, warnings));
     } else {
+        print_event_warnings(&warnings);
         println!("Wrote {} artifact to {}", kind, path.display());
     }
     Ok(())
@@ -196,6 +245,7 @@ fn cmd_inspect(cli: &Cli) -> Result<()> {
             "  optional_receipts: {}",
             inventory.artifacts.optional_receipts
         );
+        println!("  events: {}", inventory.artifacts.events);
         if !inventory.mechanical_warnings.is_empty() {
             println!("Mechanical warnings:");
             for warning in inventory.mechanical_warnings {
@@ -207,11 +257,26 @@ fn cmd_inspect(cli: &Cli) -> Result<()> {
 }
 
 fn cmd_subplan(cli: &Cli, command: SubplanCommand) -> Result<()> {
+    let started = Instant::now();
     let layout = resolve_layout(cli)?;
+    let mut warnings = Vec::new();
     match command {
         SubplanCommand::Move { id, to } => {
             let target_state: SubplanState = to.into();
-            let source = find_subplan(&layout, &id)?;
+            let source = match find_subplan(&layout, &id) {
+                Ok(source) => source,
+                Err(error) => {
+                    log_subplan_move_failed(&layout, target_state, &error, started.elapsed());
+                    return Err(error);
+                }
+            };
+            let source_state = match subplan_lifecycle_for_path(&source) {
+                Ok(state) => state,
+                Err(error) => {
+                    log_subplan_move_failed(&layout, target_state, &error, started.elapsed());
+                    return Err(error);
+                }
+            };
             let file_name = source.file_name().ok_or_else(|| {
                 Codex1Error::MissionPath("subplan source has no file name".into())
             })?;
@@ -222,27 +287,52 @@ fn cmd_subplan(cli: &Cli, command: SubplanCommand) -> Result<()> {
                     .join(file_name),
             )?;
             if target.exists() {
-                return Err(Codex1Error::ArtifactValidation(format!(
+                let error = Codex1Error::ArtifactValidation(format!(
                     "target already exists: {}",
                     target.display()
-                )));
+                ));
+                log_subplan_move_failed(&layout, target_state, &error, started.elapsed());
+                return Err(error);
             }
-            ensure_existing_contained(&layout.mission_dir, &source)?;
-            create_dir_all_contained(
+            if let Err(error) = ensure_existing_contained(&layout.mission_dir, &source) {
+                log_subplan_move_failed(&layout, target_state, &error, started.elapsed());
+                return Err(error);
+            }
+            if let Err(error) = create_dir_all_contained(
                 &layout.mission_dir,
                 Path::new("SUBPLANS").join(target_state.as_str()),
-            )?;
-            fs::rename(&source, &target).io_context(format!(
+            ) {
+                log_subplan_move_failed(&layout, target_state, &error, started.elapsed());
+                return Err(error);
+            }
+            if let Err(error) = fs::rename(&source, &target).io_context(format!(
                 "failed to move {} to {}",
                 source.display(),
                 target.display()
-            ))?;
+            )) {
+                log_subplan_move_failed(&layout, target_state, &error, started.elapsed());
+                return Err(error);
+            }
+            if let Ok(record) = event::EventRecord::subplan_moved(
+                &layout,
+                &source,
+                &target,
+                source_state,
+                target_state,
+                started.elapsed(),
+            ) {
+                if let Some(warning) = event::append_best_effort(&layout, &record) {
+                    warnings.push(warning);
+                }
+            }
+            let data = json!({
+                "from": source,
+                "to": target,
+            });
             if cli.json {
-                print_json(&envelope::success(json!({
-                    "from": source,
-                    "to": target,
-                })));
+                print_json(&envelope::success_with_warnings(data, warnings));
             } else {
+                print_event_warnings(&warnings);
                 println!("Moved subplan to {}", target.display());
             }
         }
@@ -251,8 +341,10 @@ fn cmd_subplan(cli: &Cli, command: SubplanCommand) -> Result<()> {
 }
 
 fn cmd_receipt(cli: &Cli, command: ReceiptCommand) -> Result<()> {
+    let started = Instant::now();
     let layout = resolve_layout(cli)?;
     layout.create_dirs()?;
+    let mut warnings = Vec::new();
     match command {
         ReceiptCommand::Append { message } => {
             let path = layout.receipts_dir().join("receipts.jsonl");
@@ -262,16 +354,38 @@ fn cmd_receipt(cli: &Cli, command: ReceiptCommand) -> Result<()> {
                 "timestamp": Utc::now(),
                 "message": message,
             });
-            let mut file = OpenOptions::new()
+            let mut file = match OpenOptions::new()
                 .create(true)
                 .append(true)
                 .open(&path)
-                .io_context(format!("failed to open {}", path.display()))?;
-            writeln!(file, "{record}")
-                .io_context(format!("failed to append {}", path.display()))?;
+                .io_context(format!("failed to open {}", path.display()))
+            {
+                Ok(file) => file,
+                Err(error) => {
+                    log_receipt_append_failed(&layout, &error, started.elapsed());
+                    return Err(error);
+                }
+            };
+            if let Err(error) = writeln!(file, "{record}")
+                .io_context(format!("failed to append {}", path.display()))
+            {
+                log_receipt_append_failed(&layout, &error, started.elapsed());
+                return Err(error);
+            }
+            if let Ok(record) =
+                event::EventRecord::receipt_appended(&layout, &path, started.elapsed())
+            {
+                if let Some(warning) = event::append_best_effort(&layout, &record) {
+                    warnings.push(warning);
+                }
+            }
             if cli.json {
-                print_json(&envelope::success(json!({ "path": path })));
+                print_json(&envelope::success_with_warnings(
+                    json!({ "path": path }),
+                    warnings,
+                ));
             } else {
+                print_event_warnings(&warnings);
                 println!("Appended optional receipt to {}", path.display());
             }
         }
@@ -280,22 +394,123 @@ fn cmd_receipt(cli: &Cli, command: ReceiptCommand) -> Result<()> {
 }
 
 fn cmd_loop(cli: &Cli, command: LoopCommand) -> Result<()> {
+    let started = Instant::now();
     let layout = resolve_layout(cli)?;
+    let mut warnings = Vec::new();
     let state = match command {
         LoopCommand::Start { mode, message } => {
             layout.create_dirs()?;
-            let state = LoopState::start(mode, message, &layout)?;
-            loop_state::write(&layout, &state)?;
+            let message_present = !message.trim().is_empty();
+            let mode_for_event = mode.clone();
+            let state = match LoopState::start(mode, message, &layout) {
+                Ok(state) => state,
+                Err(error) => {
+                    let record = event::EventRecord::loop_start_failed(
+                        &layout,
+                        &mode_for_event,
+                        message_present,
+                        error.code().as_str(),
+                        started.elapsed(),
+                    );
+                    let _ = event::append_best_effort(&layout, &record);
+                    return Err(error);
+                }
+            };
+            if let Err(error) = loop_state::write(&layout, &state) {
+                let record = event::EventRecord::loop_start_failed(
+                    &layout,
+                    &state.mode,
+                    message_present,
+                    error.code().as_str(),
+                    started.elapsed(),
+                );
+                let _ = event::append_best_effort(&layout, &record);
+                return Err(error);
+            }
+            let record = event::EventRecord::loop_started(
+                &layout,
+                &state.mode,
+                message_present,
+                started.elapsed(),
+            );
+            if let Some(warning) = event::append_best_effort(&layout, &record) {
+                warnings.push(warning);
+            }
             state
         }
-        LoopCommand::Pause { reason } => loop_state::pause(&layout, reason)?,
-        LoopCommand::Resume => loop_state::resume(&layout)?,
-        LoopCommand::Stop { reason } => loop_state::stop(&layout, reason)?,
+        LoopCommand::Pause { reason } => {
+            let reason_present = reason
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let state = match loop_state::pause(&layout, reason) {
+                Ok(state) => state,
+                Err(error) => {
+                    let record = event::EventRecord::loop_pause_failed(
+                        &layout,
+                        reason_present,
+                        error.code().as_str(),
+                        started.elapsed(),
+                    );
+                    let _ = event::append_best_effort(&layout, &record);
+                    return Err(error);
+                }
+            };
+            let record =
+                event::EventRecord::loop_paused(&layout, reason_present, started.elapsed());
+            if let Some(warning) = event::append_best_effort(&layout, &record) {
+                warnings.push(warning);
+            }
+            state
+        }
+        LoopCommand::Resume => {
+            let state = match loop_state::resume(&layout) {
+                Ok(state) => state,
+                Err(error) => {
+                    let record = event::EventRecord::loop_resume_failed(
+                        &layout,
+                        error.code().as_str(),
+                        started.elapsed(),
+                    );
+                    let _ = event::append_best_effort(&layout, &record);
+                    return Err(error);
+                }
+            };
+            let record = event::EventRecord::loop_resumed(&layout, started.elapsed());
+            if let Some(warning) = event::append_best_effort(&layout, &record) {
+                warnings.push(warning);
+            }
+            state
+        }
+        LoopCommand::Stop { reason } => {
+            let reason_present = reason
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty());
+            let state = match loop_state::stop(&layout, reason) {
+                Ok(state) => state,
+                Err(error) => {
+                    let record = event::EventRecord::loop_stop_failed(
+                        &layout,
+                        reason_present,
+                        error.code().as_str(),
+                        started.elapsed(),
+                    );
+                    let _ = event::append_best_effort(&layout, &record);
+                    return Err(error);
+                }
+            };
+            let record =
+                event::EventRecord::loop_stopped(&layout, reason_present, started.elapsed());
+            if let Some(warning) = event::append_best_effort(&layout, &record) {
+                warnings.push(warning);
+            }
+            state
+        }
         LoopCommand::Status => loop_state::read(&layout)?,
     };
     if cli.json {
-        print_json(&envelope::success(state));
+        print_json(&envelope::success_with_warnings(state, warnings));
     } else {
+        print_event_warnings(&warnings);
         println!(
             "Loop active={} paused={} mode={}",
             state.active, state.paused, state.mode
@@ -548,6 +763,67 @@ fn find_subplan(layout: &MissionLayout, id: &str) -> Result<PathBuf> {
     }
 }
 
+fn subplan_lifecycle_for_path(path: &Path) -> Result<SubplanState> {
+    let lifecycle = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| Codex1Error::MissionPath("subplan path has no lifecycle folder".into()))?;
+    match lifecycle {
+        "ready" => Ok(SubplanState::Ready),
+        "active" => Ok(SubplanState::Active),
+        "done" => Ok(SubplanState::Done),
+        "paused" => Ok(SubplanState::Paused),
+        "superseded" => Ok(SubplanState::Superseded),
+        _ => Err(Codex1Error::MissionPath(format!(
+            "unknown subplan lifecycle folder: {lifecycle}"
+        ))),
+    }
+}
+
+fn log_artifact_write_failed(
+    layout: &MissionLayout,
+    kind: ArtifactKind,
+    template_version: u32,
+    overwrite: bool,
+    error: &Codex1Error,
+    duration: std::time::Duration,
+) {
+    let record = event::EventRecord::artifact_write_failed(
+        layout,
+        kind,
+        template_version,
+        overwrite,
+        error.code().as_str(),
+        duration,
+    );
+    let _ = event::append_best_effort(layout, &record);
+}
+
+fn log_subplan_move_failed(
+    layout: &MissionLayout,
+    target_state: SubplanState,
+    error: &Codex1Error,
+    duration: std::time::Duration,
+) {
+    let record = event::EventRecord::subplan_move_failed(
+        layout,
+        target_state,
+        error.code().as_str(),
+        duration,
+    );
+    let _ = event::append_best_effort(layout, &record);
+}
+
+fn log_receipt_append_failed(
+    layout: &MissionLayout,
+    error: &Codex1Error,
+    duration: std::time::Duration,
+) {
+    let record = event::EventRecord::receipt_append_failed(layout, error.code().as_str(), duration);
+    let _ = event::append_best_effort(layout, &record);
+}
+
 fn run_installed_command_check(current_exe: &Path) -> Result<Value> {
     let (binary, source, on_path) = match find_on_path("codex1") {
         Some(path) => (path, "path", true),
@@ -678,5 +954,11 @@ fn print_json<T: Serialize>(value: &T) {
         Err(_) => println!(
             r#"{{"ok":false,"error":{{"code":"IO_ERROR","message":"failed to serialize output"}}}}"#
         ),
+    }
+}
+
+fn print_event_warnings(warnings: &[event::EventWarning]) {
+    for warning in warnings {
+        eprintln!("{}: {}", warning.code, warning.message);
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -10,6 +10,13 @@ pub struct SuccessEnvelope<T: Serialize> {
 }
 
 #[derive(Debug, Serialize)]
+pub struct SuccessEnvelopeWithWarnings<T: Serialize, W: Serialize> {
+    pub ok: bool,
+    pub data: T,
+    pub warnings: Vec<W>,
+}
+
+#[derive(Debug, Serialize)]
 pub struct ErrorEnvelope<'a> {
     pub ok: bool,
     pub error: ErrorBody<'a>,
@@ -26,6 +33,30 @@ pub fn success<T: Serialize>(data: T) -> serde_json::Value {
         json!({
             "ok": true,
             "data": null
+        })
+    })
+}
+
+pub fn success_with_warnings<T: Serialize, W: Serialize>(
+    data: T,
+    warnings: Vec<W>,
+) -> serde_json::Value {
+    if warnings.is_empty() {
+        return success(data);
+    }
+    serde_json::to_value(SuccessEnvelopeWithWarnings {
+        ok: true,
+        data,
+        warnings,
+    })
+    .unwrap_or_else(|_| {
+        json!({
+            "ok": true,
+            "data": null,
+            "warnings": [{
+                "code": "IO_ERROR",
+                "message": "failed to serialize warning envelope"
+            }]
         })
     })
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,494 @@
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::error::{Codex1Error, IoContext, Result};
+use crate::layout::{ArtifactKind, MissionLayout, SubplanState};
+use crate::paths::{create_dir_all_contained, ensure_contained_for_write};
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    MissionInitialized,
+    ArtifactWritten,
+    ArtifactWriteFailed,
+    SubplanMoved,
+    SubplanMoveFailed,
+    ReceiptAppended,
+    ReceiptAppendFailed,
+    LoopStarted,
+    LoopStartFailed,
+    LoopPaused,
+    LoopPauseFailed,
+    LoopResumed,
+    LoopResumeFailed,
+    LoopStopped,
+    LoopStopFailed,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventResult {
+    Success,
+    Error,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EventRecord {
+    pub version: u32,
+    pub timestamp: DateTime<Utc>,
+    pub mission_id: String,
+    pub command: &'static str,
+    pub kind: EventKind,
+    pub result: EventResult,
+    pub duration_ms: u64,
+    pub metadata: Value,
+}
+
+impl EventRecord {
+    pub fn new(
+        layout: &MissionLayout,
+        command: &'static str,
+        kind: EventKind,
+        result: EventResult,
+        duration: Duration,
+        metadata: Value,
+    ) -> Self {
+        Self {
+            version: 1,
+            timestamp: Utc::now(),
+            mission_id: layout.mission_id.clone(),
+            command,
+            kind,
+            result,
+            duration_ms: duration.as_millis().try_into().unwrap_or(u64::MAX),
+            metadata,
+        }
+    }
+
+    pub fn mission_initialized(layout: &MissionLayout, duration: Duration) -> Self {
+        Self::new(
+            layout,
+            "init",
+            EventKind::MissionInitialized,
+            EventResult::Success,
+            duration,
+            json!({}),
+        )
+    }
+
+    pub fn artifact_written(
+        layout: &MissionLayout,
+        kind: ArtifactKind,
+        template_version: u32,
+        overwrite: bool,
+        path: &Path,
+        duration: Duration,
+    ) -> Result<Self> {
+        Ok(Self::new(
+            layout,
+            "interview",
+            EventKind::ArtifactWritten,
+            EventResult::Success,
+            duration,
+            json!({
+                "artifact_kind": kind,
+                "template_version": template_version,
+                "overwrite": overwrite,
+                "path": mission_relative_path(layout, path)?,
+            }),
+        ))
+    }
+
+    pub fn artifact_write_failed(
+        layout: &MissionLayout,
+        kind: ArtifactKind,
+        template_version: u32,
+        overwrite: bool,
+        error_code: &'static str,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "interview",
+            EventKind::ArtifactWriteFailed,
+            EventResult::Error,
+            duration,
+            json!({
+                "artifact_kind": kind,
+                "template_version": template_version,
+                "overwrite": overwrite,
+                "error_code": error_code,
+            }),
+        )
+    }
+
+    pub fn subplan_moved(
+        layout: &MissionLayout,
+        from_path: &Path,
+        to_path: &Path,
+        from_lifecycle: SubplanState,
+        to_lifecycle: SubplanState,
+        duration: Duration,
+    ) -> Result<Self> {
+        Ok(Self::new(
+            layout,
+            "subplan move",
+            EventKind::SubplanMoved,
+            EventResult::Success,
+            duration,
+            json!({
+                "from_path": mission_relative_path(layout, from_path)?,
+                "to_path": mission_relative_path(layout, to_path)?,
+                "from_lifecycle": from_lifecycle,
+                "to_lifecycle": to_lifecycle,
+            }),
+        ))
+    }
+
+    pub fn subplan_move_failed(
+        layout: &MissionLayout,
+        to_lifecycle: SubplanState,
+        error_code: &'static str,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "subplan move",
+            EventKind::SubplanMoveFailed,
+            EventResult::Error,
+            duration,
+            json!({
+                "to_lifecycle": to_lifecycle,
+                "error_code": error_code,
+            }),
+        )
+    }
+
+    pub fn receipt_appended(
+        layout: &MissionLayout,
+        path: &Path,
+        duration: Duration,
+    ) -> Result<Self> {
+        Ok(Self::new(
+            layout,
+            "receipt append",
+            EventKind::ReceiptAppended,
+            EventResult::Success,
+            duration,
+            json!({
+                "path": mission_relative_path(layout, path)?,
+            }),
+        ))
+    }
+
+    pub fn receipt_append_failed(
+        layout: &MissionLayout,
+        error_code: &'static str,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "receipt append",
+            EventKind::ReceiptAppendFailed,
+            EventResult::Error,
+            duration,
+            json!({
+                "error_code": error_code,
+            }),
+        )
+    }
+
+    pub fn loop_started(
+        layout: &MissionLayout,
+        mode: &str,
+        message_present: bool,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "loop start",
+            EventKind::LoopStarted,
+            EventResult::Success,
+            duration,
+            json!({
+                "mode": mode,
+                "message_present": message_present,
+            }),
+        )
+    }
+
+    pub fn loop_start_failed(
+        layout: &MissionLayout,
+        mode: &str,
+        message_present: bool,
+        error_code: &'static str,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "loop start",
+            EventKind::LoopStartFailed,
+            EventResult::Error,
+            duration,
+            json!({
+                "mode": mode,
+                "message_present": message_present,
+                "error_code": error_code,
+            }),
+        )
+    }
+
+    pub fn loop_paused(layout: &MissionLayout, reason_present: bool, duration: Duration) -> Self {
+        Self::new(
+            layout,
+            "loop pause",
+            EventKind::LoopPaused,
+            EventResult::Success,
+            duration,
+            json!({
+                "reason_present": reason_present,
+            }),
+        )
+    }
+
+    pub fn loop_pause_failed(
+        layout: &MissionLayout,
+        reason_present: bool,
+        error_code: &'static str,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "loop pause",
+            EventKind::LoopPauseFailed,
+            EventResult::Error,
+            duration,
+            json!({
+                "reason_present": reason_present,
+                "error_code": error_code,
+            }),
+        )
+    }
+
+    pub fn loop_resumed(layout: &MissionLayout, duration: Duration) -> Self {
+        Self::new(
+            layout,
+            "loop resume",
+            EventKind::LoopResumed,
+            EventResult::Success,
+            duration,
+            json!({}),
+        )
+    }
+
+    pub fn loop_resume_failed(
+        layout: &MissionLayout,
+        error_code: &'static str,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "loop resume",
+            EventKind::LoopResumeFailed,
+            EventResult::Error,
+            duration,
+            json!({
+                "error_code": error_code,
+            }),
+        )
+    }
+
+    pub fn loop_stopped(layout: &MissionLayout, reason_present: bool, duration: Duration) -> Self {
+        Self::new(
+            layout,
+            "loop stop",
+            EventKind::LoopStopped,
+            EventResult::Success,
+            duration,
+            json!({
+                "reason_present": reason_present,
+            }),
+        )
+    }
+
+    pub fn loop_stop_failed(
+        layout: &MissionLayout,
+        reason_present: bool,
+        error_code: &'static str,
+        duration: Duration,
+    ) -> Self {
+        Self::new(
+            layout,
+            "loop stop",
+            EventKind::LoopStopFailed,
+            EventResult::Error,
+            duration,
+            json!({
+                "reason_present": reason_present,
+                "error_code": error_code,
+            }),
+        )
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct EventWarning {
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct EventLogScan {
+    pub event_count: usize,
+    pub warnings: Vec<EventLogScanWarning>,
+}
+
+#[derive(Debug)]
+pub struct EventLogScanWarning {
+    pub code: &'static str,
+    pub detail: String,
+}
+
+impl EventWarning {
+    fn append_failed(error: Codex1Error) -> Self {
+        Self {
+            code: "EVENT_LOG_APPEND_FAILED",
+            message: format!("event log append failed: {error}"),
+        }
+    }
+}
+
+pub fn append_best_effort(layout: &MissionLayout, record: &EventRecord) -> Option<EventWarning> {
+    append(layout, record)
+        .err()
+        .map(EventWarning::append_failed)
+}
+
+pub fn scan(layout: &MissionLayout) -> Result<EventLogScan> {
+    let path = layout.event_log();
+    let mut warnings = Vec::new();
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            warnings.push(EventLogScanWarning {
+                code: "SYMLINKED_PATH",
+                detail: mission_relative_path(layout, &path)
+                    .unwrap_or_else(|_| path.display().to_string()),
+            });
+            return Ok(EventLogScan {
+                event_count: 0,
+                warnings,
+            });
+        }
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => {
+            warnings.push(EventLogScanWarning {
+                code: "EVENT_LOG_NOT_FILE",
+                detail: mission_relative_path(layout, &path)
+                    .unwrap_or_else(|_| path.display().to_string()),
+            });
+            return Ok(EventLogScan {
+                event_count: 0,
+                warnings,
+            });
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(EventLogScan {
+                event_count: 0,
+                warnings,
+            });
+        }
+        Err(error) => {
+            return Err(Codex1Error::Io {
+                context: format!("failed to inspect {}", path.display()),
+                source: error,
+            });
+        }
+    }
+
+    let file = fs::File::open(&path).io_context(format!("failed to open {}", path.display()))?;
+    let mut event_count = 0;
+    for (index, line) in BufReader::new(file).lines().enumerate() {
+        let line_number = index + 1;
+        let line = line.io_context(format!("failed to read {}", path.display()))?;
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(_) => {
+                warnings.push(EventLogScanWarning {
+                    code: "MALFORMED_EVENT_LOG_LINE",
+                    detail: format!("events.jsonl line {line_number}"),
+                });
+                continue;
+            }
+        };
+        let Some(object) = value.as_object() else {
+            warnings.push(EventLogScanWarning {
+                code: "NON_OBJECT_EVENT_LOG_LINE",
+                detail: format!("events.jsonl line {line_number}"),
+            });
+            continue;
+        };
+        if object.get("version").and_then(Value::as_u64) != Some(1) {
+            warnings.push(EventLogScanWarning {
+                code: "UNSUPPORTED_EVENT_LOG_VERSION",
+                detail: format!("events.jsonl line {line_number}"),
+            });
+            continue;
+        }
+        if object.get("kind").and_then(Value::as_str).is_none() {
+            warnings.push(EventLogScanWarning {
+                code: "MISSING_EVENT_LOG_KIND",
+                detail: format!("events.jsonl line {line_number}"),
+            });
+            continue;
+        }
+        event_count += 1;
+    }
+
+    Ok(EventLogScan {
+        event_count,
+        warnings,
+    })
+}
+
+fn append(layout: &MissionLayout, record: &EventRecord) -> Result<()> {
+    create_dir_all_contained(&layout.mission_dir, ".codex1")?;
+    let path = layout.event_log();
+    ensure_contained_for_write(&layout.mission_dir, &path)?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .io_context(format!("failed to open {}", path.display()))?;
+    let line = serde_json::to_string(record).map_err(|source| Codex1Error::Io {
+        context: "failed to serialize event record".into(),
+        source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
+    })?;
+    writeln!(file, "{line}").io_context(format!("failed to append {}", path.display()))
+}
+
+pub fn mission_relative_path(layout: &MissionLayout, path: &Path) -> Result<String> {
+    let relative = path.strip_prefix(&layout.mission_dir).map_err(|_| {
+        Codex1Error::MissionPath(format!(
+            "event path escapes mission directory: {}",
+            path.display()
+        ))
+    })?;
+    if relative.as_os_str().is_empty()
+        || relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(Codex1Error::MissionPath(format!(
+            "unsafe event relative path: {}",
+            path.display()
+        )));
+    }
+    Ok(relative.display().to_string())
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,7 +9,9 @@ use serde_json::{json, Value};
 
 use crate::error::{Codex1Error, IoContext, Result};
 use crate::layout::{ArtifactKind, MissionLayout, SubplanState};
-use crate::paths::{create_dir_all_contained, ensure_contained_for_write};
+use crate::paths::{
+    create_dir_all_contained, ensure_contained_for_write, ensure_existing_contained,
+};
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -385,7 +387,11 @@ pub fn scan(layout: &MissionLayout) -> Result<EventLogScan> {
                 warnings,
             });
         }
-        Ok(metadata) if metadata.is_file() => {}
+        Ok(metadata) if metadata.is_file() => {
+            if let Err(error) = ensure_existing_contained(&layout.mission_dir, &path) {
+                return handle_unsafe_scan_path(layout, &path, error, warnings);
+            }
+        }
         Ok(_) => {
             warnings.push(EventLogScanWarning {
                 code: "EVENT_LOG_NOT_FILE",
@@ -460,6 +466,7 @@ fn append(layout: &MissionLayout, record: &EventRecord) -> Result<()> {
     create_dir_all_contained(&layout.mission_dir, ".codex1")?;
     let path = layout.event_log();
     ensure_contained_for_write(&layout.mission_dir, &path)?;
+    ensure_append_target_is_regular_file(&path)?;
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -470,6 +477,46 @@ fn append(layout: &MissionLayout, record: &EventRecord) -> Result<()> {
         source: std::io::Error::new(std::io::ErrorKind::InvalidData, source),
     })?;
     writeln!(file, "{line}").io_context(format!("failed to append {}", path.display()))
+}
+
+fn handle_unsafe_scan_path(
+    layout: &MissionLayout,
+    path: &Path,
+    error: Codex1Error,
+    mut warnings: Vec<EventLogScanWarning>,
+) -> Result<EventLogScan> {
+    match error {
+        Codex1Error::MissionPath(_) => {
+            warnings.push(EventLogScanWarning {
+                code: "SYMLINKED_PATH",
+                detail: mission_relative_path(layout, path)
+                    .unwrap_or_else(|_| path.display().to_string()),
+            });
+            Ok(EventLogScan {
+                event_count: 0,
+                warnings,
+            })
+        }
+        error => Err(error),
+    }
+}
+
+fn ensure_append_target_is_regular_file(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() => Ok(()),
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(Codex1Error::MissionPath(
+            format!("event log target must not be a symlink: {}", path.display()),
+        )),
+        Ok(_) => Err(Codex1Error::MissionPath(format!(
+            "event log target must be a regular file: {}",
+            path.display()
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Codex1Error::Io {
+            context: format!("failed to inspect {}", path.display()),
+            source: error,
+        }),
+    }
 }
 
 pub fn mission_relative_path(layout: &MissionLayout, path: &Path) -> Result<String> {

--- a/src/event.rs
+++ b/src/event.rs
@@ -388,6 +388,13 @@ pub fn scan(layout: &MissionLayout) -> Result<EventLogScan> {
             });
         }
         Ok(metadata) if metadata.is_file() => {
+            ensure_scan_parent_is_not_symlinked(layout, &path, &mut warnings)?;
+            if !warnings.is_empty() {
+                return Ok(EventLogScan {
+                    event_count: 0,
+                    warnings,
+                });
+            }
             if let Err(error) = ensure_existing_contained(&layout.mission_dir, &path) {
                 return handle_unsafe_scan_path(layout, &path, error, warnings);
             }
@@ -419,10 +426,23 @@ pub fn scan(layout: &MissionLayout) -> Result<EventLogScan> {
 
     let file = fs::File::open(&path).io_context(format!("failed to open {}", path.display()))?;
     let mut event_count = 0;
-    for (index, line) in BufReader::new(file).lines().enumerate() {
+    for (index, line) in BufReader::new(file).split(b'\n').enumerate() {
         let line_number = index + 1;
         let line = line.io_context(format!("failed to read {}", path.display()))?;
-        let value: Value = match serde_json::from_str(&line) {
+        let line = match std::str::from_utf8(&line) {
+            Ok(line) => line.trim_end_matches('\r'),
+            Err(_) => {
+                warnings.push(EventLogScanWarning {
+                    code: "MALFORMED_EVENT_LOG_LINE",
+                    detail: format!("events.jsonl line {line_number}"),
+                });
+                continue;
+            }
+        };
+        if line.is_empty() {
+            continue;
+        }
+        let value: Value = match serde_json::from_str(line) {
             Ok(value) => value,
             Err(_) => {
                 warnings.push(EventLogScanWarning {
@@ -499,6 +519,65 @@ fn handle_unsafe_scan_path(
         }
         error => Err(error),
     }
+}
+
+fn ensure_scan_parent_is_not_symlinked(
+    layout: &MissionLayout,
+    path: &Path,
+    warnings: &mut Vec<EventLogScanWarning>,
+) -> Result<()> {
+    let relative_parent = path
+        .parent()
+        .and_then(|parent| parent.strip_prefix(&layout.mission_dir).ok())
+        .ok_or_else(|| {
+            Codex1Error::MissionPath(format!(
+                "event log parent escapes mission directory: {}",
+                path.display()
+            ))
+        })?;
+    let mut current = layout.mission_dir.clone();
+    for component in relative_parent.components() {
+        let std::path::Component::Normal(part) = component else {
+            return Err(Codex1Error::MissionPath(format!(
+                "unsafe event log parent: {}",
+                path.display()
+            )));
+        };
+        current.push(part);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                warnings.push(EventLogScanWarning {
+                    code: "SYMLINKED_PATH",
+                    detail: current
+                        .strip_prefix(&layout.mission_dir)
+                        .unwrap_or(&current)
+                        .display()
+                        .to_string(),
+                });
+                return Ok(());
+            }
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => {
+                warnings.push(EventLogScanWarning {
+                    code: "EVENT_LOG_NOT_FILE",
+                    detail: current
+                        .strip_prefix(&layout.mission_dir)
+                        .unwrap_or(&current)
+                        .display()
+                        .to_string(),
+                });
+                return Ok(());
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(Codex1Error::Io {
+                    context: format!("failed to inspect {}", current.display()),
+                    source: error,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 fn ensure_append_target_is_regular_file(path: &Path) -> Result<()> {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::error::{IoContext, Result};
+use crate::event;
 use crate::layout::{ArtifactKind, MissionLayout, SubplanState};
 
 #[derive(Debug, Serialize)]
@@ -29,6 +30,7 @@ pub struct ArtifactCounts {
     pub proofs: usize,
     pub closeout: usize,
     pub optional_receipts: usize,
+    pub events: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -94,6 +96,17 @@ pub fn inspect(layout: &MissionLayout) -> Result<Inventory> {
     counts.triage = count_md(layout, &layout.triage_dir(), &mut warnings)?;
     counts.proofs = count_md(layout, &layout.proofs_dir(), &mut warnings)?;
     counts.optional_receipts = count_jsonl(layout, &layout.receipts_dir(), &mut warnings)?;
+    let event_scan = event::scan(layout)?;
+    counts.events = event_scan.event_count;
+    warnings.extend(
+        event_scan
+            .warnings
+            .into_iter()
+            .map(|warning| MechanicalWarning {
+                code: warning.code,
+                detail: warning.detail,
+            }),
+    );
 
     for file in singleton_files(layout)? {
         if regular_file_exists(layout, &file, &mut warnings)? {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -197,6 +197,10 @@ impl MissionLayout {
         self.meta_dir().join("LOOP.json")
     }
 
+    pub fn event_log(&self) -> PathBuf {
+        self.meta_dir().join("events.jsonl")
+    }
+
     pub fn receipts_dir(&self) -> PathBuf {
         self.meta_dir().join("receipts")
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod command;
 mod envelope;
 mod error;
+mod event;
 mod inspect;
 mod interview;
 mod layout;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -64,6 +64,25 @@ fn init(repo: &TempDir, mission: &str) {
         .stdout(predicate::str::contains(r#""ok": true"#));
 }
 
+fn events_path(repo: &TempDir, mission: &str) -> std::path::PathBuf {
+    repo.path()
+        .join(".codex1/missions")
+        .join(mission)
+        .join(".codex1/events.jsonl")
+}
+
+fn read_events(repo: &TempDir, mission: &str) -> Vec<Value> {
+    fs::read_to_string(events_path(repo, mission))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+fn event_log_text(repo: &TempDir, mission: &str) -> String {
+    fs::read_to_string(events_path(repo, mission)).unwrap()
+}
+
 #[test]
 fn init_returns_success_envelope() {
     let repo = repo();
@@ -85,6 +104,28 @@ fn init_returns_success_envelope() {
         .path()
         .join(".codex1/missions/alpha/SUBPLANS/ready")
         .is_dir());
+}
+
+#[test]
+fn init_appends_mission_initialized_event() {
+    let repo = repo();
+    init(&repo, "alpha");
+
+    let events = read_events(&repo, "alpha");
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert_eq!(event["version"], 1);
+    assert!(event["timestamp"].as_str().unwrap().contains('T'));
+    assert_eq!(event["mission_id"], "alpha");
+    assert_eq!(event["command"], "init");
+    assert_eq!(event["kind"], "mission_initialized");
+    assert_eq!(event["result"], "success");
+    assert!(event["duration_ms"].as_u64().is_some());
+    assert_eq!(event["metadata"], serde_json::json!({}));
+    assert!(event.get("sequence").is_none());
+    assert!(event.get("argv").is_none());
+    assert!(event.get("stdout").is_none());
+    assert!(event.get("stderr").is_none());
 }
 
 #[test]
@@ -191,6 +232,478 @@ fn prd_interview_writes_artifact_and_respects_collision_policy() {
         .assert()
         .failure()
         .stdout(predicate::str::contains("ARTIFACT_VALIDATION_ERROR"));
+}
+
+#[test]
+fn artifact_interview_appends_private_metadata_only_event() {
+    let repo = repo();
+    init(&repo, "alpha");
+    let answers = repo.path().join("answers-private.json");
+    fs::write(
+        &answers,
+        r#"{
+          "title": "Secret Alpha PRD",
+          "original_request": "payload text that must stay out of events",
+          "interpreted_destination": "A deterministic alpha",
+          "success_criteria": ["generated markdown body marker"],
+          "proof_expectations": ["cargo test"],
+          "pr_intent": "No PR"
+        }"#,
+    )
+    .unwrap();
+
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "interview", "prd", "--answers"])
+        .arg(&answers)
+        .assert()
+        .success();
+
+    let events = read_events(&repo, "alpha");
+    let event = events.last().unwrap();
+    assert_eq!(event["command"], "interview");
+    assert_eq!(event["kind"], "artifact_written");
+    assert_eq!(event["result"], "success");
+    assert_eq!(event["metadata"]["artifact_kind"], "prd");
+    assert_eq!(event["metadata"]["template_version"], 1);
+    assert_eq!(event["metadata"]["overwrite"], false);
+    assert_eq!(event["metadata"]["path"], "PRD.md");
+
+    let text = event_log_text(&repo, "alpha");
+    assert!(!text.contains("payload text that must stay out of events"));
+    assert!(!text.contains("generated markdown body marker"));
+    assert!(!text.contains("answers-private.json"));
+    assert!(!text.contains(repo.path().to_str().unwrap()));
+}
+
+#[test]
+fn successful_mutations_append_forensic_events_without_messages() {
+    let repo = repo();
+    init(&repo, "alpha");
+    let subplan_answers = repo.path().join("subplan-event.json");
+    fs::write(
+        &subplan_answers,
+        r#"{
+          "title": "Move Me",
+          "goal": "Create a subplan",
+          "linked_prd": "PRD.md",
+          "linked_plan": "PLAN.md",
+          "owner": "main",
+          "scope": ["CLI"],
+          "steps": ["write file"],
+          "expected_proof": ["test"],
+          "exit_criteria": ["done"]
+        }"#,
+    )
+    .unwrap();
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "interview", "subplan", "--answers"])
+        .arg(&subplan_answers)
+        .assert()
+        .success();
+
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "subplan",
+            "move",
+            "--id",
+            "0001-move-me",
+            "--to",
+            "active",
+        ])
+        .assert()
+        .success();
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "receipt",
+            "append",
+            "--message",
+            "receipt text must not leak",
+        ])
+        .assert()
+        .success();
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "loop",
+            "start",
+            "--mode",
+            "autopilot",
+            "--message",
+            "loop message must not leak",
+        ])
+        .assert()
+        .success();
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "loop",
+            "pause",
+            "--reason",
+            "pause reason must not leak",
+        ])
+        .assert()
+        .success();
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "loop", "resume"])
+        .assert()
+        .success();
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "loop",
+            "stop",
+            "--reason",
+            "stop reason must not leak",
+        ])
+        .assert()
+        .success();
+
+    let events = read_events(&repo, "alpha");
+    let kinds: Vec<_> = events
+        .iter()
+        .map(|event| event["kind"].as_str().unwrap())
+        .collect();
+    assert!(kinds.contains(&"subplan_moved"));
+    assert!(kinds.contains(&"receipt_appended"));
+    assert!(kinds.contains(&"loop_started"));
+    assert!(kinds.contains(&"loop_paused"));
+    assert!(kinds.contains(&"loop_resumed"));
+    assert!(kinds.contains(&"loop_stopped"));
+
+    let moved = events
+        .iter()
+        .find(|event| event["kind"] == "subplan_moved")
+        .unwrap();
+    assert_eq!(
+        moved["metadata"]["from_path"],
+        "SUBPLANS/ready/0001-move-me.md"
+    );
+    assert_eq!(
+        moved["metadata"]["to_path"],
+        "SUBPLANS/active/0001-move-me.md"
+    );
+    assert_eq!(moved["metadata"]["from_lifecycle"], "ready");
+    assert_eq!(moved["metadata"]["to_lifecycle"], "active");
+
+    let receipt = events
+        .iter()
+        .find(|event| event["kind"] == "receipt_appended")
+        .unwrap();
+    assert_eq!(
+        receipt["metadata"]["path"],
+        ".codex1/receipts/receipts.jsonl"
+    );
+
+    let started = events
+        .iter()
+        .find(|event| event["kind"] == "loop_started")
+        .unwrap();
+    assert_eq!(started["metadata"]["mode"], "autopilot");
+    assert_eq!(started["metadata"]["message_present"], true);
+
+    let paused = events
+        .iter()
+        .find(|event| event["kind"] == "loop_paused")
+        .unwrap();
+    assert_eq!(paused["metadata"]["reason_present"], true);
+
+    let text = event_log_text(&repo, "alpha");
+    for private in [
+        "receipt text must not leak",
+        "loop message must not leak",
+        "pause reason must not leak",
+        "stop reason must not leak",
+        repo.path().to_str().unwrap(),
+    ] {
+        assert!(!text.contains(private));
+    }
+}
+
+#[test]
+fn event_append_failure_warns_without_failing_primary_mutation() {
+    let json_repo = repo();
+    init(&json_repo, "alpha");
+    let event_path = events_path(&json_repo, "alpha");
+    fs::remove_file(&event_path).unwrap();
+    fs::create_dir(&event_path).unwrap();
+    let answers = json_repo.path().join("warning-answers.json");
+    fs::write(
+        &answers,
+        r#"{
+          "title": "Warning PRD",
+          "original_request": "Build alpha",
+          "interpreted_destination": "A deterministic alpha",
+          "success_criteria": ["artifact exists"],
+          "proof_expectations": ["cargo test"],
+          "pr_intent": "No PR"
+        }"#,
+    )
+    .unwrap();
+
+    let value = json_output(
+        bin()
+            .args(["--json", "--repo-root"])
+            .arg(json_repo.path())
+            .args(["--mission", "alpha", "interview", "prd", "--answers"])
+            .arg(&answers),
+    );
+
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["warnings"][0]["code"], "EVENT_LOG_APPEND_FAILED");
+    assert!(json_repo
+        .path()
+        .join(".codex1/missions/alpha/PRD.md")
+        .is_file());
+
+    let human = repo();
+    init(&human, "alpha");
+    let event_path = events_path(&human, "alpha");
+    fs::remove_file(&event_path).unwrap();
+    fs::create_dir(&event_path).unwrap();
+    let output = bin()
+        .args(["--repo-root"])
+        .arg(human.path())
+        .args([
+            "--mission",
+            "alpha",
+            "receipt",
+            "append",
+            "--message",
+            "human warning primary mutation",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Appended optional receipt"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("EVENT_LOG_APPEND_FAILED"));
+    assert!(human
+        .path()
+        .join(".codex1/missions/alpha/.codex1/receipts/receipts.jsonl")
+        .is_file());
+}
+
+#[test]
+fn read_only_commands_do_not_append_events() {
+    let repo = repo();
+    init(&repo, "alpha");
+    let before = event_log_text(&repo, "alpha");
+    let mission_dir = repo.path().join(".codex1/missions/alpha");
+
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "inspect"])
+        .assert()
+        .success();
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["template", "list"])
+        .assert()
+        .success();
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["template", "show", "prd"])
+        .assert()
+        .success();
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["doctor"])
+        .assert()
+        .success();
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "loop", "status"])
+        .assert()
+        .failure();
+    let _ = json_output_with_stdin(
+        bin()
+            .args(["--repo-root"])
+            .arg(repo.path())
+            .args(["ralph", "stop-hook"]),
+        format!(r#"{{"cwd":"{}"}}"#, mission_dir.display()),
+    );
+
+    assert_eq!(event_log_text(&repo, "alpha"), before);
+}
+
+#[test]
+fn inspect_reports_event_count_and_malformed_event_warnings_only() {
+    let repo = repo();
+    init(&repo, "alpha");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(events_path(&repo, "alpha"))
+        .unwrap()
+        .write_all(b"not-json\n{\"version\":99,\"kind\":\"future\"}\n{\"version\":1}\n[]\n")
+        .unwrap();
+
+    let value = json_output(
+        bin()
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "inspect"]),
+    );
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["data"]["artifacts"]["events"], 1);
+    let warnings = value["data"]["mechanical_warnings"].as_array().unwrap();
+    assert!(warnings
+        .iter()
+        .any(|warning| warning["code"] == "MALFORMED_EVENT_LOG_LINE"));
+    assert!(warnings
+        .iter()
+        .any(|warning| warning["code"] == "UNSUPPORTED_EVENT_LOG_VERSION"));
+    assert!(warnings
+        .iter()
+        .any(|warning| warning["code"] == "MISSING_EVENT_LOG_KIND"));
+    assert!(warnings
+        .iter()
+        .any(|warning| warning["code"] == "NON_OBJECT_EVENT_LOG_LINE"));
+
+    let text = serde_json::to_string(&value).unwrap();
+    for forbidden in [
+        "last_event",
+        "last_activity",
+        "activity_status",
+        "progress",
+        "ready",
+        "complete",
+        "next_action",
+    ] {
+        assert!(!text.contains(forbidden), "{forbidden} leaked into inspect");
+    }
+}
+
+#[test]
+fn malformed_event_logs_do_not_block_future_appends() {
+    let repo = repo();
+    init(&repo, "alpha");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(events_path(&repo, "alpha"))
+        .unwrap()
+        .write_all(b"not-json\n")
+        .unwrap();
+
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "receipt",
+            "append",
+            "--message",
+            "append after malformed log",
+        ])
+        .assert()
+        .success();
+
+    let text = event_log_text(&repo, "alpha");
+    assert!(text.contains("not-json"));
+    assert!(text.lines().any(|line| serde_json::from_str::<Value>(line)
+        .ok()
+        .is_some_and(|event| event["kind"] == "receipt_appended")));
+}
+
+#[test]
+fn safe_mutation_failures_append_failure_events_without_hiding_errors() {
+    let repo = repo();
+    init(&repo, "alpha");
+    let answers = repo.path().join("failure-answers.json");
+    fs::write(
+        &answers,
+        r#"{
+          "title": "Failure PRD",
+          "original_request": "failure payload must not leak",
+          "interpreted_destination": "A deterministic alpha",
+          "success_criteria": ["artifact exists"],
+          "proof_expectations": ["cargo test"],
+          "pr_intent": "No PR"
+        }"#,
+    )
+    .unwrap();
+    bin()
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "interview", "prd", "--answers"])
+        .arg(&answers)
+        .assert()
+        .success();
+
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "interview", "prd", "--answers"])
+        .arg(&answers)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("ARTIFACT_VALIDATION_ERROR"));
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "subplan",
+            "move",
+            "--id",
+            "missing",
+            "--to",
+            "active",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("ARTIFACT_VALIDATION_ERROR"));
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "loop", "pause"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("IO_ERROR"));
+
+    let events = read_events(&repo, "alpha");
+    for (kind, code) in [
+        ("artifact_write_failed", "ARTIFACT_VALIDATION_ERROR"),
+        ("subplan_move_failed", "ARTIFACT_VALIDATION_ERROR"),
+        ("loop_pause_failed", "IO_ERROR"),
+    ] {
+        let event = events
+            .iter()
+            .find(|event| event["kind"] == kind)
+            .unwrap_or_else(|| panic!("{kind} was not logged"));
+        assert_eq!(event["result"], "error");
+        assert_eq!(event["metadata"]["error_code"], code);
+    }
+
+    assert!(!event_log_text(&repo, "alpha").contains("failure payload must not leak"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -634,6 +634,65 @@ fn inspect_does_not_scan_events_through_symlinked_meta_directory() {
 
 #[cfg(unix)]
 #[test]
+fn inspect_does_not_scan_events_through_in_mission_symlinked_meta_directory() {
+    let repo = repo();
+    init(&repo, "alpha");
+    let mission_dir = repo.path().join(".codex1/missions/alpha");
+    let linked_meta = mission_dir.join("linked-meta");
+    fs::create_dir(&linked_meta).unwrap();
+    fs::write(
+        linked_meta.join("events.jsonl"),
+        r#"{"version":1,"kind":"mission_initialized"}"#,
+    )
+    .unwrap();
+    let meta_dir = mission_dir.join(".codex1");
+    fs::remove_dir_all(&meta_dir).unwrap();
+    symlink(&linked_meta, &meta_dir).unwrap();
+
+    let value = json_output(
+        bin()
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "inspect"]),
+    );
+
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["data"]["artifacts"]["events"], 0);
+    let warnings = value["data"]["mechanical_warnings"].as_array().unwrap();
+    assert!(warnings
+        .iter()
+        .any(|warning| warning["code"] == "SYMLINKED_PATH"));
+}
+
+#[test]
+fn inspect_treats_invalid_utf8_event_lines_as_malformed() {
+    let repo = repo();
+    init(&repo, "alpha");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(events_path(&repo, "alpha"))
+        .unwrap()
+        .write_all(b"{\"version\":1,\"kind\":\"artifact_written\"}\n\xff\n")
+        .unwrap();
+
+    let value = json_output(
+        bin()
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "inspect"]),
+    );
+
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["data"]["artifacts"]["events"], 2);
+    let warnings = value["data"]["mechanical_warnings"].as_array().unwrap();
+    assert!(warnings
+        .iter()
+        .any(|warning| warning["code"] == "MALFORMED_EVENT_LOG_LINE"
+            && warning["detail"] == "events.jsonl line 3"));
+}
+
+#[cfg(unix)]
+#[test]
 fn event_append_rejects_fifo_without_hanging_primary_mutation() {
     let repo = repo();
     init(&repo, "alpha");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::io::Write;
 use std::process::Command;
 use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
@@ -598,6 +600,126 @@ fn inspect_reports_event_count_and_malformed_event_warnings_only() {
     ] {
         assert!(!text.contains(forbidden), "{forbidden} leaked into inspect");
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn inspect_does_not_scan_events_through_symlinked_meta_directory() {
+    let repo = repo();
+    let external = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+    fs::write(
+        external.path().join("events.jsonl"),
+        r#"{"version":1,"kind":"mission_initialized"}"#,
+    )
+    .unwrap();
+    let meta_dir = repo.path().join(".codex1/missions/alpha/.codex1");
+    fs::remove_dir_all(&meta_dir).unwrap();
+    symlink(external.path(), &meta_dir).unwrap();
+
+    let value = json_output(
+        bin()
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "inspect"]),
+    );
+
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["data"]["artifacts"]["events"], 0);
+    let warnings = value["data"]["mechanical_warnings"].as_array().unwrap();
+    assert!(warnings
+        .iter()
+        .any(|warning| warning["code"] == "SYMLINKED_PATH"));
+}
+
+#[cfg(unix)]
+#[test]
+fn event_append_rejects_fifo_without_hanging_primary_mutation() {
+    let repo = repo();
+    init(&repo, "alpha");
+    let event_path = events_path(&repo, "alpha");
+    fs::remove_file(&event_path).unwrap();
+    let status = Command::new("mkfifo").arg(&event_path).status().unwrap();
+    assert!(status.success());
+
+    let mut child = bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "receipt",
+            "append",
+            "--message",
+            "fifo should not hang",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(2) {
+        if child.try_wait().unwrap().is_some() {
+            let output = child.wait_with_output().unwrap();
+            assert!(
+                output.status.success(),
+                "stdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_eq!(value["ok"], true);
+            assert_eq!(value["warnings"][0]["code"], "EVENT_LOG_APPEND_FAILED");
+            assert!(repo
+                .path()
+                .join(".codex1/missions/alpha/.codex1/receipts/receipts.jsonl")
+                .is_file());
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    child.kill().unwrap();
+    let _ = child.wait();
+    panic!("event append blocked on FIFO");
+}
+
+#[cfg(unix)]
+#[test]
+fn unsafe_path_failures_do_not_append_failure_events() {
+    let repo = repo();
+    let external = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+    let before = event_log_text(&repo, "alpha");
+    fs::write(external.path().join("PRD.md"), "# external\n").unwrap();
+    symlink(
+        external.path().join("PRD.md"),
+        repo.path().join(".codex1/missions/alpha/PRD.md"),
+    )
+    .unwrap();
+    let answers = repo.path().join("unsafe-path-answers.json");
+    fs::write(
+        &answers,
+        r#"{
+          "title": "Unsafe PRD",
+          "original_request": "Build alpha",
+          "interpreted_destination": "A deterministic alpha",
+          "success_criteria": ["artifact exists"],
+          "proof_expectations": ["cargo test"],
+          "pr_intent": "No PR"
+        }"#,
+    )
+    .unwrap();
+
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["--mission", "alpha", "interview", "prd", "--answers"])
+        .arg(&answers)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("MISSION_PATH_ERROR"));
+
+    assert_eq!(event_log_text(&repo, "alpha"), before);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add a mission-local `events.jsonl` forensic log for mutating commands with success, failure, and warning handling
- Extend `inspect` to count event entries and surface only shallow mechanical warnings
- Tighten event-log path safety for symlinked parents, malformed lines, invalid UTF-8, and non-regular targets
- Update CLI docs and README to describe the forensic-only boundary

## Testing
- Added and updated CLI integration tests for event logging, inspect warnings, symlink/path-safety regressions, and best-effort failure behavior
- `cargo test` passed
- `cargo clippy -- -D warnings` passed
- `cargo fmt -- --check` passed