### PR TITLE
Fix setup activation, rollback, and bundle safety across global and project modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml_edit",
 ]
 
 [[package]]
@@ -582,6 +583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +652,35 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -833,6 +872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
+toml_edit = { version = "0.22", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/PRD.md
+++ b/PRD.md
@@ -13,6 +13,8 @@ The revised problem is therefore:
 - Codex needs durable, high-quality artifacts for serious work.
 - Codex needs deterministic help creating those artifacts.
 - Codex needs a minimal continuation guard so it does not accidentally stop during explicit execute/autopilot loops.
+- Codex needs an easy way for users to enable or disable the Codex1 way of working per repo.
+- Codex needs Codex1 skills, Ralph hooks, and guidance to activate together as one bundle rather than leaking into every Codex session.
 - Codex does not need a smart CLI that decides mission truth.
 - The user does not want bloated process, hidden state machines, fake subagent permissions, or a review-finding generator disguised as a product.
 
@@ -53,6 +55,18 @@ The CLI supports interactive interviews and equivalent non-interactive answers-f
 The CLI may inspect and summarize artifact presence. It may check parseability, required fields, safe paths, unique IDs, and stable output envelopes. It must not decide whether the plan is good, whether a task is ready, whether review passed, whether proof is sufficient, whether close is safe, or whether replan is required.
 
 Ralph is reduced to a minimal Stop-hook adapter over explicit loop state. Ralph does not infer readiness from PRD, plan, specs, subplans, reviews, or proofs. If an explicit loop file says continuation is active and unpaused, Ralph blocks once with the recorded message and tells Codex how to pause or stop the loop. Otherwise Ralph allows stop.
+
+Codex1 setup treats the product as a bundle:
+
+- the `codex1` CLI
+- the Ralph Stop-hook adapter
+- Codex1 skills
+- Codex1 guidance or instructions
+- mission artifact conventions
+
+Global setup means the bundle is available on the machine, not that it is active everywhere. By default, setup should install the global hook capability and create a global Codex1 activation policy that enables only the current repo. Users can later enable, disable, uninstall, or migrate between global and project-local activation without losing mission artifacts.
+
+Skills follow the same activation boundary as Ralph. If a repo is not enabled for Codex1, Codex1 skills and Codex1 guidance should not be loaded or advertised there. If a repo is enabled, the hook, skills, and guidance should activate as a coherent bundle. Setup should make this obvious, reversible, and safe by backing up Codex config before edits and by providing status and doctor commands that explain the effective activation state.
 
 ## User Stories
 
@@ -136,6 +150,31 @@ Ralph is reduced to a minimal Stop-hook adapter over explicit loop state. Ralph 
 78. As a tester, I want to validate generated artifacts from known answers, so that template behavior is deterministic.
 79. As a tester, I want to validate Ralph with explicit loop files only, so that stop-hook behavior stays tiny and reliable.
 80. As a tester, I want to confirm the CLI never emits semantic readiness claims, so that oracle behavior does not creep back in.
+81. As a user, I want one setup command to start using Codex1 in the current repo, so that trying the workflow is easy.
+82. As a user, I want global install to mean "available globally" rather than "active everywhere," so that Codex1 does not unexpectedly change all my Codex sessions.
+83. As a user, I want Codex1 to be enabled per repo by default, so that I can choose where the Codex1 workflow applies.
+84. As a user, I want to disable Codex1 for a repo with one command, so that I can stop using the bundle without deleting artifacts.
+85. As a user, I want to re-enable Codex1 for a repo with one command, so that temporary opt-out is painless.
+86. As a user, I want to uninstall Codex1 hook integration without deleting mission artifacts, so that setup changes do not destroy work.
+87. As a user, I want to migrate between global and project-local setup, so that I can use the activation style that fits a repo or team.
+88. As a user, I want setup to back up config files before editing them, so that I can recover from bad setup changes.
+89. As a user, I want setup status to explain whether Codex1 is active here and why, so that I do not need to reverse engineer Codex config precedence.
+90. As a user, I want setup doctor to diagnose hook, skill, config, executable, backup, and trust problems, so that setup failures are understandable.
+91. As a user, I want Codex1 skills to activate only where Codex1 is enabled, so that Codex1 commands and workflows do not pollute unrelated repos.
+92. As a user, I want Codex1 guidance to activate only where Codex1 is enabled, so that ordinary Codex sessions remain ordinary.
+93. As a user, I want Ralph to fail open where Codex1 is disabled, so that disabled repos are not blocked by stale global hooks.
+94. As a user, I want global activation policy to support allowlist behavior, so that global setup can safely enable only selected repos.
+95. As a user, I want global activation policy to support all-repos behavior when I explicitly choose it, so that power users can opt into Codex1 everywhere.
+96. As a user, I want repo-local setup to work when global setup is not desired, so that a single project can carry its own Codex1 hook configuration.
+97. As a user, I want setup to show dry-run edits, so that I can inspect config changes before applying them.
+98. As a user, I want JSON setup output, so that Codex can run setup and understand what changed.
+99. As a user, I want setup to avoid duplicate global and project hooks where practical, so that Ralph does not run twice for the same repo.
+100. As a user, I want setup to account for official Codex trust behavior, so that project-local hooks are not silently assumed to work when Codex would skip project config.
+101. As a maintainer, I want setup activation to be a simple policy check, so that setup does not become a second workflow engine.
+102. As a maintainer, I want Codex1 bundle activation to be tested independently from artifact interviews, so that setup bugs do not destabilize the artifact model.
+103. As a tester, I want to verify disabled repos do not load Codex1 skills or block through Ralph, so that the activation boundary is real.
+104. As a tester, I want to verify enabled repos activate hook, skills, and guidance together, so that users get one coherent bundle.
+105. As a tester, I want to verify setup backups can be listed and restored, so that config edits are reversible.
 
 ## Implementation Decisions
 
@@ -231,6 +270,25 @@ Ralph is reduced to a minimal Stop-hook adapter over explicit loop state. Ralph 
 - Loop/Ralph behavior should be isolated and tiny.
 - Inspection should be isolated from semantic workflow decisions.
 - Doctor checks should verify the installed command can run from outside the source checkout when installation exists.
+- Codex1 setup treats the CLI, Ralph hook, Codex1 skills, Codex1 guidance, and mission artifact conventions as one bundle.
+- Global setup installs machine-level Codex1 capability but does not activate Codex1 everywhere by default.
+- The default setup command should install global capability and enable only the current repo.
+- Global activation policy should live in Codex1-owned global configuration.
+- Official Codex hook configuration should remain in official Codex config locations.
+- Codex1 must not assume that `.codex1` configuration is read by official Codex.
+- Project-local setup may edit project Codex config when a repo should carry its own integration.
+- Setup must support enable, disable, uninstall, migrate, status, doctor, dry-run, and backup restoration flows.
+- Setup must back up any Codex or Codex1 config file before mutating it.
+- Setup must never delete mission artifacts as part of disabling, uninstalling, or migrating activation.
+- Setup status should explain effective activation in human terms.
+- Setup doctor should diagnose executable availability, hook installation, activation policy, duplicate hooks, config parse errors, backup availability, and project trust caveats.
+- Setup should avoid making disabled repos pay semantic workflow costs.
+- Ralph must fail open when activation policy says the repo is disabled.
+- Codex1 skills and guidance must follow the same activation boundary as the hook.
+- If Codex1 is disabled for a repo, Codex1 skills should not be advertised or loaded there.
+- If Codex1 is enabled for a repo, the setup should make hook, skills, and guidance available as a coherent bundle.
+- Setup policy checks are mechanical activation checks only.
+- Setup does not decide mission readiness, artifact correctness, review status, close status, or PRD satisfaction.
 
 ## Testing Decisions
 
@@ -265,6 +323,21 @@ Ralph is reduced to a minimal Stop-hook adapter over explicit loop state. Ralph 
 - Ralph tests should verify Stop-hook active circuit breaker allows stop.
 - Ralph tests should verify block messages include pause or stop guidance.
 - Doctor tests should verify installed-command behavior without relying on source-local execution.
+- Setup tests should verify default install creates global capability and enables only the current repo.
+- Setup tests should verify global install does not activate all repos unless explicitly requested.
+- Setup tests should verify enable and disable toggle the effective activation policy for the current repo.
+- Setup tests should verify disabled repos cause Ralph to fail open.
+- Setup tests should verify disabled repos do not expose Codex1 skill bundle activation.
+- Setup tests should verify enabled repos expose hook, skills, and guidance as a coherent bundle.
+- Setup tests should verify project-local setup writes only managed hook configuration.
+- Setup tests should verify migration between global and project setup avoids duplicate active hooks.
+- Setup tests should verify config backups are created before mutation.
+- Setup tests should verify backups can be listed and restored.
+- Setup tests should verify dry-run reports intended edits without writing files.
+- Setup tests should verify status explains effective activation source and reason.
+- Setup tests should verify doctor catches missing executable, stale executable, invalid config, duplicate hook, inactive repo, and project trust caveats.
+- Setup tests should verify uninstall removes managed integration without deleting mission artifacts.
+- Setup tests should verify JSON setup commands use stable envelopes and mechanical error codes.
 - Regression tests should explicitly prevent reintroducing semantic oracle behavior into inspect or loop commands.
 - Tests should assert that there is no authoritative semantic state file in the initial product.
 - Tests should assert that audit receipts are not required to determine artifact inventory.
@@ -316,6 +389,13 @@ Ralph is reduced to a minimal Stop-hook adapter over explicit loop state. Ralph 
 - Mandatory research plans for small missions.
 - Mandatory specs for trivial one-shot non-durable work.
 - Any feature that makes the CLI the judge of mission truth.
+- Activating Codex1 globally in all repos by default.
+- Loading Codex1 skills in repos where Codex1 is disabled.
+- Injecting Codex1 guidance in repos where Codex1 is disabled.
+- Deleting mission artifacts during setup disable, uninstall, or migration.
+- Treating setup activation policy as mission status.
+- Replacing official Codex configuration with Codex1-specific configuration.
+- User-editable setup hook snippets in the first product.
 
 ## Further Notes
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ It does not decide whether work is ready, reviewed, correct, or done. Codex rema
 
 ## Quickstart
 
+To activate the Codex1 bundle for the current repository:
+
+```sh
+codex1 setup install
+codex1 setup status
+codex1 setup disable
+codex1 setup enable
+```
+
+`setup install` installs the global Ralph hook capability and enables only the current repo by default. It writes backups before config mutations and materializes Codex1-managed repo skills/guidance only where Codex1 is enabled.
+
 ```sh
 cargo run -- --mission demo init
 cargo run -- --mission demo template list
@@ -93,6 +104,8 @@ codex1 --mission demo loop stop --reason "Mission closed"
 ```
 
 `codex1 ralph stop-hook` reads Stop-hook JSON from stdin. It blocks only when the mission has active, unpaused loop state with a non-empty message. Missing, corrupt, inactive, paused, or recursive hook input allows stop.
+
+When setup policy exists, Ralph checks repo activation before scanning loop state. Disabled repos, malformed setup policy, and unresolved repos fail open.
 
 ## Anti-Oracle Rule
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ codex1 --mission demo loop stop --reason "Mission closed"
 
 `codex1 ralph stop-hook` reads Stop-hook JSON from stdin. It blocks only when the mission has active, unpaused loop state with a non-empty message. Missing, corrupt, inactive, paused, or recursive hook input allows stop.
 
-When setup policy exists, Ralph checks repo activation before scanning loop state. Disabled repos, malformed setup policy, and unresolved repos fail open.
+When setup policy exists, global Ralph hooks check repo activation before scanning loop state. Disabled repos, malformed setup policy, and unresolved repos fail open. Project-local hooks use `ralph stop-hook --scope project` so migration to project setup keeps that repo's hook effective without re-enabling the global hook.
 
 ## Anti-Oracle Rule
 

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -1,367 +1,321 @@
-# Codex1 Refactor Plan: Dumb Artifact CLI Rebuild
+# Codex1 Refactor Plan: Setup And Bundle Activation
 
 ## Problem Statement
 
-The current Codex1 repo has been intentionally reset around a new PRD after earlier implementations drifted into an over-smart CLI. Those earlier attempts repeatedly produced review findings because the CLI tried to own semantic workflow truth: task readiness, review cleanliness, close safety, replan priority, proof freshness, graph wave safety, and terminal completion.
+Codex1 now has the right core authority boundary: it is a deterministic artifact helper for native Codex, not a semantic workflow engine. The current code already has mission layout, built-in artifact interviews, inventory-only inspection, mission-local events, explicit loop state, Ralph Stop-hook behavior, and doctor checks.
 
-The developer wants to rebuild Codex1 from scratch as a deterministic artifact workflow for native Codex. The CLI should help Codex create excellent PRDs, plans, research records, specs, subplans, ADRs, reviews, triage records, proofs, and closeouts through built-in templates and structured interviews. It should not decide whether the mission is semantically ready, complete, correct, reviewed, or safe.
+The next product gap is setup.
 
-The challenge is to implement enough structure to be genuinely useful without recreating the previous status oracle. The implementation must keep Codex as the semantic judge and make the CLI boring, mechanical, reliable, and easy for Codex to use.
+Users should not have to manually edit Codex configuration, copy skills, wire hooks, remember where Codex1 is active, or guess why Ralph did or did not run. They need a friendly setup surface that makes the Codex1 way of working available on the machine, then activates it only where they choose.
+
+The developer wants Codex1 to behave as a bundle:
+
+- the `codex1` CLI
+- the Ralph Stop-hook adapter
+- Codex1 skills
+- Codex1 guidance or instructions
+- mission artifact conventions
+
+The tricky part is avoiding two bad outcomes:
+
+- Global install accidentally changes every Codex session.
+- Setup grows into a second workflow engine or config bureaucracy.
+
+The setup refactor should therefore make activation simple, explicit, reversible, and mechanical. It should edit config safely, back up what it touches, explain effective activation, and make disabled repos fail open. It must not decide mission truth, artifact correctness, review state, close state, or execution readiness.
 
 ## Solution
 
-Build a fresh `codex1` CLI around five deep modules:
+Add a setup subsystem that owns Codex1 bundle installation and activation.
 
-1. Mission and path safety.
-2. Built-in artifact templates.
-3. Interview schemas and answer validation.
-4. Deterministic markdown rendering and artifact writes.
-5. Explicit loop/Ralph state.
+The happy path is:
 
-The CLI will provide commands for:
+```sh
+codex1 setup install
+```
 
-- initializing a mission directory;
-- showing built-in templates;
-- running artifact interviews interactively;
-- running the same interviews from answers files;
-- inspecting artifact inventory without semantic readiness claims;
-- moving subplans between lifecycle folders;
-- starting, pausing, resuming, stopping, and reading explicit loop state;
-- running a Ralph Stop-hook adapter over that explicit loop state;
-- running fast installation and path-safety diagnostics.
+When run from a repo, this means:
 
-The first implementation must not include:
+1. Install Codex1 capability at the user/global level.
+2. Install or repair the managed global Ralph Stop hook in official Codex config.
+3. Create or update Codex1 global activation policy.
+4. Default that policy to allowlist mode.
+5. Enable only the current repo.
+6. Materialize the Codex1 skill/guidance bundle only for the enabled repo.
+7. Back up every config file before mutation.
+8. Return stable human and JSON output explaining what changed.
 
-- `STATE.json`;
-- authoritative event replay;
-- task readiness computation;
-- graph wave computation;
-- review pass/fail computation;
-- proof sufficiency computation;
-- close readiness computation;
-- PRD ratification;
-- plan locking;
-- replan state;
-- any command that turns artifact contents into semantic workflow authority.
+Global install must never mean active everywhere unless the user explicitly asks for that mode.
 
-The artifact tree is the product. The CLI helps create and move files. Codex decides what those files mean.
+Add these setup commands:
+
+- `setup install`
+- `setup enable`
+- `setup disable`
+- `setup uninstall`
+- `setup migrate`
+- `setup status`
+- `setup doctor`
+- `setup backups list`
+- `setup backups restore`
+
+The implementation should be split into deep modules:
+
+- setup command parsing and dispatch
+- activation policy resolution
+- official Codex config editing
+- Codex1 global config editing
+- managed hook block rendering
+- repo bundle materialization
+- backup creation and restoration
+- setup status projection
+- setup doctor diagnostics
+
+Official Codex facts that constrain the design:
+
+- User/global Codex config lives under the Codex home config location.
+- Project Codex config lives under a repo `.codex` config location and may be skipped when the project is untrusted.
+- Inline hook config uses the official `hooks.Stop` shape with command handlers.
+- Stop-hook input includes `cwd` and `stop_hook_active`.
+- Repo-scoped skills can be discovered from repo skill roots, including repo `.agents/skills`.
+- User-level skill config supports path/name enabled flags, but project config is not a reliable per-repo toggle for globally installed user skills.
+
+Because of that last point, the first implementation should not rely on a globally installed skill being dynamically enabled per repo. Instead, global setup should install Codex1's source bundle globally, while `setup enable` materializes repo-scoped Codex1 skills/guidance into the target repo. `setup disable` should remove or deactivate only Codex1-managed repo bundle files. This keeps skills from leaking into unrelated repos while preserving a simple global hook plus allowlist policy for Ralph.
 
 ## Commits
 
-1. **Create the empty Rust workspace skeleton.**  
-   Add a minimal package layout, build metadata, formatting configuration, and a placeholder binary that prints help. The codebase should compile and have one smoke test that invokes the binary.
+1. **Document the setup command contract.**
+   Add setup commands, JSON envelope expectations, activation modes, backup behavior, and anti-oracle boundaries to the CLI contract docs. Keep the docs explicit that setup is mechanical activation, not mission status.
 
-2. **Add the command-line parser and global JSON envelope.**  
-   Implement `--json`, `--repo-root`, and `--mission` flags. Add stable success and error envelopes. Add tests for success shape, error shape, and argument errors in JSON mode.
+2. **Document the bundle activation model.**
+   Add a short artifact/workflow note explaining that the Codex1 bundle includes CLI, Ralph, skills, guidance, and mission conventions. Clarify that global install means available globally, not active globally.
 
-3. **Add canonical error types.**  
-   Introduce a small error code set for argument errors, mission path errors, artifact validation errors, IO errors, template errors, interview errors, and loop errors. Keep errors mechanical and avoid semantic workflow codes like `TASK_NOT_READY` or `CLOSE_NOT_READY`.
+3. **Add setup command skeletons.**
+   Extend the CLI parser with `setup install`, `setup enable`, `setup disable`, `setup uninstall`, `setup migrate`, `setup status`, `setup doctor`, and `setup backups`. Return stable `NOT_IMPLEMENTED`-style mechanical errors only long enough for the skeleton test, then replace them in subsequent commits.
 
-4. **Add mission ID validation.**  
-   Accept only boring mission IDs. Reject empty IDs, absolute paths, dot segments, slashes, backslashes, NUL bytes, hidden path tricks, and names that normalize outside the mission root. Add focused tests.
+4. **Add setup-specific error codes.**
+   Introduce mechanical setup errors for invalid setup arguments, config parse failure, config write failure, backup failure, restore failure, and bundle materialization failure. Do not add semantic mission-status errors.
 
-5. **Add repository and mission root discovery.**  
-   Implement explicit repo root selection first, then current-directory discovery. Keep behavior simple and documented. Do not infer multiple active missions. Add tests for explicit repo root and cwd discovery.
+5. **Add setup scope types.**
+   Model setup scope as global, project, or effective repo. Keep this independent from command parsing so status, doctor, install, and migrate use the same resolver.
 
-6. **Add path containment helpers.**  
-   Centralize safe path joins and artifact write targets. Defend against `..`, absolute paths, symlink escapes, and writing outside the mission directory. Add tests with symlinked directories and symlinked artifact targets.
+6. **Add Codex home resolution.**
+   Resolve the official Codex home and config path using the same environment conventions Codex uses where practical. Default to the user Codex config location. Add tests with an isolated fake home.
 
-7. **Implement `codex1 init`.**  
-   Create a mission directory with the standard artifact folders and `.codex1/`. Do not create PRD or plan content yet. Return artifact paths in JSON mode. Add tests for idempotency and path safety.
+7. **Add Codex1 home resolution.**
+   Resolve the Codex1 global config and backup directory. Default to a user-level Codex1 home. Add tests with an isolated fake home so setup tests never touch a real user config.
 
-8. **Define artifact kinds and canonical layout.**  
-   Add constants and typed descriptors for PRD, research plan, research, plan, spec, subplan, ADR, review, triage, proof, closeout, loop state, and audit receipts. Add tests that descriptors render expected paths.
+8. **Add repo resolution for setup.**
+   Reuse existing repo discovery for `--repo` and current working directory. Canonicalize repo paths for global policy storage. Reject path errors mechanically.
 
-9. **Add the built-in template registry.**  
-   Implement a registry that exposes versioned built-in templates by artifact kind. No project or user override support. Add tests that every artifact kind has exactly one v1 template.
+9. **Add activation policy model.**
+   Define modes `off`, `allowlist`, `denylist`, and `all`. Define repo entries with canonical path and enabled flag. Add pure unit tests for effective activation decisions.
 
-10. **Add `codex1 template list` and `codex1 template show`.**  
-   Allow Codex to inspect built-in templates. Output markdown by default and structured metadata under `--json`. Add tests for all supported artifact kinds.
+10. **Add Codex1 global config parser.**
+   Parse missing config as defaults. Parse malformed config as a setup diagnostic/error depending on command. Add tests for empty, allowlist, denylist, all, off, duplicate repo entries, and invalid mode.
 
-11. **Create the PRD template.**  
-   Add sections for title, original request, interpreted destination, success criteria, non-goals, constraints, verified context, assumptions, resolved questions, proof expectations, review expectations, and PR intent. Add golden rendering tests.
+11. **Add Codex1 global config writer.**
+   Write stable TOML for the activation policy. Preserve only Codex1-owned config, not arbitrary official Codex config. Add tests for deterministic output.
 
-12. **Create the plan template.**  
-   Add sections for mission link, strategy thesis, workstreams, phases, research posture, risk map, artifact index, review posture, and recommended next slices. Add golden rendering tests.
+12. **Add backup manifest model.**
+   Define a backup record with id, timestamp, target kind, target path label, backup path, and reason. Do not store raw file content in the manifest. Add serialization tests.
 
-13. **Create the research plan template.**  
-   Add sections for research questions, sources to inspect, experiments to run, expected outputs, stopping criteria, and how findings will affect the plan. Add golden rendering tests.
+13. **Add backup creation.**
+   Before every config mutation, copy the target file if it exists and record a manifest entry. If the target does not exist, record enough metadata to restore the absence. Add tests for existing and missing target files.
 
-14. **Create the research record template.**  
-   Add sections for question, sources inspected, facts found, experiments run, uncertainties, options considered, recommendation, and links to affected artifacts. Add golden rendering tests.
+14. **Add backup restoration.**
+   Restore an existing-file backup or restore a previous missing-file state. Require explicit confirmation unless JSON tests pass a force flag. Add tests for both cases.
 
-15. **Create the spec template.**  
-   Add sections for responsibility, PRD relevance, scope, non-goals, expected behavior, interfaces/contracts, implementation notes, proof expectations, risks, and revision notes. Add golden rendering tests.
+15. **Add dry-run edit planning.**
+   Introduce a setup plan object that describes files to write, files to remove, backups to create, and bundle files to materialize. Dry-run commands return this plan without writing. Add tests proving no files change in dry-run mode.
 
-16. **Create the subplan template.**  
-   Add sections for goal, linked PRD, linked plan, linked specs, owner, scope, steps, dependencies, expected proof, exit criteria, and handoff notes. Add golden rendering tests.
+16. **Add official Codex config parser/editor.**
+   Use a TOML editing library that can preserve unrelated user configuration well enough for safe edits. The editor should find, insert, update, and remove only Codex1-managed hook entries.
 
-17. **Create the ADR template.**  
-   Add sections for status, context, decision, options considered, tradeoffs, consequences, and links to PRD/plan/specs. Add golden rendering tests.
+17. **Add managed hook identity.**
+   Define a stable managed hook marker or command identity so setup can detect its own hook without touching user hooks. Add tests with unrelated Stop hooks before and after the managed hook.
 
-18. **Create the review template.**  
-   Add sections for target artifact or code area, reviewer role, overall assessment, confidence, findings, non-blocking notes, and recommended follow-up. Add golden rendering tests.
+18. **Render the global Ralph hook command.**
+   Generate a command that invokes the installed `codex1 ralph stop-hook` through an absolute or PATH-safe command strategy. The command should not embed repo-specific mission state.
 
-19. **Create the triage template.**  
-   Add sections for linked review, accepted findings, rejected findings, deferred findings, duplicate/stale findings, rationale, and artifact changes to make. Add golden rendering tests.
+19. **Add global hook install.**
+   Implement the config edit that enables the official hooks feature if required and inserts or repairs the managed Stop hook. Add tests that existing unrelated config is preserved.
 
-20. **Create the proof template.**  
-   Add sections for linked subplan, linked spec, summary of changes, commands run, tests run, manual checks, changed areas, failures, accepted risks, and evidence links. Add golden rendering tests.
+20. **Add global hook uninstall.**
+   Remove only the managed Codex1 Stop hook and leave unrelated Stop hooks untouched. Add tests for no-op removal and multi-hook config.
 
-21. **Create the closeout template.**  
-   Add sections for PRD satisfaction summary, completed subplans, superseded subplans, paused/deferred subplans, proofs, reviews/triage, ADRs, remaining risks, PR readiness, and final notes. Add golden rendering tests.
+21. **Add project hook install.**
+   Implement project-local hook installation into the repo Codex config. Include doctor/status warnings that project-local hooks depend on official Codex project trust behavior.
 
-22. **Add section-tag rendering.**  
-   Implement a small renderer that maps answers into built-in template sections. Use deterministic section identifiers. Add tests for missing section, duplicate section, and stable output.
+22. **Add project hook uninstall.**
+   Remove only the project-local managed Codex1 hook. Do not delete the repo `.codex` directory if it contains other user files. Add tests.
 
-23. **Add interview schema types.**  
-   Model interview questions as data: ID, prompt, answer type, required flag, repeatability, default, and target section. Keep this module independent from terminal IO. Add unit tests for schema validation.
+23. **Add Codex1 skill bundle source.**
+   Add built-in Codex1 skill bodies or generated skill content as versioned resources owned by Codex1. Keep this separate from artifact templates.
 
-24. **Add answer document parsing.**  
-   Support non-interactive answers files in JSON first. Validate required answers, answer types, unknown answer IDs, and repeated answers. Add tests for happy path and validation failures.
+24. **Add repo bundle materializer.**
+   Materialize Codex1-managed repo skills/guidance into a repo-scoped skill location that official Codex can discover. Use owned filenames/directories and avoid symlinks in the first implementation.
 
-25. **Add interactive interview runner.**  
-   Implement a small stdin/stdout runner that asks deterministic questions and produces the same answer structure as answers-file mode. Keep terminal behavior simple. Add tests through injected input/output streams.
+25. **Add repo bundle deactivation.**
+   Remove or disable only Codex1-managed repo bundle files. Preserve user skills and user guidance. Add tests with neighboring user skill directories.
 
-26. **Add PRD interview command.**  
-   Implement `codex1 interview prd`. It writes `PRD.md`. Add tests for interactive-like runner through answers file, missing required answers, safe write behavior, and JSON output.
+26. **Add bundle version tracking.**
+   Store a small managed marker with bundle version and generated file list. Use it to repair, update, or remove only files Codex1 owns. Add tests for stale bundle versions.
 
-27. **Add plan interview command.**  
-   Implement `codex1 interview plan`. It writes `PLAN.md`. It may reference existing PRD but does not validate semantic sufficiency. Add tests for deterministic rendering and no semantic readiness output.
+27. **Implement `setup status`.**
+   Report effective activation for a repo: global config found, activation mode, repo policy result, global hook installed, project hook installed, repo bundle materialized, duplicate hook risk, backups available, and project trust caveats. Do not report mission readiness.
 
-28. **Add research plan interview command.**  
-   Implement `codex1 interview research-plan`. It writes `RESEARCH_PLAN.md`. Add tests.
+28. **Implement JSON status shape.**
+   Add a stable machine-readable setup status object. Keep it about activation/config only. Add tests for active, inactive, disabled, uninstalled, project-local, and duplicate-hook cases.
 
-29. **Add research record interview command.**  
-   Implement `codex1 interview research`. It writes a new timestamped or numbered `RESEARCH/` file. Add tests for unique file naming.
+29. **Implement `setup install` default behavior.**
+   Default to global capability plus current-repo allowlist activation. Create backups, install global hook, write Codex1 policy, and materialize repo bundle. Add an end-to-end test in a fake home and fake repo.
 
-30. **Add spec interview command.**  
-   Implement `codex1 interview spec`. It writes a new `SPECS/` file. Add tests for slugging, uniqueness, and deterministic content.
+30. **Implement `setup install --mode all`.**
+   Allow explicit all-repos activation. Ensure this is never the default. Add tests proving default install is current-repo-only.
 
-31. **Add subplan interview command.**  
-   Implement `codex1 interview subplan`. It writes to `SUBPLANS/ready/` by default. Add tests for lifecycle folder creation and deterministic content.
+31. **Implement `setup install --scope project`.**
+   Install only project-local integration and repo bundle for the target repo. Do not write the global hook unless requested. Add tests.
 
-32. **Add ADR interview command.**  
-   Implement `codex1 interview adr`. It writes to `ADRS/`. Add tests.
+32. **Implement `setup enable`.**
+   If global setup exists, add or enable the repo in the global policy and materialize the repo bundle. If no setup exists, run the default install behavior. Add tests.
 
-33. **Add review interview command.**  
-   Implement `codex1 interview review`. It writes to `REVIEWS/`. It records opinion shape only and does not mark anything blocked. Add tests.
+33. **Implement `setup disable`.**
+   Disable the repo in global policy when using global setup, remove/deactivate the repo bundle, and remove project hook only when project integration is the active source. Never delete mission artifacts. Add tests.
 
-34. **Add triage interview command.**  
-   Implement `codex1 interview triage`. It writes to `TRIAGE/`. It records main Codex adjudication but does not mutate workflow state. Add tests.
+34. **Gate Ralph by activation policy.**
+   Update Ralph to check setup activation before scanning loop state when setup config exists. Disabled or invalid activation policy must fail open. Existing explicit loop tests should still pass when no setup config exists.
 
-35. **Add proof interview command.**  
-   Implement `codex1 interview proof`. It writes to `PROOFS/`. It does not verify that the proof proves correctness. Add tests.
+35. **Add Ralph setup regression tests.**
+   Verify an active loop blocks in an enabled repo, allows in a disabled repo, allows when policy is malformed, and allows when repo cannot be resolved.
 
-36. **Add closeout interview command.**  
-   Implement `codex1 interview closeout`. It writes `CLOSEOUT.md`. It does not decide PRD satisfaction. Add tests.
+36. **Implement `setup uninstall`.**
+   Remove managed hook integration for the selected scope and optionally deactivate repo bundle. Do not delete missions or artifacts. Add tests.
 
-37. **Add artifact creation collision policy.**  
-   Define how commands behave when a target artifact exists: fail by default, allow explicit overwrite flag for main artifacts, and create unique names for numbered/timestamped artifacts. Add tests.
+37. **Implement `setup migrate --to project`.**
+   Install project-local hook and repo bundle, disable this repo in global policy if requested or needed, and avoid duplicate effective hooks. Add tests.
 
-38. **Add subplan lifecycle move command.**  
-   Implement `codex1 subplan move --id <id> --to ready|active|done|paused|superseded`. This is a safe file move only. Add tests for moving, duplicate targets, unknown states, and safe paths.
+38. **Implement `setup migrate --to global`.**
+   Install global hook, enable the repo in global policy, remove project-local managed hook, and preserve repo bundle. Add tests.
 
-39. **Allow multiple active subplans.**  
-   Ensure the move command never enforces a single active subplan. Add a regression test with two active subplans.
+39. **Implement `setup backups list`.**
+   List setup backups from the manifest in human and JSON form. Add tests with multiple backup records.
 
-40. **Add artifact inventory inspection.**  
-   Implement `codex1 inspect`. Report which artifacts and folders exist, counts by artifact kind, and mechanical warnings such as malformed frontmatter or missing directories. Do not report readiness. Add tests.
+40. **Implement `setup backups restore`.**
+   Restore a selected backup and report what changed. Add tests for official Codex config, Codex1 global config, and repo-local config restore.
 
-41. **Add oracle-regression tests for inspect.**  
-   Assert that inspect output does not contain fields such as `next_action`, `ready`, `complete`, `blocked`, `review_passed`, `close_ready`, `replan_required`, or `task_status`.
+41. **Extend doctor with setup diagnostics.**
+   Add checks for installed command execution from outside the checkout, global hook parseability, project hook parseability, activation policy parseability, repo bundle materialization, duplicate hooks, and backup manifest health.
 
-42. **Add audit receipt append command.**  
-   Implement `codex1 receipt append` or a similarly named command for optional audit receipts. Receipts are not authority. Add tests that inspect works without receipts.
+42. **Add official config fixture tests.**
+   Use fixtures based on official Codex hook and skill config shapes to verify setup edits parse and preserve unrelated config.
 
-43. **Add loop state schema.**  
-   Define `.codex1/LOOP.json` with version, active, paused, mode, message, pause command, and updated timestamp. Keep it tiny. Add parse and validation tests.
+43. **Add skill activation tests.**
+   Verify enabled repos receive Codex1 repo-scoped skill files and disabled repos do not. Verify user skills and unrelated repo skills are preserved.
 
-44. **Add loop start command.**  
-   Implement `codex1 loop start --mode <mode> --message <message>`. It writes explicit loop state. Add tests.
+44. **Add guidance activation tests.**
+   Verify any Codex1 guidance materialized by setup is repo-scoped, managed, and removed on disable/uninstall without touching user-authored guidance.
 
-45. **Add loop pause command.**  
-   Implement `codex1 loop pause --reason <reason>`. It marks loop paused and records a reason. Add tests.
+45. **Add backup safety tests.**
+   Verify every mutating setup command that writes config creates a backup first. Verify failed setup writes do not claim success without a backup.
 
-46. **Add loop resume command.**  
-   Implement `codex1 loop resume`. It unpauses loop state if present. Add tests.
+46. **Add no-real-home tests.**
+   Ensure all setup tests run against fake Codex and Codex1 homes. Add a regression test that the real user config path is never touched during tests.
 
-47. **Add loop stop command.**  
-   Implement `codex1 loop stop --reason <reason>`. It marks loop inactive. Add tests.
+47. **Update README quickstart.**
+   Add a setup section showing `setup install`, `setup status`, `setup disable`, and `setup enable`. Keep the artifact workflow quickstart intact.
 
-48. **Add loop status command.**  
-   Implement `codex1 loop status --json`. It reports explicit loop state only. Add tests.
+48. **Update skill workflow docs.**
+   Explain that Codex1 skills are activated by setup and should not be assumed available outside enabled repos.
 
-49. **Add Ralph Stop-hook adapter.**  
-   Implement `codex1 ralph stop-hook`. It reads official Stop-hook input, honors `stop_hook_active`, resolves mission from `cwd`, reads loop state, and blocks only when active, unpaused, and message exists. Add tests.
+49. **Update CLI contract docs.**
+   Document setup command outputs, activation modes, backup behavior, dry-run behavior, and fail-open semantics.
 
-50. **Add Ralph fail-open tests.**  
-   Cover missing loop state, corrupt loop state, inactive loop, paused loop, empty message, path errors, and `stop_hook_active == true`. All must allow stop.
+50. **Add anti-oracle setup regression tests.**
+   Assert setup status does not emit mission next actions, task readiness, review pass/fail, proof sufficiency, close readiness, or PRD satisfaction.
 
-51. **Add Ralph block-message tests.**  
-   Verify the block output includes the continuation message and a pause/stop command. Keep wording short and useful.
-
-52. **Add doctor command.**  
-   Implement fast diagnostics: binary can run from outside checkout, templates are registered, mission path safety basics pass, loop/Ralph smoke works. Add tests with controlled PATH where practical.
-
-53. **Add installed-command diagnostic.**  
-   Verify the installed `codex1` command can emit a JSON error envelope from a temp directory without source-local environment assumptions. Add tests or an integration smoke if feasible.
-
-54. **Add command help snapshots.**  
-   Snapshot top-level help and major subcommand help enough to prevent accidental CLI drift. Keep snapshots focused.
-
-55. **Add README quickstart.**  
-   Document the concept, the artifact tree, a small mission flow, a research-heavy mission flow, loop/Ralph behavior, and the anti-oracle rule.
-
-56. **Add artifact model documentation.**  
-   Document each artifact's role, what owns it, what must not own it, and when it is created. Include examples without overbuilding a second spec forest.
-
-57. **Add CLI contract documentation.**  
-   Document commands, JSON envelope, path safety, answers-file format, and the fact that inspect is inventory-only.
-
-58. **Add skill workflow notes.**  
-   Document how future skills should use the CLI: clarify creates PRD, plan researches and creates plan/specs/subplans, execute works subplans, review-loop records reviews/triage, interrupt pauses loop, autopilot chains them.
-
-59. **Add anti-regression design tests.**  
-   Add tests or static checks that prevent `STATE.json`, `next_action`, graph wave computation, close readiness fields, or review pass/fail fields from appearing in public inspect/loop APIs.
-
-60. **Run full verification and trim.**  
-   Run formatting, linting, unit tests, integration tests, and help smoke tests. Remove accidental complexity and any command that smells like semantic workflow authority.
+51. **Run full verification and prune.**
+   Run formatting, the full test suite, compile checks, and manual setup smoke tests in fake homes. Remove any setup logic that starts to look like workflow authority rather than activation/config editing.
 
 ## Decision Document
 
-- The rebuilt product starts from `PRD.md`.
-- The previous `OUTCOME.md` concept is removed.
-- The previous smart status oracle is removed.
-- The first product does not include an authoritative `STATE.json`.
-- The first product does not include event replay as authority.
-- Optional audit receipts may exist, but they are not truth.
-- Human-facing artifacts are markdown-first.
-- Built-in templates are the only supported templates.
-- User-editable templates are deferred.
-- Every durable mission has a PRD.
-- `PLAN.md` is a living strategy map.
-- `PLAN.md` is mutable and current.
-- `PLAN.md` is not a task tracker, proof ledger, graph scheduler, or status dashboard.
-- `RESEARCH_PLAN.md` is optional and durable only for substantial research.
-- `RESEARCH/` is first-class for significant investigation.
-- `SPECS/` contains spec-driven development contracts for bounded responsibilities.
-- Every executable slice has a subplan.
-- `SUBPLANS/` uses lifecycle folders.
-- Multiple active subplans are allowed.
-- The CLI does not approve parallelism.
-- Skills teach Codex how to reason about parallelism, ownership, risk, and delegation.
-- `ADRS/` contains durable architecture decisions.
-- `REVIEWS/` contains timestamped reviewer opinions.
-- `TRIAGE/` contains main-Codex adjudication records.
-- `PROOFS/` contains one proof per completed subplan.
-- `CLOSEOUT.md` is written when Codex judges the PRD is satisfied.
-- Closeout creation is not a CLI semantic gate.
-- Subagents receive PRD, plan, relevant spec, relevant subplan, applicable ADRs, and explicit ownership.
-- Subagents do not edit PRD or plan.
-- Subagents may edit their assigned spec only when explicitly allowed.
-- Subagents may propose artifact changes.
-- Ralph reads only explicit loop state.
-- Ralph never reads PRD, plan, specs, reviews, proofs, or closeout.
-- Ralph never infers readiness or completion.
-- Inspect reports inventory and mechanical warnings only.
-- Inspect must not include semantic readiness fields.
-- The implementation should be organized around deep modules:
-  - path safety;
-  - template registry;
-  - interview schema and answer validation;
-  - renderer;
-  - artifact writer;
-  - inventory inspector;
-  - loop state;
-  - Ralph adapter;
-  - JSON envelope and errors.
-- Commands should be thin wrappers over those modules.
+- Setup is part of the Codex1 product, not a separate installer project.
+- Codex1 is treated as a bundle of CLI, Ralph hook, skills, guidance, and artifact conventions.
+- Global setup means Codex1 is available on the machine.
+- Global setup does not mean Codex1 is active in every repo.
+- The default setup behavior is global capability plus current-repo activation.
+- The default global activation mode is allowlist.
+- All-repos activation must be explicit.
+- Repo disable must be reversible.
+- Repo disable must not delete mission artifacts.
+- Setup uninstall must not delete mission artifacts.
+- Setup migration must preserve mission artifacts.
+- Setup edits official Codex config only for official Codex integration points.
+- Codex1's own activation policy lives in Codex1-owned global config.
+- Codex1 must not assume official Codex reads `.codex1` config.
+- The global Ralph hook can be installed once and fail open for disabled repos.
+- Ralph checks activation policy before applying loop pressure when setup policy exists.
+- Invalid setup policy causes Ralph to fail open.
+- Repo-scoped skill activation is preferred over globally active user skills.
+- The first implementation should materialize Codex1 skills into enabled repos rather than rely on dynamic per-repo global skill toggles.
+- Codex1-managed skill/guidance files must be clearly owned and safely removable.
+- User-authored skills and guidance must be preserved.
+- Project-local hook setup is supported for teams or repos that do not want a global hook.
+- Project-local hook setup must explain official Codex project trust caveats.
+- Backups are mandatory before setup mutates config.
+- Dry-run is mandatory for setup mutation commands.
+- Setup status explains activation/config, not mission progress.
+- Setup doctor diagnoses setup health, not mission health.
+- Setup commands use the same stable JSON envelope as the rest of the CLI.
+- Setup events may be logged only as mechanical command metadata if the existing event policy supports them; events do not become activation truth.
+- Setup remains mechanical and must not decide task readiness, review pass/fail, close readiness, proof sufficiency, or PRD satisfaction.
 
 ## Testing Decisions
 
-- Tests should emphasize public behavior: command output, generated files, path safety, and stable JSON envelopes.
-- Golden tests should cover deterministic rendering for every built-in template.
-- Interview tests should exercise both answers-file mode and injected interactive input.
-- Path tests should be adversarial and include traversal, absolute paths, symlinks, and unsafe mission IDs.
-- Inspect tests should verify inventory output and explicitly verify absence of semantic workflow fields.
-- Loop tests should cover all state transitions with no dependency on other mission artifacts.
-- Ralph tests should cover fail-open behavior and the one block condition.
-- Subplan move tests should cover lifecycle folder movement and multiple active subplans.
-- Artifact collision tests should cover existing PRD, existing plan, unique numbered artifacts, and explicit overwrite behavior where supported.
-- Doctor tests should avoid relying only on `cargo run`; installed-command checks should run from a temp directory.
-- End-to-end tests should cover:
-  - a small mission from PRD to closeout;
-  - a research-heavy mission from PRD to research plan to research to plan;
-  - a spec/subplan/proof flow;
-  - a review/triage flow;
-  - a loop/Ralph flow.
-- Regression tests should prevent reintroduction of:
-  - authoritative `STATE.json`;
-  - task readiness projection;
-  - graph wave projection;
-  - review pass/fail projection;
-  - close readiness projection;
-  - PRD ratification;
-  - plan locking;
-  - replan state.
-- Tests should not require network access, GitHub, external models, or actual Codex subagents.
+- Tests should verify external command behavior and file effects rather than private implementation details.
+- Setup tests must use fake Codex homes, fake Codex1 homes, and temp repos.
+- No setup test may read or write the developer's real Codex config.
+- Config editor tests should use realistic official Codex TOML fixtures with unrelated user settings.
+- Managed hook tests should prove unrelated hooks are preserved.
+- Activation policy tests should be pure and exhaustive for each mode.
+- Backup tests should verify backup-before-write ordering at the observable level.
+- Dry-run tests should verify no files are changed.
+- Skill bundle tests should verify only Codex1-managed files are created or removed.
+- Ralph integration tests should verify enabled active loops block and disabled active loops allow.
+- Doctor tests should verify stale/missing executable behavior from outside the checkout.
+- Migration tests should verify no duplicate effective hook remains after switching scopes.
+- JSON tests should verify setup success, setup warnings, and setup errors use stable envelopes.
+- Anti-oracle tests should verify setup status and doctor never emit mission workflow truth.
+- Existing artifact, event, loop, Ralph, and inspect tests must continue passing.
 
 ## Out of Scope
 
-- GitHub issue creation.
-- Writing the Codex skill files.
-- User-editable templates.
-- Project-specific templates.
-- Template plugin systems.
-- `STATE.json` as semantic authority.
-- Event sourcing or replay.
-- Smart status projection.
-- Task lifecycle state.
-- Review lifecycle state.
-- Replan lifecycle state.
-- Plan locking.
-- PRD ratification.
-- Graph wave computation.
-- Close readiness computation.
-- Proof sufficiency validation.
-- Review correctness validation.
-- A TUI.
+- A graphical installer.
 - A daemon.
-- A database.
-- A wrapper runtime around Codex.
-- Subagent spawning from the CLI.
-- Caller identity detection.
-- Fake subagent permission enforcement.
-- PR creation.
-- Any command that decides mission truth.
+- Automatic background setup.
+- Network installation of Codex1.
+- Remote plugin marketplace publishing.
+- User-editable setup hook snippets.
+- User-editable artifact templates.
+- Automatically modifying every repo on the machine.
+- Activating Codex1 globally by default.
+- Loading Codex1 skills in disabled repos.
+- Injecting Codex1 guidance in disabled repos.
+- Deleting mission artifacts during setup changes.
+- Making setup status into mission status.
+- Making setup doctor into mission validation.
+- Replacing official Codex configuration with Codex1-only configuration.
+- Detecting whether a human or Codex initiated setup.
+- Creating GitHub issues or PRs as part of setup.
+- Solving official Codex trust prompts inside Codex1.
 
 ## Further Notes
 
-The implementation should be deliberately modest. The main risk is not that the product is too small. The main risk is that the implementation agent will try to rebuild the old semantic control plane because it feels useful.
+The most important setup invariant is:
 
-Whenever implementation reaches for a workflow verdict, stop and ask whether this belongs in Codex reasoning instead.
+> Codex1 can be installed globally, but it should only behave globally when the user explicitly chooses that.
 
-Good CLI questions:
+The second most important invariant is:
 
-- Can this path be safely written?
-- Does this answers file contain required answers?
-- Can this markdown artifact be rendered deterministically?
-- Does this loop file explicitly request continuation?
-- What artifacts exist?
+> Disabled means disabled: Ralph fails open, Codex1 skills are not active, and Codex1 guidance is not injected.
 
-Bad CLI questions:
-
-- Is this plan correct?
-- Is this subplan ready?
-- Did this proof prove enough?
-- Did this review pass?
-- Is this mission complete?
-- Should Codex replan?
-
-The anti-oracle rule should be treated as the core engineering constraint:
-
-```text
-Codex1 preserves and structures Codex's thinking.
-Codex1 does not replace Codex's thinking.
-```
+The setup implementation should be boring in the same way the artifact CLI is boring. It edits known config, writes backups, materializes owned files, reports what happened, and stops. It should not grow opinions about whether a mission is well planned, whether a subplan is done, or whether a PRD is satisfied.

--- a/docs/artifact-model.md
+++ b/docs/artifact-model.md
@@ -37,3 +37,9 @@ The artifact tree is the durable product. Files are human-facing markdown with m
 `.codex1/events.jsonl` stores automatic forensic command metadata. Events help explain mechanical command history during debugging, but they are not durable content truth, not receipts, not workflow state, and not replay authority. Normal planning and execution should ignore events unless mission archaeology is needed.
 
 There is no authoritative `STATE.json`.
+
+## Setup Bundle Boundary
+
+Codex1 setup is a bundle activation layer for the CLI, Ralph hook, skills, guidance, and mission artifact conventions. It may materialize repo-scoped Codex1 skill and guidance files for enabled repos, but it does not create, delete, validate, or judge mission artifacts as part of activation.
+
+See [setup-bundle.md](setup-bundle.md) for the setup activation model.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -41,7 +41,7 @@ Errors use:
 }
 ```
 
-Error codes are mechanical: `ARGUMENT_ERROR`, `MISSION_PATH_ERROR`, `ARTIFACT_VALIDATION_ERROR`, `IO_ERROR`, `TEMPLATE_ERROR`, `INTERVIEW_ERROR`, and `LOOP_ERROR`.
+Error codes are mechanical: `ARGUMENT_ERROR`, `MISSION_PATH_ERROR`, `ARTIFACT_VALIDATION_ERROR`, `IO_ERROR`, `TEMPLATE_ERROR`, `INTERVIEW_ERROR`, `LOOP_ERROR`, `SETUP_ARGUMENT_ERROR`, `SETUP_CONFIG_PARSE_ERROR`, `SETUP_CONFIG_WRITE_ERROR`, `SETUP_BACKUP_ERROR`, `SETUP_RESTORE_ERROR`, and `SETUP_BUNDLE_ERROR`.
 
 ## Commands
 
@@ -61,7 +61,37 @@ Error codes are mechanical: `ARGUMENT_ERROR`, `MISSION_PATH_ERROR`, `ARTIFACT_VA
 
 `ralph stop-hook` reads Stop-hook JSON from stdin and fails open unless explicit loop state says to block.
 
+`setup install|enable|disable|uninstall|migrate|status|doctor|backups` manages Codex1 bundle availability and activation. Setup commands are about hook/config/skill/guidance activation only; they do not inspect or judge mission artifacts.
+
 `doctor` runs fast diagnostics for template registration, path validation basics, loop schema version, the installed-command JSON envelope, and a loop/Ralph smoke check.
+
+## Setup Contract
+
+Setup treats Codex1 as a bundle of the `codex1` CLI, the Ralph Stop-hook adapter, Codex1 skills, Codex1 guidance, and mission artifact conventions. Global setup makes the bundle available on the machine. It does not make Codex1 active in every repository unless the user explicitly chooses all-repos activation.
+
+The setup command surface is:
+
+```sh
+codex1 setup install [--mode off|allowlist|denylist|all] [--scope global|project] [--repo <path>] [--dry-run]
+codex1 setup enable [--repo <path>] [--dry-run]
+codex1 setup disable [--repo <path>] [--dry-run]
+codex1 setup uninstall [--scope global|project] [--repo <path>] [--dry-run]
+codex1 setup migrate --to global|project [--repo <path>] [--dry-run]
+codex1 setup status [--repo <path>]
+codex1 setup doctor [--repo <path>]
+codex1 setup backups list
+codex1 setup backups restore <id> [--force] [--dry-run]
+```
+
+The default activation mode for global setup is `allowlist`: `setup install` enables only the target repo, normally the current repo. `all` activation is valid only when requested explicitly. `off` disables Codex1 everywhere. `denylist` enables all repos except disabled entries. Activation policy is Codex1-owned global config, while repo-scoped skills and guidance are materialized into enabled repositories so they do not leak into unrelated repos.
+
+Mutating setup commands plan every write, removal, and bundle materialization. With `--dry-run`, they return the planned edits without changing files. Without `--dry-run`, they back up every existing config file before mutation and record enough metadata to restore a previously missing file back to absence. Backups are setup metadata, not mission receipts.
+
+JSON setup output uses the normal envelope. Successful mutation responses report mechanical fields such as activation mode, target repo, files written or removed, backups created, hook state, and bundle state. Setup errors use setup-specific mechanical codes for argument, parse, write, backup, restore, and bundle materialization failures.
+
+`setup status` explains effective activation: global config presence, activation mode, repo policy result, global hook state, project hook state, repo bundle state, duplicate-hook risk, backup availability, and project-trust caveats. `setup doctor` diagnoses setup health such as executable availability, hook parseability, activation policy parseability, bundle materialization, duplicate hooks, and backup manifest health.
+
+Setup must fail open for Ralph. If a setup policy is absent, invalid, unreadable, or cannot resolve the repo, Ralph falls back to existing explicit loop behavior or allows stop according to the applicable fail-open rule for that slice. Disabled repos must not receive loop pressure from setup gating.
 
 ## Mission Event Log
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -59,7 +59,7 @@ Error codes are mechanical: `ARGUMENT_ERROR`, `MISSION_PATH_ERROR`, `ARTIFACT_VA
 
 `loop start|pause|resume|stop|status` manages `.codex1/LOOP.json`.
 
-`ralph stop-hook` reads Stop-hook JSON from stdin and fails open unless explicit loop state says to block.
+`ralph stop-hook [--scope global|project]` reads Stop-hook JSON from stdin and fails open unless explicit loop state says to block. Global hook invocations consult Codex1 activation policy when it exists. Project hook invocations are repo-local and do not let a disabled global policy entry veto the project hook.
 
 `setup install|enable|disable|uninstall|migrate|status|doctor|backups` manages Codex1 bundle availability and activation. Setup commands are about hook/config/skill/guidance activation only; they do not inspect or judge mission artifacts.
 
@@ -83,7 +83,7 @@ codex1 setup backups list
 codex1 setup backups restore <id> [--force] [--dry-run]
 ```
 
-The default activation mode for global setup is `allowlist`: `setup install` enables only the target repo, normally the current repo. `all` activation is valid only when requested explicitly. `off` disables Codex1 everywhere. `denylist` enables all repos except disabled entries. Activation policy is Codex1-owned global config, while repo-scoped skills and guidance are materialized into enabled repositories so they do not leak into unrelated repos.
+The default activation mode for global setup is `allowlist`: `setup install` enables only the target repo, normally the current repo. `all` activation is valid only when requested explicitly. `off` disables Codex1 everywhere and is valid only for global setup. `denylist` enables all repos except disabled entries. Activation policy is Codex1-owned global config, while repo-scoped skills and guidance are materialized into enabled repositories so they do not leak into unrelated repos.
 
 Mutating setup commands plan every write, removal, and bundle materialization. With `--dry-run`, they return the planned edits without changing files. Without `--dry-run`, they back up every existing config file before mutation and record enough metadata to restore a previously missing file back to absence. Backups are setup metadata, not mission receipts.
 
@@ -91,7 +91,7 @@ JSON setup output uses the normal envelope. Successful mutation responses report
 
 `setup status` explains effective activation: global config presence, activation mode, repo policy result, global hook state, project hook state, repo bundle state, duplicate-hook risk, backup availability, and project-trust caveats. `setup doctor` diagnoses setup health such as executable availability, hook parseability, activation policy parseability, bundle materialization, duplicate hooks, and backup manifest health.
 
-Setup must fail open for Ralph. If a setup policy is absent, invalid, unreadable, or cannot resolve the repo, Ralph falls back to existing explicit loop behavior or allows stop according to the applicable fail-open rule for that slice. Disabled repos must not receive loop pressure from setup gating.
+Setup must fail open for Ralph. If a setup policy is absent, invalid, unreadable, or cannot resolve the repo, Ralph falls back to existing explicit loop behavior or allows stop according to the applicable fail-open rule for that slice. Disabled repos must not receive loop pressure from the global setup hook, while project-local hooks remain effective for repos that explicitly install them.
 
 ## Mission Event Log
 

--- a/docs/setup-bundle.md
+++ b/docs/setup-bundle.md
@@ -1,0 +1,15 @@
+# Setup Bundle
+
+Codex1 setup treats the product as one bundle:
+
+- `codex1` CLI commands
+- the Ralph Stop-hook adapter
+- Codex1 skills
+- Codex1 guidance
+- mission artifact conventions
+
+Global setup means the bundle is available on the machine. It does not mean the bundle is active in every repository. The default setup path is global availability plus activation for only the current repo through an allowlist policy.
+
+Activation is mechanical and reversible. Setup edits known Codex integration points, writes Codex1-owned policy, materializes owned repo-scoped skill and guidance files, creates backups before mutation, and reports effective activation. It does not decide mission truth, artifact correctness, review state, close readiness, or PRD satisfaction.
+
+Repo disable, uninstall, and migration must not delete mission artifacts. They may remove only Codex1-managed hook entries and Codex1-managed repo bundle files.

--- a/docs/skill-workflows.md
+++ b/docs/skill-workflows.md
@@ -2,6 +2,8 @@
 
 Codex skills are the user-facing workflow. The CLI is a deterministic artifact helper.
 
+Codex1 setup activates Codex1 skills repo-by-repo. Do not assume Codex1 skills are available outside enabled repositories. `codex1 setup enable` materializes Codex1-managed repo-scoped skills and guidance, and `codex1 setup disable` removes only those managed files.
+
 ## Clarify
 
 Clarify gathers enough user intent to write `PRD.md` through `codex1 interview prd`. Codex decides how much detail the mission needs.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,10 @@ pub enum Commands {
         #[command(subcommand)]
         command: RalphCommand,
     },
+    Setup {
+        #[command(subcommand)]
+        command: SetupCommand,
+    },
     Doctor,
 }
 
@@ -110,6 +114,90 @@ pub enum LoopCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum RalphCommand {
     StopHook,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum SetupCommand {
+    Install(SetupInstallArgs),
+    Enable(SetupRepoArgs),
+    Disable(SetupRepoArgs),
+    Uninstall(SetupUninstallArgs),
+    Migrate(SetupMigrateArgs),
+    Status(SetupRepoArgs),
+    Doctor(SetupRepoArgs),
+    Backups {
+        #[command(subcommand)]
+        command: SetupBackupsCommand,
+    },
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SetupInstallArgs {
+    #[arg(long, value_enum)]
+    pub mode: Option<SetupModeArg>,
+    #[arg(long, value_enum)]
+    pub scope: Option<SetupScopeArg>,
+    #[arg(long, value_name = "PATH")]
+    pub repo: Option<PathBuf>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SetupRepoArgs {
+    #[arg(long, value_name = "PATH")]
+    pub repo: Option<PathBuf>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SetupUninstallArgs {
+    #[arg(long, value_enum)]
+    pub scope: Option<SetupScopeArg>,
+    #[arg(long, value_name = "PATH")]
+    pub repo: Option<PathBuf>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SetupMigrateArgs {
+    #[arg(long, value_enum)]
+    pub to: SetupScopeArg,
+    #[arg(long, value_name = "PATH")]
+    pub repo: Option<PathBuf>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum SetupBackupsCommand {
+    List,
+    Restore(SetupBackupRestoreArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SetupBackupRestoreArgs {
+    pub id: String,
+    #[arg(long)]
+    pub force: bool,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum SetupModeArg {
+    Off,
+    Allowlist,
+    Denylist,
+    All,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum SetupScopeArg {
+    Global,
+    Project,
 }
 
 #[derive(Clone, Debug, ValueEnum)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,7 +113,16 @@ pub enum LoopCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum RalphCommand {
-    StopHook,
+    StopHook {
+        #[arg(long, value_enum, default_value = "global")]
+        scope: RalphHookScopeArg,
+    },
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum RalphHookScopeArg {
+    Global,
+    Project,
 }
 
 #[derive(Clone, Debug, Subcommand)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -28,6 +28,7 @@ use crate::paths::{
 };
 use crate::ralph;
 use crate::render::{render_markdown, render_template_outline, AnswerValue, Answers};
+use crate::setup;
 use crate::template;
 
 pub fn run() -> ExitCode {
@@ -76,6 +77,7 @@ fn run_cli(cli: Cli) -> Result<()> {
         Commands::Receipt { command } => cmd_receipt(&cli, command),
         Commands::Loop { command } => cmd_loop(&cli, command),
         Commands::Ralph { command } => cmd_ralph(&cli, command),
+        Commands::Setup { command } => cmd_setup(&cli, command),
         Commands::Doctor => cmd_doctor(&cli),
     }
 }
@@ -537,6 +539,10 @@ fn cmd_ralph(cli: &Cli, command: RalphCommand) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn cmd_setup(cli: &Cli, command: crate::cli::SetupCommand) -> Result<()> {
+    setup::run(cli.json, command)
 }
 
 fn cmd_doctor(cli: &Cli) -> Result<()> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -546,7 +546,7 @@ fn cmd_ralph(cli: &Cli, command: RalphCommand) -> Result<()> {
 }
 
 fn cmd_setup(cli: &Cli, command: crate::cli::SetupCommand) -> Result<()> {
-    setup::run(cli.json, command)
+    setup::run(cli.json, cli.repo_root.clone(), command)
 }
 
 fn cmd_doctor(cli: &Cli) -> Result<()> {
@@ -942,6 +942,7 @@ fn run_loop_ralph_smoke_in(current_exe: &Path, root: &Path) -> Result<Value> {
     let ralph = run_command(
         Command::new(current_exe)
             .current_dir(root)
+            .env("CODEX1_DOCTOR_SMOKE", "1")
             .args(["--repo-root"])
             .arg(root)
             .args(["--mission", "smoke", "ralph", "stop-hook"]),

--- a/src/command.rs
+++ b/src/command.rs
@@ -12,8 +12,8 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 use crate::cli::{
-    Cli, Commands, InterviewArgs, LoopCommand, RalphCommand, ReceiptCommand, SubplanCommand,
-    TemplateCommand,
+    Cli, Commands, InterviewArgs, LoopCommand, RalphCommand, RalphHookScopeArg, ReceiptCommand,
+    SubplanCommand, TemplateCommand,
 };
 use crate::envelope;
 use crate::error::{Codex1Error, IoContext, Result};
@@ -533,8 +533,12 @@ fn cmd_loop(cli: &Cli, command: LoopCommand) -> Result<()> {
 
 fn cmd_ralph(cli: &Cli, command: RalphCommand) -> Result<()> {
     match command {
-        RalphCommand::StopHook => {
-            let output = ralph::stop_hook(cli.repo_root.clone(), cli.mission.clone());
+        RalphCommand::StopHook { scope } => {
+            let scope = match scope {
+                RalphHookScopeArg::Global => ralph::HookScope::Global,
+                RalphHookScopeArg::Project => ralph::HookScope::Project,
+            };
+            let output = ralph::stop_hook(cli.repo_root.clone(), cli.mission.clone(), scope);
             print_json(&output);
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,12 @@ pub enum ErrorCode {
     Template,
     Interview,
     Loop,
+    SetupArgument,
+    SetupConfigParse,
+    SetupConfigWrite,
+    SetupBackup,
+    SetupRestore,
+    SetupBundle,
 }
 
 impl ErrorCode {
@@ -23,6 +29,12 @@ impl ErrorCode {
             Self::Template => "TEMPLATE_ERROR",
             Self::Interview => "INTERVIEW_ERROR",
             Self::Loop => "LOOP_ERROR",
+            Self::SetupArgument => "SETUP_ARGUMENT_ERROR",
+            Self::SetupConfigParse => "SETUP_CONFIG_PARSE_ERROR",
+            Self::SetupConfigWrite => "SETUP_CONFIG_WRITE_ERROR",
+            Self::SetupBackup => "SETUP_BACKUP_ERROR",
+            Self::SetupRestore => "SETUP_RESTORE_ERROR",
+            Self::SetupBundle => "SETUP_BUNDLE_ERROR",
         }
     }
 }
@@ -41,6 +53,18 @@ pub enum Codex1Error {
     Interview(String),
     #[error("{0}")]
     Loop(String),
+    #[error("{0}")]
+    SetupArgument(String),
+    #[error("{0}")]
+    SetupConfigParse(String),
+    #[error("{0}")]
+    SetupConfigWrite(String),
+    #[error("{0}")]
+    SetupBackup(String),
+    #[error("{0}")]
+    SetupRestore(String),
+    #[error("{0}")]
+    SetupBundle(String),
     #[error("{context}: {source}")]
     Io {
         context: String,
@@ -64,6 +88,12 @@ impl Codex1Error {
             Self::Template(_) => ErrorCode::Template,
             Self::Interview(_) | Self::Json { .. } => ErrorCode::Interview,
             Self::Loop(_) => ErrorCode::Loop,
+            Self::SetupArgument(_) => ErrorCode::SetupArgument,
+            Self::SetupConfigParse(_) => ErrorCode::SetupConfigParse,
+            Self::SetupConfigWrite(_) => ErrorCode::SetupConfigWrite,
+            Self::SetupBackup(_) => ErrorCode::SetupBackup,
+            Self::SetupRestore(_) => ErrorCode::SetupRestore,
+            Self::SetupBundle(_) => ErrorCode::SetupBundle,
             Self::Io { .. } => ErrorCode::Io,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod loop_state;
 mod paths;
 mod ralph;
 mod render;
+mod setup;
 mod template;
 
 use std::process::ExitCode;

--- a/src/ralph.rs
+++ b/src/ralph.rs
@@ -10,6 +10,12 @@ use crate::loop_state::{self, LoopState};
 use crate::paths::{discover_repo_root, discover_repo_root_from};
 use crate::setup;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HookScope {
+    Global,
+    Project,
+}
+
 #[derive(Debug, Deserialize)]
 struct StopHookInput {
     #[serde(default)]
@@ -41,7 +47,11 @@ impl StopHookOutput {
     }
 }
 
-pub fn stop_hook(repo_root: Option<PathBuf>, mission: Option<String>) -> StopHookOutput {
+pub fn stop_hook(
+    repo_root: Option<PathBuf>,
+    mission: Option<String>,
+    hook_scope: HookScope,
+) -> StopHookOutput {
     let mut input = String::new();
     if io::stdin().read_to_string(&mut input).is_err() {
         return StopHookOutput::approve();
@@ -71,7 +81,7 @@ pub fn stop_hook(repo_root: Option<PathBuf>, mission: Option<String>) -> StopHoo
         Ok(root) => root,
         Err(_) => return StopHookOutput::approve(),
     };
-    if !setup::ralph_should_scan_repo(&root) {
+    if !setup::ralph_should_scan_repo(&root, hook_scope == HookScope::Project) {
         return StopHookOutput::approve();
     }
     let active_loops = if let Some(id) = mission {

--- a/src/ralph.rs
+++ b/src/ralph.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use crate::layout::MissionLayout;
 use crate::loop_state::{self, LoopState};
 use crate::paths::{discover_repo_root, discover_repo_root_from};
+use crate::setup;
 
 #[derive(Debug, Deserialize)]
 struct StopHookInput {
@@ -70,6 +71,9 @@ pub fn stop_hook(repo_root: Option<PathBuf>, mission: Option<String>) -> StopHoo
         Ok(root) => root,
         Err(_) => return StopHookOutput::approve(),
     };
+    if !setup::ralph_should_scan_repo(&root) {
+        return StopHookOutput::approve();
+    }
     let active_loops = if let Some(id) = mission {
         let layout = match MissionLayout::new(root, id) {
             Ok(layout) => layout,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -15,7 +15,7 @@ use crate::cli::{
 };
 use crate::envelope;
 use crate::error::{Codex1Error, IoContext, Result};
-use crate::paths::discover_repo_root;
+use crate::paths::{discover_repo_root, ensure_contained_for_write};
 
 const CONFIG_FILE: &str = "config.toml";
 const BACKUP_MANIFEST_VERSION: u32 = 1;
@@ -26,6 +26,7 @@ const MANAGED_HOOK_STATUS: &str = "Codex1 Ralph";
 const BUNDLE_SKILL: &str = ".agents/skills/codex1/SKILL.md";
 const BUNDLE_GUIDANCE: &str = ".codex1/setup-guidance.md";
 const BUNDLE_MARKER: &str = ".codex1/setup-bundle.json";
+const MANAGED_BUNDLE_FILES: [&str; 2] = [BUNDLE_SKILL, BUNDLE_GUIDANCE];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -224,7 +225,10 @@ pub fn run(cli_json: bool, command: SetupCommand) -> Result<()> {
     }
 }
 
-pub fn ralph_should_scan_repo(repo: &Path) -> bool {
+pub fn ralph_should_scan_repo(repo: &Path, project_hook: bool) -> bool {
+    if project_hook {
+        return true;
+    }
     let Ok(paths) = resolve_paths() else {
         return false;
     };
@@ -254,12 +258,16 @@ fn emit(cli_json: bool, data: serde_json::Value) -> Result<()> {
 fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
     let scope = SetupScope::from_arg(args.scope);
     let mode = ActivationMode::from_arg(args.mode);
+    if scope == SetupScope::Project && mode == ActivationMode::Off {
+        return Err(Codex1Error::SetupArgument(
+            "setup install --scope project cannot use --mode off".into(),
+        ));
+    }
     let repo = resolve_repo(args.repo)?;
     let paths = resolve_paths()?;
     let mut plan = SetupPlan::new(args.dry_run);
     match scope {
         SetupScope::Global => {
-            install_managed_hook(&paths.codex_config, &mut plan, args.dry_run, "global hook")?;
             let mut policy = read_policy_or_default(&paths)?;
             policy.mode = mode;
             if matches!(
@@ -268,13 +276,30 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
             ) {
                 policy.set_repo(repo.clone(), true);
             }
+            if policy.effective_for(&repo) {
+                materialize_bundle(&repo, &mut plan, args.dry_run)?;
+                install_managed_hook(
+                    &paths.codex_config,
+                    SetupScope::Global,
+                    &mut plan,
+                    args.dry_run,
+                    "global hook",
+                )?;
+            } else {
+                remove_bundle(&repo, &mut plan, args.dry_run)?;
+            }
             write_policy(&paths, &policy, &mut plan, args.dry_run)?;
-            materialize_bundle(&repo, &mut plan, args.dry_run)?;
         }
         SetupScope::Project => {
             let project_config = project_config_path(&repo);
-            install_managed_hook(&project_config, &mut plan, args.dry_run, "project hook")?;
             materialize_bundle(&repo, &mut plan, args.dry_run)?;
+            install_managed_hook(
+                &project_config,
+                SetupScope::Project,
+                &mut plan,
+                args.dry_run,
+                "project hook",
+            )?;
         }
     }
     Ok(json!({
@@ -290,12 +315,12 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
 fn enable(args: SetupRepoArgs) -> Result<serde_json::Value> {
     let repo = resolve_repo(args.repo)?;
     let paths = resolve_paths()?;
-    if !paths.codex1_config.exists() && !args.dry_run {
+    if !paths.codex1_config.exists() {
         return install(SetupInstallArgs {
             mode: Some(SetupModeArg::Allowlist),
             scope: Some(SetupScopeArg::Global),
             repo: Some(repo),
-            dry_run: false,
+            dry_run: args.dry_run,
         });
     }
     let mut plan = SetupPlan::new(args.dry_run);
@@ -304,8 +329,15 @@ fn enable(args: SetupRepoArgs) -> Result<serde_json::Value> {
         policy.mode = ActivationMode::Allowlist;
     }
     policy.set_repo(repo.clone(), true);
-    write_policy(&paths, &policy, &mut plan, args.dry_run)?;
     materialize_bundle(&repo, &mut plan, args.dry_run)?;
+    install_managed_hook(
+        &paths.codex_config,
+        SetupScope::Global,
+        &mut plan,
+        args.dry_run,
+        "global hook",
+    )?;
+    write_policy(&paths, &policy, &mut plan, args.dry_run)?;
     Ok(json!({
         "summary": format!("setup enabled for {}", repo.display()),
         "command": "setup enable",
@@ -373,6 +405,7 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
         SetupScope::Project => {
             install_managed_hook(
                 &project_config_path(&repo),
+                SetupScope::Project,
                 &mut plan,
                 args.dry_run,
                 "project hook",
@@ -383,7 +416,13 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
             write_policy(&paths, &policy, &mut plan, args.dry_run)?;
         }
         SetupScope::Global => {
-            install_managed_hook(&paths.codex_config, &mut plan, args.dry_run, "global hook")?;
+            install_managed_hook(
+                &paths.codex_config,
+                SetupScope::Global,
+                &mut plan,
+                args.dry_run,
+                "global hook",
+            )?;
             let mut policy = read_policy_or_default(&paths)?;
             if matches!(policy.mode, ActivationMode::Off) {
                 policy.mode = ActivationMode::Allowlist;
@@ -670,6 +709,7 @@ fn write_policy(
 
 fn install_managed_hook(
     config_path: &Path,
+    hook_scope: SetupScope,
     plan: &mut SetupPlan,
     dry_run: bool,
     reason: &str,
@@ -691,11 +731,11 @@ fn install_managed_hook(
         }
     };
     parse_toml_text(&text)?;
-    text = remove_managed_hook_block(&text);
+    text = remove_managed_hook_block(&text)?;
     if !text.trim().is_empty() && !text.ends_with('\n') {
         text.push('\n');
     }
-    text.push_str(&managed_hook_block()?);
+    text.push_str(&managed_hook_block(hook_scope)?);
     parse_toml_text(&text)?;
     write_text(config_path, &text)
 }
@@ -715,7 +755,7 @@ fn remove_managed_hook(
             config_path.display()
         ))
     })?;
-    let edited = remove_managed_hook_block(&original);
+    let edited = remove_managed_hook_block(&original)?;
     if edited == original {
         return Ok(());
     }
@@ -736,28 +776,48 @@ fn managed_hook_count(config_path: &Path) -> usize {
     text.matches(MANAGED_HOOK_START).count()
 }
 
-fn managed_hook_block() -> Result<String> {
+fn managed_hook_block(scope: SetupScope) -> Result<String> {
     let exe = env::current_exe().io_context("failed to resolve current executable")?;
-    Ok(format!(
+    Ok(managed_hook_block_for_command(&hook_command_for_exe(
+        &exe, scope,
+    )))
+}
+
+fn managed_hook_block_for_command(command: &str) -> String {
+    format!(
         r#"{MANAGED_HOOK_START}
 [[hooks.Stop]]
 
 [[hooks.Stop.hooks]]
 type = "command"
-command = "{} ralph stop-hook"
+command = {}
 timeout = 10
 statusMessage = "{MANAGED_HOOK_STATUS}"
 {MANAGED_HOOK_END}
 "#,
-        shell_quote(&exe)
-    ))
+        toml_string(command)
+    )
 }
 
-fn remove_managed_hook_block(text: &str) -> String {
+fn hook_command_for_exe(exe: &Path, scope: SetupScope) -> String {
+    let scope_arg = match scope {
+        SetupScope::Global => "global",
+        SetupScope::Project => "project",
+    };
+    let exe = exe.display().to_string().replace('"', "\\\"");
+    format!("\"{exe}\" ralph stop-hook --scope {scope_arg}")
+}
+
+fn remove_managed_hook_block(text: &str) -> Result<String> {
     let mut out = String::new();
     let mut skipping = false;
     for line in text.lines() {
         if line.trim() == MANAGED_HOOK_START {
+            if skipping {
+                return Err(Codex1Error::SetupConfigParse(
+                    "nested Codex1 managed hook marker".into(),
+                ));
+            }
             skipping = true;
             continue;
         }
@@ -770,7 +830,12 @@ fn remove_managed_hook_block(text: &str) -> String {
             out.push('\n');
         }
     }
-    out
+    if skipping {
+        return Err(Codex1Error::SetupConfigParse(
+            "unterminated Codex1 managed hook block".into(),
+        ));
+    }
+    Ok(out)
 }
 
 fn parse_toml_file(path: &Path) -> Result<()> {
@@ -794,29 +859,29 @@ fn parse_toml_text(text: &str) -> Result<()> {
 }
 
 fn materialize_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
-    let skill = repo.join(BUNDLE_SKILL);
-    let guidance = repo.join(BUNDLE_GUIDANCE);
-    let marker = bundle_marker_path(repo);
+    let skill = repo_bundle_target(repo, BUNDLE_SKILL)?;
+    let guidance = repo_bundle_target(repo, BUNDLE_GUIDANCE)?;
+    let marker = repo_bundle_target(repo, BUNDLE_MARKER)?;
     plan.materialized.push(skill.clone());
     plan.materialized.push(guidance.clone());
     plan.writes.push(marker.clone());
     if dry_run {
         return Ok(());
     }
-    write_owned_file(&skill, skill_body())?;
-    write_owned_file(&guidance, guidance_body())?;
+    write_owned_file(repo, &skill, skill_body())?;
+    write_owned_file(repo, &guidance, guidance_body())?;
     let marker_body = serde_json::to_string_pretty(&BundleMarker {
         managed_by: "codex1-managed".to_string(),
         version: BUNDLE_VERSION,
         files: vec![BUNDLE_SKILL.into(), BUNDLE_GUIDANCE.into()],
     })
     .unwrap();
-    write_owned_file(&marker, &(marker_body + "\n"))?;
+    write_owned_file(repo, &marker, &(marker_body + "\n"))?;
     Ok(())
 }
 
 fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
-    let marker = bundle_marker_path(repo);
+    let marker = repo_bundle_target(repo, BUNDLE_MARKER)?;
     let marker_text = match fs::read_to_string(&marker) {
         Ok(text) => text,
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
@@ -833,21 +898,65 @@ fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()>
             marker.display()
         ))
     })?;
+    if marker_data.managed_by != "codex1-managed" || marker_data.version != BUNDLE_VERSION {
+        return Err(Codex1Error::SetupBundle(format!(
+            "invalid Codex1 bundle marker {}",
+            marker.display()
+        )));
+    }
     for relative in marker_data.files {
-        let path = repo.join(&relative);
+        if !MANAGED_BUNDLE_FILES.contains(&relative.as_str()) {
+            return Err(Codex1Error::SetupBundle(format!(
+                "bundle marker contains unmanaged file {}",
+                relative
+            )));
+        }
+        let path = repo_bundle_target(repo, &relative)?;
         plan.removes.push(path.clone());
         if !dry_run {
-            remove_file_if_owned(&path)?;
+            remove_file_if_owned(repo, &path)?;
         }
     }
     plan.removes.push(marker.clone());
     if !dry_run {
-        remove_file_if_owned(&marker)?;
+        remove_file_if_owned(repo, &marker)?;
     }
     Ok(())
 }
 
-fn write_owned_file(path: &Path, body: &str) -> Result<()> {
+fn repo_bundle_target(repo: &Path, relative: impl AsRef<Path>) -> Result<PathBuf> {
+    let relative = relative.as_ref();
+    if relative.is_absolute() {
+        return Err(Codex1Error::SetupBundle(format!(
+            "bundle path must be relative: {}",
+            relative.display()
+        )));
+    }
+    if relative.components().any(
+        |component| !matches!(component, std::path::Component::Normal(part) if !part.is_empty()),
+    ) {
+        return Err(Codex1Error::SetupBundle(format!(
+            "unsafe bundle path: {}",
+            relative.display()
+        )));
+    }
+    let path = repo.join(relative);
+    ensure_contained_for_write(repo, &path).map_err(|error| {
+        Codex1Error::SetupBundle(format!(
+            "bundle path escapes repo or crosses a symlink: {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(path)
+}
+
+fn write_owned_file(repo: &Path, path: &Path, body: &str) -> Result<()> {
+    ensure_contained_for_write(repo, path).map_err(|error| {
+        Codex1Error::SetupBundle(format!(
+            "bundle path escapes repo or crosses a symlink: {}: {error}",
+            path.display()
+        ))
+    })?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|source| {
             Codex1Error::SetupBundle(format!("failed to create {}: {source}", parent.display()))
@@ -869,7 +978,13 @@ fn write_owned_file(path: &Path, body: &str) -> Result<()> {
     })
 }
 
-fn remove_file_if_owned(path: &Path) -> Result<()> {
+fn remove_file_if_owned(repo: &Path, path: &Path) -> Result<()> {
+    ensure_contained_for_write(repo, path).map_err(|error| {
+        Codex1Error::SetupBundle(format!(
+            "bundle path escapes repo or crosses a symlink: {}: {error}",
+            path.display()
+        ))
+    })?;
     let text = match fs::read_to_string(path) {
         Ok(text) => text,
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
@@ -1054,6 +1169,23 @@ fn toml_escape_path(path: &Path) -> String {
         .replace('"', "\\\"")
 }
 
+fn toml_string(value: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 fn mode_name(mode: ActivationMode) -> &'static str {
     match mode {
         ActivationMode::Off => "off",
@@ -1061,11 +1193,6 @@ fn mode_name(mode: ActivationMode) -> &'static str {
         ActivationMode::Denylist => "denylist",
         ActivationMode::All => "all",
     }
-}
-
-fn shell_quote(path: &Path) -> String {
-    let text = path.display().to_string();
-    format!("'{}'", text.replace('\'', r#"'\''"#))
 }
 
 #[cfg(test)]
@@ -1111,8 +1238,26 @@ mod tests {
             "model = \"x\"\n{MANAGED_HOOK_START}\n[[hooks.Stop]]\n{MANAGED_HOOK_END}\n[other]\na = 1\n"
         );
         assert_eq!(
-            remove_managed_hook_block(&text),
+            remove_managed_hook_block(&text).unwrap(),
             "model = \"x\"\n[other]\na = 1\n"
         );
+    }
+
+    #[test]
+    fn managed_hook_block_removal_rejects_unterminated_marker() {
+        let text = format!("model = \"x\"\n{MANAGED_HOOK_START}\n[other]\na = 1\n");
+        assert!(remove_managed_hook_block(&text).is_err());
+    }
+
+    #[test]
+    fn hook_command_is_toml_escaped_for_windows_paths() {
+        let command =
+            hook_command_for_exe(Path::new(r"C:\Users\me\codex1.exe"), SetupScope::Global);
+        assert_eq!(
+            toml_string(&command),
+            r#""\"C:\\Users\\me\\codex1.exe\" ralph stop-hook --scope global""#
+        );
+        let block = managed_hook_block_for_command(&command);
+        parse_toml_text(&block).unwrap();
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -23,6 +23,8 @@ const BUNDLE_VERSION: u32 = 1;
 const MANAGED_HOOK_START: &str = "# codex1-managed-ralph-start";
 const MANAGED_HOOK_END: &str = "# codex1-managed-ralph-end";
 const MANAGED_HOOK_STATUS: &str = "Codex1 Ralph";
+const MANAGED_GUIDANCE_START: &str = "<!-- codex1-managed setup guidance start -->";
+const MANAGED_GUIDANCE_END: &str = "<!-- codex1-managed setup guidance end -->";
 const BUNDLE_SKILL: &str = ".agents/skills/codex1/SKILL.md";
 const BUNDLE_GUIDANCE: &str = "AGENTS.md";
 const BUNDLE_MARKER: &str = ".codex1/setup-bundle.json";
@@ -264,7 +266,7 @@ pub fn ralph_should_scan_repo(repo: &Path, project_hook: bool) -> bool {
         return false;
     };
     if !paths.codex1_config.exists() {
-        return true;
+        return managed_hook_count(&paths.codex_config) == 0;
     }
     let Ok(policy) = read_policy(&paths) else {
         return false;
@@ -278,8 +280,9 @@ fn global_policy_should_scan_repo(policy: &ActivationPolicy, repo: &Path) -> boo
     }
     match policy.mode {
         ActivationMode::Off => false,
-        ActivationMode::Allowlist => repo_bundle_materialized(repo),
-        ActivationMode::Denylist | ActivationMode::All => true,
+        ActivationMode::Allowlist | ActivationMode::Denylist | ActivationMode::All => {
+            repo_bundle_materialized(repo)
+        }
     }
 }
 
@@ -291,6 +294,40 @@ fn known_policy_repos(policy: &ActivationPolicy, fallback: &Path) -> Vec<PathBuf
         }
     }
     repos
+}
+
+fn remove_repo_scoped_setup(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
+    if !repo.exists() {
+        return Ok(());
+    }
+    remove_bundle(repo, plan, dry_run)?;
+    remove_project_hook(repo, plan, dry_run)
+}
+
+fn remove_project_hook(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
+    let path = project_config_path(repo);
+    if !path.exists() {
+        return Ok(());
+    }
+    remove_managed_hook(
+        &project_config_path_checked(repo)?,
+        plan,
+        dry_run,
+        "project hook",
+    )
+}
+
+fn preflight_remove_project_hook(repo: &Path) -> Result<()> {
+    let path = project_config_path(repo);
+    if !path.exists() {
+        return Ok(());
+    }
+    preflight_remove_managed_hook(&project_config_path_checked(repo)?)
+}
+
+fn preflight_remove_bundle(repo: &Path) -> Result<()> {
+    let mut plan = SetupPlan::new(true);
+    remove_bundle(repo, &mut plan, true)
 }
 
 fn emit(cli_json: bool, data: serde_json::Value) -> Result<()> {
@@ -316,10 +353,10 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
         ));
     }
     let repo = resolve_repo(args.repo)?;
-    let paths = resolve_paths()?;
     let mut plan = SetupPlan::new(args.dry_run);
     match scope {
         SetupScope::Global => {
+            let paths = resolve_paths()?;
             let mut policy = read_policy_or_default(&paths)?;
             let cleanup_repos = if matches!(mode, ActivationMode::Off) {
                 known_policy_repos(&policy, &repo)
@@ -335,10 +372,14 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
             }
             if policy.effective_for(&repo) {
                 let had_bundle = repo_bundle_materialized(&repo);
+                let had_global_hook = managed_hook_count_parseable(&paths.codex_config) > 0;
+                let original_policy = read_optional_text(&paths.codex1_config)?;
                 preflight_materialize_bundle(&repo)?;
+                preflight_install_managed_hook(&paths.codex_config, SetupScope::Global)?;
+                preflight_remove_project_hook(&repo)?;
                 materialize_bundle(&repo, &mut plan, args.dry_run)?;
-                if let Err(error) =
-                    write_policy(&paths, &policy, &mut plan, args.dry_run).and_then(|()| {
+                if let Err(error) = write_policy(&paths, &policy, &mut plan, args.dry_run)
+                    .and_then(|()| {
                         install_managed_hook(
                             &paths.codex_config,
                             SetupScope::Global,
@@ -347,7 +388,19 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
                             "global hook",
                         )
                     })
+                    .and_then(|()| remove_project_hook(&repo, &mut plan, args.dry_run))
                 {
+                    if !args.dry_run {
+                        let _ = restore_text(&paths.codex1_config, original_policy.as_deref());
+                        if !had_global_hook {
+                            let _ = remove_managed_hook(
+                                &paths.codex_config,
+                                &mut SetupPlan::new(false),
+                                false,
+                                "global hook rollback",
+                            );
+                        }
+                    }
                     if !args.dry_run && !had_bundle {
                         let _ = remove_bundle(&repo, &mut SetupPlan::new(false), false);
                     }
@@ -355,7 +408,7 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
                 }
             } else {
                 for repo in cleanup_repos {
-                    remove_bundle(&repo, &mut plan, args.dry_run)?;
+                    remove_repo_scoped_setup(&repo, &mut plan, args.dry_run)?;
                 }
                 if !matches!(mode, ActivationMode::Off) {
                     remove_bundle(&repo, &mut plan, args.dry_run)?;
@@ -366,14 +419,31 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
         SetupScope::Project => {
             let project_config = project_config_path_checked(&repo)?;
             preflight_materialize_bundle(&repo)?;
-            install_managed_hook(
+            let had_bundle = repo_bundle_materialized(&repo);
+            let had_project_hook = managed_hook_count_parseable(&project_config) > 0;
+            if let Err(error) = install_managed_hook_without_backup(
                 &project_config,
                 SetupScope::Project,
                 &mut plan,
                 args.dry_run,
-                "project hook",
-            )?;
-            materialize_bundle(&repo, &mut plan, args.dry_run)?;
+            )
+            .and_then(|()| materialize_bundle(&repo, &mut plan, args.dry_run))
+            {
+                if !args.dry_run {
+                    if !had_project_hook {
+                        let _ = remove_managed_hook(
+                            &project_config,
+                            &mut SetupPlan::new(false),
+                            false,
+                            "project hook",
+                        );
+                    }
+                    if !had_bundle {
+                        let _ = remove_bundle(&repo, &mut SetupPlan::new(false), false);
+                    }
+                }
+                return Err(error);
+            }
         }
     }
     Ok(json!({
@@ -404,17 +474,35 @@ fn enable(args: SetupRepoArgs) -> Result<serde_json::Value> {
     }
     policy.set_repo(repo.clone(), true);
     let had_bundle = repo_bundle_materialized(&repo);
+    let had_global_hook = managed_hook_count_parseable(&paths.codex_config) > 0;
+    let original_policy = read_optional_text(&paths.codex1_config)?;
     preflight_materialize_bundle(&repo)?;
+    preflight_install_managed_hook(&paths.codex_config, SetupScope::Global)?;
+    preflight_remove_project_hook(&repo)?;
     materialize_bundle(&repo, &mut plan, args.dry_run)?;
-    if let Err(error) = write_policy(&paths, &policy, &mut plan, args.dry_run).and_then(|()| {
-        install_managed_hook(
-            &paths.codex_config,
-            SetupScope::Global,
-            &mut plan,
-            args.dry_run,
-            "global hook",
-        )
-    }) {
+    if let Err(error) = write_policy(&paths, &policy, &mut plan, args.dry_run)
+        .and_then(|()| {
+            install_managed_hook(
+                &paths.codex_config,
+                SetupScope::Global,
+                &mut plan,
+                args.dry_run,
+                "global hook",
+            )
+        })
+        .and_then(|()| remove_project_hook(&repo, &mut plan, args.dry_run))
+    {
+        if !args.dry_run {
+            let _ = restore_text(&paths.codex1_config, original_policy.as_deref());
+            if !had_global_hook {
+                let _ = remove_managed_hook(
+                    &paths.codex_config,
+                    &mut SetupPlan::new(false),
+                    false,
+                    "global hook rollback",
+                );
+            }
+        }
         if !args.dry_run && !had_bundle {
             let _ = remove_bundle(&repo, &mut SetupPlan::new(false), false);
         }
@@ -434,14 +522,11 @@ fn disable(args: SetupRepoArgs) -> Result<serde_json::Value> {
     let mut plan = SetupPlan::new(args.dry_run);
     let mut policy = read_policy_or_default(&paths)?;
     policy.disable_repo(repo.clone());
+    preflight_remove_bundle(&repo)?;
+    preflight_remove_project_hook(&repo)?;
     write_policy(&paths, &policy, &mut plan, args.dry_run)?;
     remove_bundle(&repo, &mut plan, args.dry_run)?;
-    remove_managed_hook(
-        &project_config_path_checked(&repo)?,
-        &mut plan,
-        args.dry_run,
-        "project hook",
-    )?;
+    remove_project_hook(&repo, &mut plan, args.dry_run)?;
     Ok(json!({
         "summary": format!("setup disabled for {}", repo.display()),
         "command": "setup disable",
@@ -489,35 +574,76 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
             let project_config = project_config_path_checked(&repo)?;
             let mut policy = read_policy_or_default(&paths)?;
             policy.disable_repo(repo.clone());
-            install_managed_hook(
+            let had_bundle = repo_bundle_materialized(&repo);
+            let had_project_hook = managed_hook_count_parseable(&project_config) > 0;
+            if let Err(error) = install_managed_hook(
                 &project_config,
                 SetupScope::Project,
                 &mut plan,
                 args.dry_run,
                 "project hook",
-            )?;
-            materialize_bundle(&repo, &mut plan, args.dry_run)?;
-            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+            )
+            .and_then(|()| materialize_bundle(&repo, &mut plan, args.dry_run))
+            .and_then(|()| write_policy(&paths, &policy, &mut plan, args.dry_run))
+            {
+                if !args.dry_run {
+                    if !had_project_hook {
+                        let _ = remove_managed_hook(
+                            &project_config,
+                            &mut SetupPlan::new(false),
+                            false,
+                            "project hook rollback",
+                        );
+                    }
+                    if !had_bundle {
+                        let _ = remove_bundle(&repo, &mut SetupPlan::new(false), false);
+                    }
+                }
+                return Err(error);
+            }
         }
         SetupScope::Global => {
             preflight_materialize_bundle(&repo)?;
             let project_config = project_config_path_checked(&repo)?;
             parse_toml_file(&project_config)?;
+            preflight_remove_managed_hook(&project_config)?;
+            preflight_install_managed_hook(&paths.codex_config, SetupScope::Global)?;
             let mut policy = read_policy_or_default(&paths)?;
             if matches!(policy.mode, ActivationMode::Off) {
                 policy.mode = ActivationMode::Allowlist;
             }
             policy.set_repo(repo.clone(), true);
-            install_managed_hook(
+            let had_bundle = repo_bundle_materialized(&repo);
+            let had_global_hook = managed_hook_count_parseable(&paths.codex_config) > 0;
+            let original_policy = read_optional_text(&paths.codex1_config)?;
+            if let Err(error) = install_managed_hook(
                 &paths.codex_config,
                 SetupScope::Global,
                 &mut plan,
                 args.dry_run,
                 "global hook",
-            )?;
-            materialize_bundle(&repo, &mut plan, args.dry_run)?;
-            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
-            remove_managed_hook(&project_config, &mut plan, args.dry_run, "project hook")?;
+            )
+            .and_then(|()| materialize_bundle(&repo, &mut plan, args.dry_run))
+            .and_then(|()| write_policy(&paths, &policy, &mut plan, args.dry_run))
+            .and_then(|()| {
+                remove_managed_hook(&project_config, &mut plan, args.dry_run, "project hook")
+            }) {
+                if !args.dry_run {
+                    let _ = restore_text(&paths.codex1_config, original_policy.as_deref());
+                    if !had_global_hook {
+                        let _ = remove_managed_hook(
+                            &paths.codex_config,
+                            &mut SetupPlan::new(false),
+                            false,
+                            "global hook rollback",
+                        );
+                    }
+                    if !had_bundle {
+                        let _ = remove_bundle(&repo, &mut SetupPlan::new(false), false);
+                    }
+                }
+                return Err(error);
+            }
         }
     }
     Ok(json!({
@@ -574,14 +700,17 @@ fn status(repo_arg: Option<PathBuf>) -> Result<SetupStatus> {
     let global_hook_count = managed_hook_count_parseable(&paths.codex_config);
     let project_config = project_config_path(&repo);
     let project_hook_count = managed_hook_count_parseable(&project_config);
+    let global_hook_executable_ok = managed_hook_executable_ok(&paths.codex_config);
+    let project_hook_executable_ok = managed_hook_executable_ok(&project_config);
     let repo_bundle_materialized = repo_bundle_materialized(&repo);
     if project_hook_count > 0 {
         warnings.push("project-local hooks depend on official Codex project trust".to_string());
     }
     let repo_policy_enabled = policy.effective_for(&repo);
     let effective_active = (global_hook_count > 0
+        && global_hook_executable_ok
         && global_policy_should_scan_repo(&policy, &repo))
-        || (project_hook_count > 0 && repo_bundle_materialized);
+        || (project_hook_count > 0 && project_hook_executable_ok && repo_bundle_materialized);
     let backups_available = read_manifest(&paths)
         .map(|manifest| manifest.records.len())
         .unwrap_or(0);
@@ -628,6 +757,7 @@ fn backups_restore(args: SetupBackupRestoreArgs) -> Result<serde_json::Value> {
         .iter()
         .find(|record| record.id == args.id)
         .ok_or_else(|| Codex1Error::SetupRestore(format!("unknown backup id {}", args.id)))?;
+    validate_backup_record_for_restore(&paths, record)?;
     if !args.dry_run {
         if record.existed {
             let backup_path = record.backup_path.as_ref().ok_or_else(|| {
@@ -668,21 +798,75 @@ fn backups_restore(args: SetupBackupRestoreArgs) -> Result<serde_json::Value> {
     }))
 }
 
+fn validate_backup_record_for_restore(paths: &SetupPaths, record: &BackupRecord) -> Result<()> {
+    if record.target_path != paths.codex_config && record.target_path != paths.codex1_config {
+        return Err(Codex1Error::SetupRestore(format!(
+            "backup {} target is outside managed setup paths: {}",
+            record.id,
+            record.target_path.display()
+        )));
+    }
+    if let Some(backup_path) = &record.backup_path {
+        let backups_dir = fs::canonicalize(&paths.backups_dir).map_err(|source| {
+            Codex1Error::SetupRestore(format!(
+                "failed to canonicalize backups dir {}: {source}",
+                paths.backups_dir.display()
+            ))
+        })?;
+        let metadata = fs::symlink_metadata(backup_path).map_err(|source| {
+            Codex1Error::SetupRestore(format!(
+                "failed to inspect backup file {}: {source}",
+                backup_path.display()
+            ))
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(Codex1Error::SetupRestore(format!(
+                "backup {} file must not be a symlink: {}",
+                record.id,
+                backup_path.display()
+            )));
+        }
+        let backup_real = fs::canonicalize(backup_path).map_err(|source| {
+            Codex1Error::SetupRestore(format!(
+                "failed to canonicalize backup file {}: {source}",
+                backup_path.display()
+            ))
+        })?;
+        if !backup_real.starts_with(backups_dir) {
+            return Err(Codex1Error::SetupRestore(format!(
+                "backup {} file is outside managed backups: {}",
+                record.id,
+                backup_path.display()
+            )));
+        }
+    } else if record.existed {
+        return Err(Codex1Error::SetupRestore(format!(
+            "backup {} has no file path",
+            record.id
+        )));
+    }
+    Ok(())
+}
+
 fn resolve_repo(repo: Option<PathBuf>) -> Result<PathBuf> {
     discover_repo_root(repo)
         .map_err(|error| Codex1Error::SetupArgument(format!("failed to resolve repo: {error}")))
 }
 
 fn resolve_paths() -> Result<SetupPaths> {
-    let home = home_dir()?;
-    let codex_home = match env::var_os("CODEX_HOME") {
-        Some(value) => PathBuf::from(value),
-        None => home.join(".codex"),
+    let codex_home_env = env::var_os("CODEX_HOME");
+    let codex1_home_env = env::var_os("CODEX1_HOME");
+    let home = if codex_home_env.is_none() || codex1_home_env.is_none() {
+        Some(home_dir()?)
+    } else {
+        None
     };
-    let codex1_home = match env::var_os("CODEX1_HOME") {
-        Some(value) => PathBuf::from(value),
-        None => home.join(".codex1"),
-    };
+    let codex_home = codex_home_env
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.as_ref().unwrap().join(".codex"));
+    let codex1_home = codex1_home_env
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.as_ref().unwrap().join(".codex1"));
     Ok(SetupPaths {
         codex_config: codex_home.join(CONFIG_FILE),
         codex_home,
@@ -694,10 +878,22 @@ fn resolve_paths() -> Result<SetupPaths> {
 }
 
 fn home_dir() -> Result<PathBuf> {
-    env::var_os("HOME")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .ok_or_else(|| Codex1Error::SetupArgument("HOME is required for setup".into()))
+    if let Some(home) = env::var_os("HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(home));
+    }
+    if let Some(home) = env::var_os("USERPROFILE").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(home));
+    }
+    match (env::var_os("HOMEDRIVE"), env::var_os("HOMEPATH")) {
+        (Some(drive), Some(path)) if !drive.is_empty() && !path.is_empty() => {
+            let mut home = PathBuf::from(drive);
+            home.push(path);
+            Ok(home)
+        }
+        _ => Err(Codex1Error::SetupArgument(
+            "HOME, USERPROFILE, or CODEX_HOME/CODEX1_HOME are required for setup".into(),
+        )),
+    }
 }
 
 fn read_policy_or_default(paths: &SetupPaths) -> Result<ActivationPolicy> {
@@ -793,6 +989,68 @@ fn write_policy(
     })
 }
 
+fn read_optional_text(path: &Path) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(text) => Ok(Some(text)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(Codex1Error::SetupConfigParse(format!(
+            "failed to read {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn restore_text(path: &Path, text: Option<&str>) -> Result<()> {
+    match text {
+        Some(text) => write_text(path, text),
+        None => match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(Codex1Error::SetupConfigWrite(format!(
+                "failed to remove {}: {error}",
+                path.display()
+            ))),
+        },
+    }
+}
+
+fn preflight_install_managed_hook(config_path: &Path, hook_scope: SetupScope) -> Result<()> {
+    let mut text = match fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "failed to read {}: {error}",
+                config_path.display()
+            )))
+        }
+    };
+    parse_toml_text(&text)?;
+    text = remove_managed_hook_block(&text)?;
+    if !text.trim().is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text.push_str(&managed_hook_block(hook_scope)?);
+    parse_toml_text(&text)
+}
+
+fn preflight_remove_managed_hook(config_path: &Path) -> Result<()> {
+    if !config_path.exists() {
+        return Ok(());
+    }
+    let original = fs::read_to_string(config_path).map_err(|source| {
+        Codex1Error::SetupConfigParse(format!(
+            "failed to read {}: {source}",
+            config_path.display()
+        ))
+    })?;
+    let edited = remove_managed_hook_block(&original)?;
+    if edited != original {
+        parse_toml_text(&edited)?;
+    }
+    Ok(())
+}
+
 fn install_managed_hook(
     config_path: &Path,
     hook_scope: SetupScope,
@@ -800,12 +1058,33 @@ fn install_managed_hook(
     dry_run: bool,
     reason: &str,
 ) -> Result<()> {
+    install_managed_hook_inner(config_path, hook_scope, plan, dry_run, Some(reason))
+}
+
+fn install_managed_hook_without_backup(
+    config_path: &Path,
+    hook_scope: SetupScope,
+    plan: &mut SetupPlan,
+    dry_run: bool,
+) -> Result<()> {
+    install_managed_hook_inner(config_path, hook_scope, plan, dry_run, None)
+}
+
+fn install_managed_hook_inner(
+    config_path: &Path,
+    hook_scope: SetupScope,
+    plan: &mut SetupPlan,
+    dry_run: bool,
+    backup_reason: Option<&str>,
+) -> Result<()> {
     plan.writes.push(config_path.to_path_buf());
     if dry_run {
         return Ok(());
     }
-    let paths = resolve_paths()?;
-    backup_target(&paths, config_path, "codex-config", reason, plan)?;
+    if let Some(reason) = backup_reason {
+        let paths = resolve_paths()?;
+        backup_target(&paths, config_path, "codex-config", reason, plan)?;
+    }
     let mut text = match fs::read_to_string(config_path) {
         Ok(text) => text,
         Err(error) if error.kind() == ErrorKind::NotFound => String::new(),
@@ -1114,7 +1393,12 @@ fn validate_bundle(repo: &Path) -> Result<()> {
         let text = fs::read_to_string(&path).map_err(|source| {
             Codex1Error::SetupBundle(format!("failed to read {}: {source}", path.display()))
         })?;
-        if text != expected_bundle_body(relative) {
+        let valid = if relative == BUNDLE_GUIDANCE {
+            guidance_has_managed_block(&text) || text == guidance_body()
+        } else {
+            text == expected_bundle_body(relative)
+        };
+        if !valid {
             return Err(Codex1Error::SetupBundle(format!(
                 "invalid managed bundle file {}",
                 path.display()
@@ -1131,7 +1415,12 @@ fn preflight_materialize_bundle(repo: &Path) -> Result<()> {
             let existing = fs::read_to_string(&path).map_err(|source| {
                 Codex1Error::SetupBundle(format!("failed to read {}: {source}", path.display()))
             })?;
-            if existing != expected_bundle_body(relative) {
+            let valid = if relative == BUNDLE_GUIDANCE {
+                true
+            } else {
+                existing == expected_bundle_body(relative)
+            };
+            if !valid {
                 return Err(Codex1Error::SetupBundle(format!(
                     "refusing to overwrite non-managed file {}",
                     path.display()
@@ -1153,7 +1442,7 @@ fn materialize_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Resul
         return Ok(());
     }
     write_owned_file(repo, &skill, skill_body())?;
-    write_owned_file(repo, &guidance, guidance_body())?;
+    write_guidance_file(repo, &guidance)?;
     write_owned_file(repo, &marker, &bundle_marker_body())?;
     Ok(())
 }
@@ -1189,7 +1478,11 @@ fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()>
         let path = repo_bundle_target(repo, &relative)?;
         plan.removes.push(path.clone());
         if !dry_run {
-            remove_file_if_owned(repo, &path, &expected_bundle_body(&relative))?;
+            if relative == BUNDLE_GUIDANCE {
+                remove_guidance_if_owned(repo, &path)?;
+            } else {
+                remove_file_if_owned(repo, &path, &expected_bundle_body(&relative))?;
+            }
         }
     }
     plan.removes.push(marker.clone());
@@ -1221,12 +1514,21 @@ fn remove_known_bundle_files(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -
                 )))
             }
         };
-        if text != expected_bundle_body(relative) {
+        let owned = if relative == BUNDLE_GUIDANCE {
+            guidance_has_managed_block(&text) || text == guidance_body()
+        } else {
+            text == expected_bundle_body(relative)
+        };
+        if !owned {
             continue;
         }
         plan.removes.push(path.clone());
         if !dry_run {
-            remove_file_if_owned(repo, &path, &expected_bundle_body(relative))?;
+            if relative == BUNDLE_GUIDANCE {
+                remove_guidance_if_owned(repo, &path)?;
+            } else {
+                remove_file_if_owned(repo, &path, &expected_bundle_body(relative))?;
+            }
         }
     }
     Ok(())
@@ -1286,6 +1588,50 @@ fn write_owned_file(repo: &Path, path: &Path, body: &str) -> Result<()> {
     })
 }
 
+fn write_guidance_file(repo: &Path, path: &Path) -> Result<()> {
+    ensure_contained_for_write(repo, path).map_err(|error| {
+        Codex1Error::SetupBundle(format!(
+            "bundle path escapes repo or crosses a symlink: {}: {error}",
+            path.display()
+        ))
+    })?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| {
+            Codex1Error::SetupBundle(format!("failed to create {}: {source}", parent.display()))
+        })?;
+    }
+    let block = managed_guidance_block();
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            fs::write(path, &block).map_err(|source| {
+                Codex1Error::SetupBundle(format!("failed to write {}: {source}", path.display()))
+            })?;
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(Codex1Error::SetupBundle(format!(
+                "failed to read {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    if guidance_has_managed_block(&text) || text == guidance_body() {
+        return Ok(());
+    }
+    let mut edited = text;
+    if !edited.ends_with('\n') {
+        edited.push('\n');
+    }
+    if !edited.ends_with("\n\n") {
+        edited.push('\n');
+    }
+    edited.push_str(&block);
+    fs::write(path, edited).map_err(|source| {
+        Codex1Error::SetupBundle(format!("failed to write {}: {source}", path.display()))
+    })
+}
+
 fn remove_file_if_owned(repo: &Path, path: &Path, expected: &str) -> Result<()> {
     ensure_contained_for_write(repo, path).map_err(|error| {
         Codex1Error::SetupBundle(format!(
@@ -1316,6 +1662,52 @@ fn remove_file_if_owned(repo: &Path, path: &Path, expected: &str) -> Result<()> 
             "failed to remove {}: {error}",
             path.display()
         ))),
+    }
+}
+
+fn remove_guidance_if_owned(repo: &Path, path: &Path) -> Result<()> {
+    ensure_contained_for_write(repo, path).map_err(|error| {
+        Codex1Error::SetupBundle(format!(
+            "bundle path escapes repo or crosses a symlink: {}: {error}",
+            path.display()
+        ))
+    })?;
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Codex1Error::SetupBundle(format!(
+                "failed to read {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    if text == guidance_body() || text == managed_guidance_block() {
+        return match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(Codex1Error::SetupBundle(format!(
+                "failed to remove {}: {error}",
+                path.display()
+            ))),
+        };
+    }
+    let Some(edited) = remove_guidance_block(&text) else {
+        return Ok(());
+    };
+    if edited.trim().is_empty() {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(Codex1Error::SetupBundle(format!(
+                "failed to remove {}: {error}",
+                path.display()
+            ))),
+        }
+    } else {
+        fs::write(path, edited).map_err(|source| {
+            Codex1Error::SetupBundle(format!("failed to write {}: {source}", path.display()))
+        })
     }
 }
 
@@ -1359,6 +1751,46 @@ codex1-managed
 
 Codex1 is active for this repository when setup status says the bundle is materialized and hook policy allows it. Mission truth remains in human-facing artifacts; setup only controls activation.
 "#
+}
+
+fn managed_guidance_block() -> String {
+    format!(
+        "{MANAGED_GUIDANCE_START}\n{}{MANAGED_GUIDANCE_END}\n",
+        guidance_body()
+    )
+}
+
+fn guidance_has_managed_block(text: &str) -> bool {
+    text.contains(MANAGED_GUIDANCE_START) && text.contains(MANAGED_GUIDANCE_END)
+}
+
+fn remove_guidance_block(text: &str) -> Option<String> {
+    let start = text.find(MANAGED_GUIDANCE_START)?;
+    let after_start = start + MANAGED_GUIDANCE_START.len();
+    let relative_end = text[after_start..].find(MANAGED_GUIDANCE_END)?;
+    let mut end = after_start + relative_end + MANAGED_GUIDANCE_END.len();
+    if text[end..].starts_with("\r\n") {
+        end += 2;
+    } else if text[end..].starts_with('\n') {
+        end += 1;
+    }
+    let mut edited = String::new();
+    let mut prefix = text[..start].to_string();
+    while prefix.ends_with('\n') {
+        prefix.pop();
+        if prefix.ends_with('\r') {
+            prefix.pop();
+        }
+    }
+    edited.push_str(&prefix);
+    if !prefix.is_empty() && !text[end..].is_empty() {
+        edited.push('\n');
+    }
+    edited.push_str(&text[end..]);
+    while edited.contains("\n\n\n") {
+        edited = edited.replace("\n\n\n", "\n\n");
+    }
+    Some(edited)
 }
 
 fn project_config_path(repo: &Path) -> PathBuf {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::ErrorKind;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use chrono::Utc;
@@ -64,6 +66,13 @@ impl SetupScope {
             Some(SetupScopeArg::Global) | None => Self::Global,
         }
     }
+
+    fn hook_arg(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Project => "project",
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -118,6 +127,14 @@ impl ActivationPolicy {
             self.mode = ActivationMode::Denylist;
         }
         self.set_repo(repo, false);
+    }
+
+    fn has_any_global_activation(&self) -> bool {
+        match self.mode {
+            ActivationMode::Off => false,
+            ActivationMode::Allowlist => self.repos.iter().any(|entry| entry.enabled),
+            ActivationMode::Denylist | ActivationMode::All => true,
+        }
     }
 
     fn to_toml(&self) -> String {
@@ -250,7 +267,9 @@ pub fn run(cli_json: bool, global_repo: Option<PathBuf>, command: SetupCommand) 
         }
         SetupCommand::Backups { command } => match command {
             SetupBackupsCommand::List => emit(cli_json, backups_list()?),
-            SetupBackupsCommand::Restore(args) => emit(cli_json, backups_restore(args)?),
+            SetupBackupsCommand::Restore(args) => {
+                emit(cli_json, backups_restore(global_repo, args)?)
+            }
         },
     }
 }
@@ -280,17 +299,29 @@ fn global_policy_should_scan_repo(policy: &ActivationPolicy, repo: &Path) -> boo
     }
     match policy.mode {
         ActivationMode::Off => false,
-        ActivationMode::Allowlist | ActivationMode::Denylist | ActivationMode::All => {
-            repo_bundle_materialized(repo)
-        }
+        ActivationMode::Allowlist => repo_bundle_materialized(repo),
+        ActivationMode::Denylist | ActivationMode::All => true,
     }
 }
 
-fn known_policy_repos(policy: &ActivationPolicy, fallback: &Path) -> Vec<PathBuf> {
+fn known_policy_repos(
+    paths: &SetupPaths,
+    policy: &ActivationPolicy,
+    fallback: &Path,
+) -> Vec<PathBuf> {
     let mut repos = vec![fallback.to_path_buf()];
     for entry in &policy.repos {
         if !repos.contains(&entry.path) {
             repos.push(entry.path.clone());
+        }
+    }
+    if let Ok(manifest) = read_manifest(paths) {
+        for record in manifest.records {
+            if let Some(repo) = project_config_repo(&record.target_path) {
+                if !repos.contains(&repo) {
+                    repos.push(repo);
+                }
+            }
         }
     }
     repos
@@ -302,6 +333,47 @@ fn remove_repo_scoped_setup(repo: &Path, plan: &mut SetupPlan, dry_run: bool) ->
     }
     remove_bundle(repo, plan, dry_run)?;
     remove_project_hook(repo, plan, dry_run)
+}
+
+fn project_setup_recorded(paths: &SetupPaths, repo: &Path) -> bool {
+    read_manifest(paths)
+        .map(|manifest| {
+            manifest
+                .records
+                .iter()
+                .filter_map(|record| project_config_repo(&record.target_path))
+                .any(|record_repo| record_repo == repo)
+        })
+        .unwrap_or(false)
+}
+
+fn dedup_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for path in paths {
+        if !out.contains(&path) {
+            out.push(path);
+        }
+    }
+    out
+}
+
+fn global_setup_remains_for_repo(paths: &SetupPaths, repo: &Path) -> Result<bool> {
+    if managed_hook_count_parseable(&paths.codex_config) == 0 {
+        return Ok(false);
+    }
+    if !managed_hook_executable_ok(&paths.codex_config, SetupScope::Global) {
+        return Ok(false);
+    }
+    let policy = read_policy_or_default(paths)?;
+    Ok(global_policy_should_scan_repo(&policy, repo))
+}
+
+fn global_policy_enables_repo(paths: &SetupPaths, repo: &Path) -> Result<bool> {
+    if !paths.codex1_config.exists() {
+        return Ok(false);
+    }
+    let policy = read_policy_or_default(paths)?;
+    Ok(global_policy_should_scan_repo(&policy, repo))
 }
 
 fn remove_project_hook(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
@@ -326,8 +398,65 @@ fn preflight_remove_project_hook(repo: &Path) -> Result<()> {
 }
 
 fn preflight_remove_bundle(repo: &Path) -> Result<()> {
-    let mut plan = SetupPlan::new(true);
-    remove_bundle(repo, &mut plan, true)
+    validate_bundle_removal(repo).map(|_| ())
+}
+
+fn validate_bundle_removal(repo: &Path) -> Result<Option<Vec<String>>> {
+    let marker = repo_bundle_target(repo, BUNDLE_MARKER)?;
+    let marker_text = match fs::read_to_string(&marker) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(Codex1Error::SetupBundle(format!(
+                "failed to read {}: {error}",
+                marker.display()
+            )))
+        }
+    };
+    let marker_data = parse_bundle_marker(&marker, &marker_text)?;
+    if marker_data.managed_by != "codex1-managed" || marker_data.version != BUNDLE_VERSION {
+        return Err(Codex1Error::SetupBundle(format!(
+            "invalid Codex1 bundle marker {}",
+            marker.display()
+        )));
+    }
+    if marker_text != bundle_marker_body() {
+        return Err(Codex1Error::SetupBundle(format!(
+            "refusing to remove non-managed file {}",
+            marker.display()
+        )));
+    }
+    for relative in &marker_data.files {
+        if !MANAGED_BUNDLE_FILES.contains(&relative.as_str()) {
+            return Err(Codex1Error::SetupBundle(format!(
+                "bundle marker contains unmanaged file {}",
+                relative
+            )));
+        }
+        let path = repo_bundle_target(repo, relative)?;
+        let text = match fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(Codex1Error::SetupBundle(format!(
+                    "failed to read {}: {error}",
+                    path.display()
+                )))
+            }
+        };
+        let owned = if relative == BUNDLE_GUIDANCE {
+            guidance_has_managed_block(&text) || text == guidance_body()
+        } else {
+            text == expected_bundle_body(relative)
+        };
+        if !owned {
+            return Err(Codex1Error::SetupBundle(format!(
+                "refusing to remove non-managed file {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(Some(marker_data.files))
 }
 
 fn emit(cli_json: bool, data: serde_json::Value) -> Result<()> {
@@ -359,7 +488,7 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
             let paths = resolve_paths()?;
             let mut policy = read_policy_or_default(&paths)?;
             let cleanup_repos = if matches!(mode, ActivationMode::Off) {
-                known_policy_repos(&policy, &repo)
+                known_policy_repos(&paths, &policy, &repo)
             } else {
                 Vec::new()
             };
@@ -375,10 +504,11 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
                 let had_global_hook = managed_hook_count_parseable(&paths.codex_config) > 0;
                 let original_policy = read_optional_text(&paths.codex1_config)?;
                 preflight_materialize_bundle(&repo)?;
+                preflight_write_policy(&paths)?;
                 preflight_install_managed_hook(&paths.codex_config, SetupScope::Global)?;
                 preflight_remove_project_hook(&repo)?;
-                materialize_bundle(&repo, &mut plan, args.dry_run)?;
-                if let Err(error) = write_policy(&paths, &policy, &mut plan, args.dry_run)
+                if let Err(error) = materialize_bundle(&repo, &mut plan, args.dry_run)
+                    .and_then(|()| write_policy(&paths, &policy, &mut plan, args.dry_run))
                     .and_then(|()| {
                         install_managed_hook(
                             &paths.codex_config,
@@ -407,29 +537,63 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
                     return Err(error);
                 }
             } else {
+                for repo in &cleanup_repos {
+                    preflight_remove_bundle(repo)?;
+                    preflight_remove_project_hook(repo)?;
+                }
+                if !matches!(mode, ActivationMode::Off) {
+                    preflight_remove_bundle(&repo)?;
+                }
+                write_policy(&paths, &policy, &mut plan, args.dry_run)?;
                 for repo in cleanup_repos {
                     remove_repo_scoped_setup(&repo, &mut plan, args.dry_run)?;
                 }
                 if !matches!(mode, ActivationMode::Off) {
                     remove_bundle(&repo, &mut plan, args.dry_run)?;
                 }
-                write_policy(&paths, &policy, &mut plan, args.dry_run)?;
             }
         }
         SetupScope::Project => {
+            let paths = resolve_paths()?;
             let project_config = project_config_path_checked(&repo)?;
             preflight_materialize_bundle(&repo)?;
+            let suppress_global = global_policy_enables_repo(&paths, &repo)?;
+            let original_policy = if suppress_global {
+                Some(read_optional_text(&paths.codex1_config)?)
+            } else {
+                None
+            };
+            let mut suppressed_policy = if suppress_global {
+                let mut policy = read_policy_or_default(&paths)?;
+                policy.disable_repo(repo.clone());
+                preflight_write_policy(&paths)?;
+                Some(policy)
+            } else {
+                None
+            };
             let had_bundle = repo_bundle_materialized(&repo);
             let had_project_hook = managed_hook_count_parseable(&project_config) > 0;
-            if let Err(error) = install_managed_hook_without_backup(
+            let install_result = install_managed_hook(
                 &project_config,
                 SetupScope::Project,
                 &mut plan,
                 args.dry_run,
-            )
-            .and_then(|()| materialize_bundle(&repo, &mut plan, args.dry_run))
+                "project hook",
+            );
+            if let Err(error) = install_result
+                .and_then(|()| materialize_bundle(&repo, &mut plan, args.dry_run))
+                .and_then(|()| {
+                    if let Some(policy) = suppressed_policy.take() {
+                        write_policy(&paths, &policy, &mut plan, args.dry_run)
+                    } else {
+                        Ok(())
+                    }
+                })
             {
                 if !args.dry_run {
+                    if let Some(original_policy) = original_policy.as_ref() {
+                        let _ = restore_text(&paths.codex1_config, original_policy.as_deref());
+                    }
                     if !had_project_hook {
                         let _ = remove_managed_hook(
                             &project_config,
@@ -460,6 +624,17 @@ fn enable(args: SetupRepoArgs) -> Result<serde_json::Value> {
     let repo = resolve_repo(args.repo)?;
     let paths = resolve_paths()?;
     if !paths.codex1_config.exists() {
+        let project_config = project_config_path(&repo);
+        if managed_hook_count_parseable(&project_config) > 0
+            || project_setup_recorded(&paths, &repo)
+        {
+            return install(SetupInstallArgs {
+                mode: Some(SetupModeArg::Allowlist),
+                scope: Some(SetupScopeArg::Project),
+                repo: Some(repo),
+                dry_run: args.dry_run,
+            });
+        }
         return install(SetupInstallArgs {
             mode: Some(SetupModeArg::Allowlist),
             scope: Some(SetupScopeArg::Global),
@@ -477,10 +652,11 @@ fn enable(args: SetupRepoArgs) -> Result<serde_json::Value> {
     let had_global_hook = managed_hook_count_parseable(&paths.codex_config) > 0;
     let original_policy = read_optional_text(&paths.codex1_config)?;
     preflight_materialize_bundle(&repo)?;
+    preflight_write_policy(&paths)?;
     preflight_install_managed_hook(&paths.codex_config, SetupScope::Global)?;
     preflight_remove_project_hook(&repo)?;
-    materialize_bundle(&repo, &mut plan, args.dry_run)?;
-    if let Err(error) = write_policy(&paths, &policy, &mut plan, args.dry_run)
+    if let Err(error) = materialize_bundle(&repo, &mut plan, args.dry_run)
+        .and_then(|()| write_policy(&paths, &policy, &mut plan, args.dry_run))
         .and_then(|()| {
             install_managed_hook(
                 &paths.codex_config,
@@ -520,6 +696,20 @@ fn disable(args: SetupRepoArgs) -> Result<serde_json::Value> {
     let repo = resolve_repo(args.repo)?;
     let paths = resolve_paths()?;
     let mut plan = SetupPlan::new(args.dry_run);
+    if !paths.codex1_config.exists()
+        && managed_hook_count_parseable(&project_config_path(&repo)) > 0
+    {
+        preflight_remove_bundle(&repo)?;
+        preflight_remove_project_hook(&repo)?;
+        remove_bundle(&repo, &mut plan, args.dry_run)?;
+        remove_project_hook(&repo, &mut plan, args.dry_run)?;
+        return Ok(json!({
+            "summary": format!("setup disabled for {}", repo.display()),
+            "command": "setup disable",
+            "repo": repo,
+            "plan": plan,
+        }));
+    }
     let mut policy = read_policy_or_default(&paths)?;
     policy.disable_repo(repo.clone());
     preflight_remove_bundle(&repo)?;
@@ -542,16 +732,52 @@ fn uninstall(args: SetupUninstallArgs) -> Result<serde_json::Value> {
     let mut plan = SetupPlan::new(args.dry_run);
     match scope {
         SetupScope::Global => {
-            remove_managed_hook(&paths.codex_config, &mut plan, args.dry_run, "global hook")?;
+            let original_policy = read_policy_or_default(&paths)?;
+            let known_repos = known_policy_repos(&paths, &original_policy, &repo);
+            let mut policy = original_policy.clone();
+            policy.disable_repo(repo.clone());
+            let remove_shared_hook = !policy.has_any_global_activation();
+            let selected_has_project_hook =
+                managed_hook_count_parseable(&project_config_path(&repo)) > 0;
+            let bundle_repos = if remove_shared_hook {
+                dedup_paths(known_repos.into_iter().filter(|known_repo| {
+                    managed_hook_count_parseable(&project_config_path(known_repo)) == 0
+                }))
+            } else if selected_has_project_hook {
+                Vec::new()
+            } else {
+                vec![repo.clone()]
+            };
+            for bundle_repo in &bundle_repos {
+                preflight_remove_bundle(bundle_repo)?;
+            }
+            if remove_shared_hook {
+                preflight_remove_managed_hook(&paths.codex_config)?;
+            }
+            if paths.codex1_config.exists() {
+                write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+            }
+            if remove_shared_hook {
+                remove_managed_hook(&paths.codex_config, &mut plan, args.dry_run, "global hook")?;
+            }
+            for bundle_repo in bundle_repos {
+                remove_bundle(&bundle_repo, &mut plan, args.dry_run)?;
+            }
         }
         SetupScope::Project => {
+            let keep_bundle = global_setup_remains_for_repo(&paths, &repo)?;
+            if !keep_bundle {
+                preflight_remove_bundle(&repo)?;
+            }
             remove_managed_hook(
                 &project_config_path_checked(&repo)?,
                 &mut plan,
                 args.dry_run,
                 "project hook",
             )?;
-            remove_bundle(&repo, &mut plan, args.dry_run)?;
+            if !keep_bundle {
+                remove_bundle(&repo, &mut plan, args.dry_run)?;
+            }
         }
     }
     Ok(json!({
@@ -573,7 +799,9 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
             preflight_materialize_bundle(&repo)?;
             let project_config = project_config_path_checked(&repo)?;
             let mut policy = read_policy_or_default(&paths)?;
+            let original_policy = read_optional_text(&paths.codex1_config)?;
             policy.disable_repo(repo.clone());
+            preflight_write_policy(&paths)?;
             let had_bundle = repo_bundle_materialized(&repo);
             let had_project_hook = managed_hook_count_parseable(&project_config) > 0;
             if let Err(error) = install_managed_hook(
@@ -587,6 +815,7 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
             .and_then(|()| write_policy(&paths, &policy, &mut plan, args.dry_run))
             {
                 if !args.dry_run {
+                    let _ = restore_text(&paths.codex1_config, original_policy.as_deref());
                     if !had_project_hook {
                         let _ = remove_managed_hook(
                             &project_config,
@@ -608,6 +837,7 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
             parse_toml_file(&project_config)?;
             preflight_remove_managed_hook(&project_config)?;
             preflight_install_managed_hook(&paths.codex_config, SetupScope::Global)?;
+            preflight_write_policy(&paths)?;
             let mut policy = read_policy_or_default(&paths)?;
             if matches!(policy.mode, ActivationMode::Off) {
                 policy.mode = ActivationMode::Allowlist;
@@ -672,7 +902,7 @@ fn doctor(repo_arg: Option<PathBuf>) -> Result<serde_json::Value> {
         json!({"name": "codex1_policy_parseable", "ok": status.global_config_parseable}),
         json!({"name": "backup_manifest_parseable", "ok": read_manifest(&paths).is_ok()}),
         json!({"name": "global_hook_installed", "ok": status.global_hook_installed || status.project_hook_installed}),
-        json!({"name": "managed_hook_executable", "ok": managed_hook_executable_ok(&status.codex_config) && managed_hook_executable_ok(&project_config)}),
+        json!({"name": "managed_hook_executable", "ok": managed_hook_executable_ok(&status.codex_config, SetupScope::Global) && managed_hook_executable_ok(&project_config, SetupScope::Project)}),
         json!({"name": "repo_bundle_materialized", "ok": status.repo_bundle_materialized}),
         json!({"name": "duplicate_hook_risk", "ok": !status.duplicate_hook_risk}),
     ];
@@ -700,17 +930,21 @@ fn status(repo_arg: Option<PathBuf>) -> Result<SetupStatus> {
     let global_hook_count = managed_hook_count_parseable(&paths.codex_config);
     let project_config = project_config_path(&repo);
     let project_hook_count = managed_hook_count_parseable(&project_config);
-    let global_hook_executable_ok = managed_hook_executable_ok(&paths.codex_config);
-    let project_hook_executable_ok = managed_hook_executable_ok(&project_config);
+    let global_hook_executable_ok =
+        managed_hook_executable_ok(&paths.codex_config, SetupScope::Global);
+    let project_hook_executable_ok =
+        managed_hook_executable_ok(&project_config, SetupScope::Project);
     let repo_bundle_materialized = repo_bundle_materialized(&repo);
     if project_hook_count > 0 {
         warnings.push("project-local hooks depend on official Codex project trust".to_string());
     }
     let repo_policy_enabled = policy.effective_for(&repo);
-    let effective_active = (global_hook_count > 0
+    let global_hook_active = global_hook_count > 0
         && global_hook_executable_ok
-        && global_policy_should_scan_repo(&policy, &repo))
-        || (project_hook_count > 0 && project_hook_executable_ok && repo_bundle_materialized);
+        && global_policy_should_scan_repo(&policy, &repo);
+    let project_hook_active =
+        project_hook_count > 0 && project_hook_executable_ok && repo_bundle_materialized;
+    let effective_active = global_hook_active || project_hook_active;
     let backups_available = read_manifest(&paths)
         .map(|manifest| manifest.records.len())
         .unwrap_or(0);
@@ -727,7 +961,7 @@ fn status(repo_arg: Option<PathBuf>) -> Result<SetupStatus> {
         global_hook_installed: global_hook_count > 0,
         project_hook_installed: project_hook_count > 0,
         repo_bundle_materialized,
-        duplicate_hook_risk: global_hook_count + project_hook_count > 1,
+        duplicate_hook_risk: global_hook_active && project_hook_active,
         backups_available,
         project_trust_caveat: project_hook_count > 0,
         warnings,
@@ -744,7 +978,10 @@ fn backups_list() -> Result<serde_json::Value> {
     }))
 }
 
-fn backups_restore(args: SetupBackupRestoreArgs) -> Result<serde_json::Value> {
+fn backups_restore(
+    repo_arg: Option<PathBuf>,
+    args: SetupBackupRestoreArgs,
+) -> Result<serde_json::Value> {
     if !args.force && !args.dry_run {
         return Err(Codex1Error::SetupRestore(
             "setup backups restore requires --force unless --dry-run is used".into(),
@@ -757,7 +994,7 @@ fn backups_restore(args: SetupBackupRestoreArgs) -> Result<serde_json::Value> {
         .iter()
         .find(|record| record.id == args.id)
         .ok_or_else(|| Codex1Error::SetupRestore(format!("unknown backup id {}", args.id)))?;
-    validate_backup_record_for_restore(&paths, record)?;
+    validate_backup_record_for_restore(&paths, repo_arg.as_deref(), record)?;
     if !args.dry_run {
         if record.existed {
             let backup_path = record.backup_path.as_ref().ok_or_else(|| {
@@ -798,13 +1035,25 @@ fn backups_restore(args: SetupBackupRestoreArgs) -> Result<serde_json::Value> {
     }))
 }
 
-fn validate_backup_record_for_restore(paths: &SetupPaths, record: &BackupRecord) -> Result<()> {
-    if record.target_path != paths.codex_config && record.target_path != paths.codex1_config {
+fn validate_backup_record_for_restore(
+    paths: &SetupPaths,
+    repo_arg: Option<&Path>,
+    record: &BackupRecord,
+) -> Result<()> {
+    let valid_target = record.target_path == paths.codex_config
+        || record.target_path == paths.codex1_config
+        || validate_project_config_restore_target(repo_arg, &record.target_path).is_ok();
+    if !valid_target {
         return Err(Codex1Error::SetupRestore(format!(
             "backup {} target is outside managed setup paths: {}",
             record.id,
             record.target_path.display()
         )));
+    }
+    if record.target_path == paths.codex_config || record.target_path == paths.codex1_config {
+        reject_symlinked_config_target(&record.target_path).map_err(|error| {
+            Codex1Error::SetupRestore(format!("backup {} target is unsafe: {error}", record.id))
+        })?;
     }
     if let Some(backup_path) = &record.backup_path {
         let backups_dir = fs::canonicalize(&paths.backups_dir).map_err(|source| {
@@ -846,6 +1095,64 @@ fn validate_backup_record_for_restore(paths: &SetupPaths, record: &BackupRecord)
         )));
     }
     Ok(())
+}
+
+fn validate_project_config_restore_target(repo_arg: Option<&Path>, target: &Path) -> Result<()> {
+    if target.file_name().and_then(OsStr::to_str) != Some(CONFIG_FILE) {
+        return Err(Codex1Error::SetupRestore(format!(
+            "project config backup target must be config.toml: {}",
+            target.display()
+        )));
+    }
+    let codex_dir = target.parent().ok_or_else(|| {
+        Codex1Error::SetupRestore(format!(
+            "project config backup target has no parent: {}",
+            target.display()
+        ))
+    })?;
+    if codex_dir.file_name().and_then(OsStr::to_str) != Some(".codex") {
+        return Err(Codex1Error::SetupRestore(format!(
+            "project config backup target must be under .codex: {}",
+            target.display()
+        )));
+    }
+    let repo = project_config_repo(target).ok_or_else(|| {
+        Codex1Error::SetupRestore(format!(
+            "project config backup target has no repo parent: {}",
+            target.display()
+        ))
+    })?;
+    let selected_repo = resolve_repo(repo_arg.map(Path::to_path_buf))?;
+    if repo != selected_repo {
+        return Err(Codex1Error::SetupRestore(format!(
+            "project config backup target is outside selected repo: {}",
+            target.display()
+        )));
+    }
+    if !selected_repo.join(".git").exists() {
+        return Err(Codex1Error::SetupRestore(format!(
+            "project config backup target is not under a repo: {}",
+            target.display()
+        )));
+    }
+    ensure_contained_for_write(&selected_repo, target).map_err(|source| {
+        Codex1Error::SetupRestore(format!(
+            "project config backup target escapes repo: {}: {source}",
+            target.display()
+        ))
+    })
+}
+
+fn project_config_repo(target: &Path) -> Option<PathBuf> {
+    if target.file_name().and_then(OsStr::to_str) != Some(CONFIG_FILE) {
+        return None;
+    }
+    let codex_dir = target.parent()?;
+    if codex_dir.file_name().and_then(OsStr::to_str) != Some(".codex") {
+        return None;
+    }
+    let repo = codex_dir.parent()?;
+    fs::canonicalize(repo).ok()
 }
 
 fn resolve_repo(repo: Option<PathBuf>) -> Result<PathBuf> {
@@ -966,6 +1273,7 @@ fn write_policy(
     if dry_run {
         return Ok(());
     }
+    preflight_write_policy(paths)?;
     backup_target(
         paths,
         &paths.codex1_config,
@@ -987,6 +1295,11 @@ fn write_policy(
             paths.codex1_config.display()
         ))
     })
+}
+
+fn preflight_write_policy(paths: &SetupPaths) -> Result<()> {
+    reject_symlinked_config_target(&paths.codex1_config)?;
+    read_manifest(paths).map(|_| ())
 }
 
 fn read_optional_text(path: &Path) -> Result<Option<String>> {
@@ -1015,6 +1328,7 @@ fn restore_text(path: &Path, text: Option<&str>) -> Result<()> {
 }
 
 fn preflight_install_managed_hook(config_path: &Path, hook_scope: SetupScope) -> Result<()> {
+    reject_symlinked_config_target(config_path)?;
     let mut text = match fs::read_to_string(config_path) {
         Ok(text) => text,
         Err(error) if error.kind() == ErrorKind::NotFound => String::new(),
@@ -1038,6 +1352,7 @@ fn preflight_remove_managed_hook(config_path: &Path) -> Result<()> {
     if !config_path.exists() {
         return Ok(());
     }
+    reject_symlinked_config_target(config_path)?;
     let original = fs::read_to_string(config_path).map_err(|source| {
         Codex1Error::SetupConfigParse(format!(
             "failed to read {}: {source}",
@@ -1061,15 +1376,6 @@ fn install_managed_hook(
     install_managed_hook_inner(config_path, hook_scope, plan, dry_run, Some(reason))
 }
 
-fn install_managed_hook_without_backup(
-    config_path: &Path,
-    hook_scope: SetupScope,
-    plan: &mut SetupPlan,
-    dry_run: bool,
-) -> Result<()> {
-    install_managed_hook_inner(config_path, hook_scope, plan, dry_run, None)
-}
-
 fn install_managed_hook_inner(
     config_path: &Path,
     hook_scope: SetupScope,
@@ -1081,6 +1387,7 @@ fn install_managed_hook_inner(
     if dry_run {
         return Ok(());
     }
+    reject_symlinked_config_target(config_path)?;
     if let Some(reason) = backup_reason {
         let paths = resolve_paths()?;
         backup_target(&paths, config_path, "codex-config", reason, plan)?;
@@ -1114,6 +1421,7 @@ fn remove_managed_hook(
     if !config_path.exists() {
         return Ok(());
     }
+    reject_symlinked_config_target(config_path)?;
     let original = fs::read_to_string(config_path).map_err(|source| {
         Codex1Error::SetupConfigParse(format!(
             "failed to read {}: {source}",
@@ -1148,7 +1456,7 @@ fn managed_hook_count_parseable(config_path: &Path) -> usize {
     managed_hook_count(config_path)
 }
 
-fn managed_hook_executable_ok(config_path: &Path) -> bool {
+fn managed_hook_executable_ok(config_path: &Path, hook_scope: SetupScope) -> bool {
     let Ok(commands) = managed_hook_commands(config_path) else {
         return false;
     };
@@ -1160,7 +1468,45 @@ fn managed_hook_executable_ok(config_path: &Path) -> bool {
     }
     commands
         .iter()
-        .all(|command| hook_command_executable(command).is_some_and(|path| path.is_file()))
+        .all(|command| managed_hook_command_ok(command, hook_scope))
+}
+
+fn managed_hook_command_ok(command: &str, hook_scope: SetupScope) -> bool {
+    let Some((path, rest)) = hook_command_invocation(command) else {
+        return false;
+    };
+    if !hook_executable_ok(&path) {
+        return false;
+    }
+    let mut args = rest.split_whitespace();
+    matches!(
+        (
+            args.next(),
+            args.next(),
+            args.next(),
+            args.next(),
+            args.next()
+        ),
+        (Some("ralph"), Some("stop-hook"), Some("--scope"), Some(scope), None)
+            if scope == hook_scope.hook_arg()
+    )
+}
+
+fn hook_executable_ok(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        metadata.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 fn managed_hook_commands(config_path: &Path) -> Result<Vec<String>> {
@@ -1210,18 +1556,27 @@ fn managed_hook_commands(config_path: &Path) -> Result<Vec<String>> {
     Ok(commands)
 }
 
+#[cfg(test)]
 fn hook_command_executable(command: &str) -> Option<PathBuf> {
+    hook_command_invocation(command).map(|(path, _)| path)
+}
+
+fn hook_command_invocation(command: &str) -> Option<(PathBuf, String)> {
     let command = command.trim_start();
     if let Some(rest) = command.strip_prefix('\'') {
-        return posix_single_quoted_word(rest).map(PathBuf::from);
+        return posix_single_quoted_word(rest)
+            .map(|(word, rest)| (PathBuf::from(word), rest.trim_start().to_string()));
     }
     if let Some(rest) = command.strip_prefix('"') {
         let mut path = String::new();
-        let mut chars = rest.chars().peekable();
+        let mut chars = rest.char_indices().peekable();
         while let Some(ch) = chars.next() {
-            match ch {
-                '"' => return Some(PathBuf::from(path)),
-                '\\' if chars.peek() == Some(&'"') => {
+            match ch.1 {
+                '"' => {
+                    let rest = &rest[ch.0 + ch.1.len_utf8()..];
+                    return Some((PathBuf::from(path), rest.trim_start().to_string()));
+                }
+                '\\' if chars.peek().is_some_and(|next| next.1 == '"') => {
                     chars.next();
                     path.push('"');
                 }
@@ -1230,10 +1585,13 @@ fn hook_command_executable(command: &str) -> Option<PathBuf> {
         }
         return None;
     }
-    command.split_whitespace().next().map(PathBuf::from)
+    let mut parts = command.splitn(2, char::is_whitespace);
+    let word = parts.next()?;
+    let rest = parts.next().unwrap_or("").trim_start();
+    Some((PathBuf::from(word), rest.to_string()))
 }
 
-fn posix_single_quoted_word(mut rest: &str) -> Option<String> {
+fn posix_single_quoted_word(mut rest: &str) -> Option<(String, &str)> {
     let mut word = String::new();
     loop {
         let end = rest.find('\'')?;
@@ -1244,7 +1602,7 @@ fn posix_single_quoted_word(mut rest: &str) -> Option<String> {
             rest = next;
             continue;
         }
-        return Some(word);
+        return Some((word, rest));
     }
 }
 
@@ -1287,13 +1645,10 @@ enum CommandShell {
 }
 
 fn hook_command_for_exe_with_shell(exe: &Path, scope: SetupScope, shell: CommandShell) -> String {
-    let scope_arg = match scope {
-        SetupScope::Global => "global",
-        SetupScope::Project => "project",
-    };
     format!(
-        "{} ralph stop-hook --scope {scope_arg}",
-        shell_escape_exe(exe, shell)
+        "{} ralph stop-hook --scope {}",
+        shell_escape_exe(exe, shell),
+        scope.hook_arg()
     )
 }
 
@@ -1382,6 +1737,12 @@ fn validate_bundle(repo: &Path) -> Result<()> {
         ))
     })?;
     let marker_data = parse_bundle_marker(&marker, &marker_text)?;
+    if marker_data.managed_by != "codex1-managed" || marker_data.version != BUNDLE_VERSION {
+        return Err(Codex1Error::SetupBundle(format!(
+            "invalid Codex1 bundle marker {}",
+            marker.display()
+        )));
+    }
     if marker_data.files != MANAGED_BUNDLE_FILES.map(String::from) {
         return Err(Codex1Error::SetupBundle(format!(
             "bundle marker has unexpected files {}",
@@ -1394,7 +1755,7 @@ fn validate_bundle(repo: &Path) -> Result<()> {
             Codex1Error::SetupBundle(format!("failed to read {}: {source}", path.display()))
         })?;
         let valid = if relative == BUNDLE_GUIDANCE {
-            guidance_has_managed_block(&text) || text == guidance_body()
+            guidance_has_current_managed_block(&text)
         } else {
             text == expected_bundle_body(relative)
         };
@@ -1449,32 +1810,11 @@ fn materialize_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Resul
 
 fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
     let marker = repo_bundle_target(repo, BUNDLE_MARKER)?;
-    let marker_text = match fs::read_to_string(&marker) {
-        Ok(text) => text,
-        Err(error) if error.kind() == ErrorKind::NotFound => {
-            return remove_known_bundle_files(repo, plan, dry_run);
-        }
-        Err(error) => {
-            return Err(Codex1Error::SetupBundle(format!(
-                "failed to read {}: {error}",
-                marker.display()
-            )))
-        }
+    let Some(files) = validate_bundle_removal(repo)? else {
+        return remove_known_bundle_files(repo, plan, dry_run);
     };
-    let marker_data = parse_bundle_marker(&marker, &marker_text)?;
-    if marker_data.managed_by != "codex1-managed" || marker_data.version != BUNDLE_VERSION {
-        return Err(Codex1Error::SetupBundle(format!(
-            "invalid Codex1 bundle marker {}",
-            marker.display()
-        )));
-    }
-    for relative in marker_data.files {
-        if !MANAGED_BUNDLE_FILES.contains(&relative.as_str()) {
-            return Err(Codex1Error::SetupBundle(format!(
-                "bundle marker contains unmanaged file {}",
-                relative
-            )));
-        }
+
+    for relative in files {
         let path = repo_bundle_target(repo, &relative)?;
         plan.removes.push(path.clone());
         if !dry_run {
@@ -1616,17 +1956,28 @@ fn write_guidance_file(repo: &Path, path: &Path) -> Result<()> {
             )))
         }
     };
-    if guidance_has_managed_block(&text) || text == guidance_body() {
+    if guidance_has_current_managed_block(&text) {
         return Ok(());
     }
-    let mut edited = text;
+    let mut edited = if guidance_has_managed_block(&text) {
+        replace_guidance_block(&text, &block).ok_or_else(|| {
+            Codex1Error::SetupBundle(format!(
+                "failed to replace managed guidance block in {}",
+                path.display()
+            ))
+        })?
+    } else {
+        text
+    };
     if !edited.ends_with('\n') {
         edited.push('\n');
     }
-    if !edited.ends_with("\n\n") {
-        edited.push('\n');
+    if !guidance_has_managed_block(&edited) {
+        if !edited.ends_with("\n\n") {
+            edited.push('\n');
+        }
+        edited.push_str(&block);
     }
-    edited.push_str(&block);
     fs::write(path, edited).map_err(|source| {
         Codex1Error::SetupBundle(format!("failed to write {}: {source}", path.display()))
     })
@@ -1762,6 +2113,27 @@ fn managed_guidance_block() -> String {
 
 fn guidance_has_managed_block(text: &str) -> bool {
     text.contains(MANAGED_GUIDANCE_START) && text.contains(MANAGED_GUIDANCE_END)
+}
+
+fn guidance_has_current_managed_block(text: &str) -> bool {
+    text == guidance_body() || text.contains(&managed_guidance_block())
+}
+
+fn replace_guidance_block(text: &str, replacement: &str) -> Option<String> {
+    let start = text.find(MANAGED_GUIDANCE_START)?;
+    let after_start = start + MANAGED_GUIDANCE_START.len();
+    let relative_end = text[after_start..].find(MANAGED_GUIDANCE_END)?;
+    let mut end = after_start + relative_end + MANAGED_GUIDANCE_END.len();
+    if text[end..].starts_with("\r\n") {
+        end += 2;
+    } else if text[end..].starts_with('\n') {
+        end += 1;
+    }
+    let mut edited = String::new();
+    edited.push_str(&text[..start]);
+    edited.push_str(replacement);
+    edited.push_str(&text[end..]);
+    Some(edited)
 }
 
 fn remove_guidance_block(text: &str) -> Option<String> {
@@ -1900,6 +2272,7 @@ fn write_manifest(paths: &SetupPaths, manifest: &BackupManifest) -> Result<()> {
 }
 
 fn write_text(path: &Path, text: &str) -> Result<()> {
+    reject_symlinked_config_target(path)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|source| {
             Codex1Error::SetupConfigWrite(format!(
@@ -1911,6 +2284,20 @@ fn write_text(path: &Path, text: &str) -> Result<()> {
     fs::write(path, text).map_err(|source| {
         Codex1Error::SetupConfigWrite(format!("failed to write {}: {source}", path.display()))
     })
+}
+
+fn reject_symlinked_config_target(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(Codex1Error::SetupConfigWrite(
+            format!("refusing to write symlinked config {}", path.display()),
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Codex1Error::SetupConfigWrite(format!(
+            "failed to inspect {}: {error}",
+            path.display()
+        ))),
+    }
 }
 
 fn safe_backup_name(path: &Path) -> String {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1349,16 +1349,17 @@ fn preflight_install_managed_hook(config_path: &Path, hook_scope: SetupScope) ->
 }
 
 fn preflight_remove_managed_hook(config_path: &Path) -> Result<()> {
-    if !config_path.exists() {
-        return Ok(());
-    }
     reject_symlinked_config_target(config_path)?;
-    let original = fs::read_to_string(config_path).map_err(|source| {
-        Codex1Error::SetupConfigParse(format!(
-            "failed to read {}: {source}",
-            config_path.display()
-        ))
-    })?;
+    let original = match fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "failed to read {}: {error}",
+                config_path.display()
+            )))
+        }
+    };
     let edited = remove_managed_hook_block(&original)?;
     if edited != original {
         parse_toml_text(&edited)?;
@@ -1373,25 +1374,13 @@ fn install_managed_hook(
     dry_run: bool,
     reason: &str,
 ) -> Result<()> {
-    install_managed_hook_inner(config_path, hook_scope, plan, dry_run, Some(reason))
-}
-
-fn install_managed_hook_inner(
-    config_path: &Path,
-    hook_scope: SetupScope,
-    plan: &mut SetupPlan,
-    dry_run: bool,
-    backup_reason: Option<&str>,
-) -> Result<()> {
     plan.writes.push(config_path.to_path_buf());
     if dry_run {
         return Ok(());
     }
     reject_symlinked_config_target(config_path)?;
-    if let Some(reason) = backup_reason {
-        let paths = resolve_paths()?;
-        backup_target(&paths, config_path, "codex-config", reason, plan)?;
-    }
+    let paths = resolve_paths()?;
+    backup_target(&paths, config_path, "codex-config", reason, plan)?;
     let mut text = match fs::read_to_string(config_path) {
         Ok(text) => text,
         Err(error) if error.kind() == ErrorKind::NotFound => String::new(),
@@ -1418,16 +1407,17 @@ fn remove_managed_hook(
     dry_run: bool,
     reason: &str,
 ) -> Result<()> {
-    if !config_path.exists() {
-        return Ok(());
-    }
     reject_symlinked_config_target(config_path)?;
-    let original = fs::read_to_string(config_path).map_err(|source| {
-        Codex1Error::SetupConfigParse(format!(
-            "failed to read {}: {source}",
-            config_path.display()
-        ))
-    })?;
+    let original = match fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "failed to read {}: {error}",
+                config_path.display()
+            )))
+        }
+    };
     let edited = remove_managed_hook_block(&original)?;
     if edited == original {
         return Ok(());
@@ -1450,19 +1440,27 @@ fn managed_hook_count(config_path: &Path) -> usize {
 }
 
 fn managed_hook_count_parseable(config_path: &Path) -> usize {
-    if parse_toml_file(config_path).is_err() {
+    let Ok(text) = fs::read_to_string(config_path) else {
+        return 0;
+    };
+    if parse_toml_text(&text).is_err() {
         return 0;
     }
-    managed_hook_count(config_path)
+    text.matches(MANAGED_HOOK_START).count()
 }
 
 fn managed_hook_executable_ok(config_path: &Path, hook_scope: SetupScope) -> bool {
-    let Ok(commands) = managed_hook_commands(config_path) else {
-        return false;
+    let text = match fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return true,
+        Err(_) => return false,
     };
-    if managed_hook_count(config_path) == 0 {
+    if !text.contains(MANAGED_HOOK_START) {
         return true;
     }
+    let Ok(commands) = parse_managed_hook_commands(&text) else {
+        return false;
+    };
     if commands.is_empty() {
         return false;
     }
@@ -1509,17 +1507,7 @@ fn hook_executable_ok(path: &Path) -> bool {
     }
 }
 
-fn managed_hook_commands(config_path: &Path) -> Result<Vec<String>> {
-    let text = match fs::read_to_string(config_path) {
-        Ok(text) => text,
-        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => {
-            return Err(Codex1Error::SetupConfigParse(format!(
-                "failed to read {}: {error}",
-                config_path.display()
-            )))
-        }
-    };
+fn parse_managed_hook_commands(text: &str) -> Result<Vec<String>> {
     let mut commands = Vec::new();
     let mut scanning = false;
     for line in text.lines() {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,1118 @@
+use std::env;
+use std::ffi::OsStr;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use toml_edit::DocumentMut;
+
+use crate::cli::{
+    SetupBackupRestoreArgs, SetupBackupsCommand, SetupCommand, SetupInstallArgs, SetupMigrateArgs,
+    SetupModeArg, SetupRepoArgs, SetupScopeArg, SetupUninstallArgs,
+};
+use crate::envelope;
+use crate::error::{Codex1Error, IoContext, Result};
+use crate::paths::discover_repo_root;
+
+const CONFIG_FILE: &str = "config.toml";
+const BACKUP_MANIFEST_VERSION: u32 = 1;
+const BUNDLE_VERSION: u32 = 1;
+const MANAGED_HOOK_START: &str = "# codex1-managed-ralph-start";
+const MANAGED_HOOK_END: &str = "# codex1-managed-ralph-end";
+const MANAGED_HOOK_STATUS: &str = "Codex1 Ralph";
+const BUNDLE_SKILL: &str = ".agents/skills/codex1/SKILL.md";
+const BUNDLE_GUIDANCE: &str = ".codex1/setup-guidance.md";
+const BUNDLE_MARKER: &str = ".codex1/setup-bundle.json";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SetupScope {
+    Global,
+    Project,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ActivationMode {
+    Off,
+    Allowlist,
+    Denylist,
+    All,
+}
+
+impl ActivationMode {
+    fn from_arg(value: Option<SetupModeArg>) -> Self {
+        match value {
+            Some(SetupModeArg::Off) => Self::Off,
+            Some(SetupModeArg::Allowlist) | None => Self::Allowlist,
+            Some(SetupModeArg::Denylist) => Self::Denylist,
+            Some(SetupModeArg::All) => Self::All,
+        }
+    }
+}
+
+impl SetupScope {
+    fn from_arg(value: Option<SetupScopeArg>) -> Self {
+        match value {
+            Some(SetupScopeArg::Project) => Self::Project,
+            Some(SetupScopeArg::Global) | None => Self::Global,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoPolicyEntry {
+    pub path: PathBuf,
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivationPolicy {
+    pub mode: ActivationMode,
+    #[serde(default)]
+    pub repos: Vec<RepoPolicyEntry>,
+}
+
+impl Default for ActivationPolicy {
+    fn default() -> Self {
+        Self {
+            mode: ActivationMode::Allowlist,
+            repos: Vec::new(),
+        }
+    }
+}
+
+impl ActivationPolicy {
+    pub fn effective_for(&self, repo: &Path) -> bool {
+        let explicit = self
+            .repos
+            .iter()
+            .rev()
+            .find(|entry| entry.path == repo)
+            .map(|entry| entry.enabled);
+        match self.mode {
+            ActivationMode::Off => false,
+            ActivationMode::Allowlist => explicit.unwrap_or(false),
+            ActivationMode::Denylist => explicit.unwrap_or(true),
+            ActivationMode::All => explicit.unwrap_or(true),
+        }
+    }
+
+    fn set_repo(&mut self, repo: PathBuf, enabled: bool) {
+        self.repos.retain(|entry| entry.path != repo);
+        self.repos.push(RepoPolicyEntry {
+            path: repo,
+            enabled,
+        });
+        self.repos.sort_by(|left, right| left.path.cmp(&right.path));
+    }
+
+    fn to_toml(&self) -> String {
+        let mut text = format!("mode = \"{}\"\n", mode_name(self.mode));
+        for entry in &self.repos {
+            text.push_str("\n[[repos]]\n");
+            text.push_str(&format!("path = \"{}\"\n", toml_escape_path(&entry.path)));
+            text.push_str(&format!("enabled = {}\n", entry.enabled));
+        }
+        text
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SetupPaths {
+    pub codex_home: PathBuf,
+    pub codex_config: PathBuf,
+    pub codex1_home: PathBuf,
+    pub codex1_config: PathBuf,
+    pub backups_dir: PathBuf,
+    pub backup_manifest: PathBuf,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BackupManifest {
+    pub version: u32,
+    #[serde(default)]
+    pub records: Vec<BackupRecord>,
+}
+
+impl Default for BackupManifest {
+    fn default() -> Self {
+        Self {
+            version: BACKUP_MANIFEST_VERSION,
+            records: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BackupRecord {
+    pub id: String,
+    pub timestamp: String,
+    pub target_kind: String,
+    pub target_path: PathBuf,
+    pub target_path_label: String,
+    pub backup_path: Option<PathBuf>,
+    pub existed: bool,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SetupPlan {
+    pub dry_run: bool,
+    pub writes: Vec<PathBuf>,
+    pub removes: Vec<PathBuf>,
+    pub backups: Vec<PathBuf>,
+    pub materialized: Vec<PathBuf>,
+}
+
+impl SetupPlan {
+    fn new(dry_run: bool) -> Self {
+        Self {
+            dry_run,
+            writes: Vec::new(),
+            removes: Vec::new(),
+            backups: Vec::new(),
+            materialized: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SetupStatus {
+    pub repo: PathBuf,
+    pub codex_home: PathBuf,
+    pub codex_config: PathBuf,
+    pub codex1_home: PathBuf,
+    pub global_config_found: bool,
+    pub global_config_parseable: bool,
+    pub activation_mode: ActivationMode,
+    pub repo_policy_enabled: bool,
+    pub effective_active: bool,
+    pub global_hook_installed: bool,
+    pub project_hook_installed: bool,
+    pub repo_bundle_materialized: bool,
+    pub duplicate_hook_risk: bool,
+    pub backups_available: usize,
+    pub project_trust_caveat: bool,
+    pub warnings: Vec<String>,
+    pub anti_oracle: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct BundleMarker {
+    managed_by: String,
+    version: u32,
+    files: Vec<String>,
+}
+
+pub fn run(cli_json: bool, command: SetupCommand) -> Result<()> {
+    match command {
+        SetupCommand::Install(args) => emit(cli_json, install(args)?),
+        SetupCommand::Enable(args) => emit(cli_json, enable(args)?),
+        SetupCommand::Disable(args) => emit(cli_json, disable(args)?),
+        SetupCommand::Uninstall(args) => emit(cli_json, uninstall(args)?),
+        SetupCommand::Migrate(args) => emit(cli_json, migrate(args)?),
+        SetupCommand::Status(args) => emit(cli_json, status_value(args.repo)?),
+        SetupCommand::Doctor(args) => emit(cli_json, doctor(args.repo)?),
+        SetupCommand::Backups { command } => match command {
+            SetupBackupsCommand::List => emit(cli_json, backups_list()?),
+            SetupBackupsCommand::Restore(args) => emit(cli_json, backups_restore(args)?),
+        },
+    }
+}
+
+pub fn ralph_should_scan_repo(repo: &Path) -> bool {
+    let Ok(paths) = resolve_paths() else {
+        return false;
+    };
+    if !paths.codex1_config.exists() {
+        return true;
+    }
+    let Ok(policy) = read_policy(&paths) else {
+        return false;
+    };
+    policy.effective_for(repo)
+}
+
+fn emit(cli_json: bool, data: serde_json::Value) -> Result<()> {
+    if cli_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&envelope::success(data)).unwrap()
+        );
+    } else if let Some(summary) = data.get("summary").and_then(|value| value.as_str()) {
+        println!("{summary}");
+    } else {
+        println!("{}", serde_json::to_string_pretty(&data).unwrap());
+    }
+    Ok(())
+}
+
+fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
+    let scope = SetupScope::from_arg(args.scope);
+    let mode = ActivationMode::from_arg(args.mode);
+    let repo = resolve_repo(args.repo)?;
+    let paths = resolve_paths()?;
+    let mut plan = SetupPlan::new(args.dry_run);
+    match scope {
+        SetupScope::Global => {
+            install_managed_hook(&paths.codex_config, &mut plan, args.dry_run, "global hook")?;
+            let mut policy = read_policy_or_default(&paths)?;
+            policy.mode = mode;
+            if matches!(
+                policy.mode,
+                ActivationMode::Allowlist | ActivationMode::Denylist
+            ) {
+                policy.set_repo(repo.clone(), true);
+            }
+            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+            materialize_bundle(&repo, &mut plan, args.dry_run)?;
+        }
+        SetupScope::Project => {
+            let project_config = project_config_path(&repo);
+            install_managed_hook(&project_config, &mut plan, args.dry_run, "project hook")?;
+            materialize_bundle(&repo, &mut plan, args.dry_run)?;
+        }
+    }
+    Ok(json!({
+        "summary": format!("setup install planned/applied for {}", repo.display()),
+        "command": "setup install",
+        "scope": scope,
+        "activation_mode": mode,
+        "repo": repo,
+        "plan": plan,
+    }))
+}
+
+fn enable(args: SetupRepoArgs) -> Result<serde_json::Value> {
+    let repo = resolve_repo(args.repo)?;
+    let paths = resolve_paths()?;
+    if !paths.codex1_config.exists() && !args.dry_run {
+        return install(SetupInstallArgs {
+            mode: Some(SetupModeArg::Allowlist),
+            scope: Some(SetupScopeArg::Global),
+            repo: Some(repo),
+            dry_run: false,
+        });
+    }
+    let mut plan = SetupPlan::new(args.dry_run);
+    let mut policy = read_policy_or_default(&paths)?;
+    if matches!(policy.mode, ActivationMode::Off) {
+        policy.mode = ActivationMode::Allowlist;
+    }
+    policy.set_repo(repo.clone(), true);
+    write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+    materialize_bundle(&repo, &mut plan, args.dry_run)?;
+    Ok(json!({
+        "summary": format!("setup enabled for {}", repo.display()),
+        "command": "setup enable",
+        "repo": repo,
+        "plan": plan,
+    }))
+}
+
+fn disable(args: SetupRepoArgs) -> Result<serde_json::Value> {
+    let repo = resolve_repo(args.repo)?;
+    let paths = resolve_paths()?;
+    let mut plan = SetupPlan::new(args.dry_run);
+    let mut policy = read_policy_or_default(&paths)?;
+    policy.set_repo(repo.clone(), false);
+    write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+    remove_bundle(&repo, &mut plan, args.dry_run)?;
+    remove_managed_hook(
+        &project_config_path(&repo),
+        &mut plan,
+        args.dry_run,
+        "project hook",
+    )?;
+    Ok(json!({
+        "summary": format!("setup disabled for {}", repo.display()),
+        "command": "setup disable",
+        "repo": repo,
+        "plan": plan,
+    }))
+}
+
+fn uninstall(args: SetupUninstallArgs) -> Result<serde_json::Value> {
+    let scope = SetupScope::from_arg(args.scope);
+    let repo = resolve_repo(args.repo)?;
+    let paths = resolve_paths()?;
+    let mut plan = SetupPlan::new(args.dry_run);
+    match scope {
+        SetupScope::Global => {
+            remove_managed_hook(&paths.codex_config, &mut plan, args.dry_run, "global hook")?;
+        }
+        SetupScope::Project => {
+            remove_managed_hook(
+                &project_config_path(&repo),
+                &mut plan,
+                args.dry_run,
+                "project hook",
+            )?;
+            remove_bundle(&repo, &mut plan, args.dry_run)?;
+        }
+    }
+    Ok(json!({
+        "summary": format!("setup uninstall planned/applied for {}", repo.display()),
+        "command": "setup uninstall",
+        "scope": scope,
+        "repo": repo,
+        "plan": plan,
+    }))
+}
+
+fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
+    let repo = resolve_repo(args.repo)?;
+    let paths = resolve_paths()?;
+    let mut plan = SetupPlan::new(args.dry_run);
+    let target = SetupScope::from_arg(Some(args.to));
+    match target {
+        SetupScope::Project => {
+            install_managed_hook(
+                &project_config_path(&repo),
+                &mut plan,
+                args.dry_run,
+                "project hook",
+            )?;
+            materialize_bundle(&repo, &mut plan, args.dry_run)?;
+            let mut policy = read_policy_or_default(&paths)?;
+            policy.set_repo(repo.clone(), false);
+            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+        }
+        SetupScope::Global => {
+            install_managed_hook(&paths.codex_config, &mut plan, args.dry_run, "global hook")?;
+            let mut policy = read_policy_or_default(&paths)?;
+            if matches!(policy.mode, ActivationMode::Off) {
+                policy.mode = ActivationMode::Allowlist;
+            }
+            policy.set_repo(repo.clone(), true);
+            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+            remove_managed_hook(
+                &project_config_path(&repo),
+                &mut plan,
+                args.dry_run,
+                "project hook",
+            )?;
+            materialize_bundle(&repo, &mut plan, args.dry_run)?;
+        }
+    }
+    Ok(json!({
+        "summary": format!("setup migrated for {}", repo.display()),
+        "command": "setup migrate",
+        "to": target,
+        "repo": repo,
+        "plan": plan,
+    }))
+}
+
+fn status_value(repo_arg: Option<PathBuf>) -> Result<serde_json::Value> {
+    let status = status(repo_arg)?;
+    Ok(json!({
+        "summary": if status.effective_active { "codex1 setup active" } else { "codex1 setup inactive" },
+        "status": status,
+    }))
+}
+
+fn doctor(repo_arg: Option<PathBuf>) -> Result<serde_json::Value> {
+    let status = status(repo_arg)?;
+    let checks = vec![
+        json!({"name": "codex_config_parseable", "ok": parse_toml_file(&status.codex_config).is_ok()}),
+        json!({"name": "codex1_policy_parseable", "ok": status.global_config_parseable}),
+        json!({"name": "global_hook_installed", "ok": status.global_hook_installed}),
+        json!({"name": "repo_bundle_materialized", "ok": status.repo_bundle_materialized}),
+        json!({"name": "duplicate_hook_risk", "ok": !status.duplicate_hook_risk}),
+    ];
+    Ok(json!({
+        "summary": "setup doctor complete",
+        "checks": checks,
+        "status": status,
+        "anti_oracle": "setup doctor diagnoses activation/config only",
+    }))
+}
+
+fn status(repo_arg: Option<PathBuf>) -> Result<SetupStatus> {
+    let repo = resolve_repo(repo_arg)?;
+    let paths = resolve_paths()?;
+    let global_config_found = paths.codex1_config.exists();
+    let (policy, global_config_parseable, mut warnings) = match read_policy(&paths) {
+        Ok(policy) => (policy, true, Vec::new()),
+        Err(error) if global_config_found => (
+            ActivationPolicy::default(),
+            false,
+            vec![format!("failed to parse Codex1 config: {error}")],
+        ),
+        Err(_) => (ActivationPolicy::default(), true, Vec::new()),
+    };
+    let global_hook_count = managed_hook_count(&paths.codex_config);
+    let project_config = project_config_path(&repo);
+    let project_hook_count = managed_hook_count(&project_config);
+    let repo_bundle_materialized = bundle_marker_path(&repo).exists()
+        && repo.join(BUNDLE_SKILL).is_file()
+        && repo.join(BUNDLE_GUIDANCE).is_file();
+    if project_hook_count > 0 {
+        warnings.push("project-local hooks depend on official Codex project trust".to_string());
+    }
+    let repo_policy_enabled = policy.effective_for(&repo);
+    let backups_available = read_manifest(&paths)
+        .map(|manifest| manifest.records.len())
+        .unwrap_or(0);
+    Ok(SetupStatus {
+        repo,
+        codex_home: paths.codex_home,
+        codex_config: paths.codex_config,
+        codex1_home: paths.codex1_home,
+        global_config_found,
+        global_config_parseable,
+        activation_mode: policy.mode,
+        repo_policy_enabled,
+        effective_active: (global_hook_count > 0 && repo_policy_enabled)
+            || (project_hook_count > 0 && repo_bundle_materialized),
+        global_hook_installed: global_hook_count > 0,
+        project_hook_installed: project_hook_count > 0,
+        repo_bundle_materialized,
+        duplicate_hook_risk: global_hook_count + project_hook_count > 1,
+        backups_available,
+        project_trust_caveat: project_hook_count > 0,
+        warnings,
+        anti_oracle: "setup status reports activation/config only",
+    })
+}
+
+fn backups_list() -> Result<serde_json::Value> {
+    let paths = resolve_paths()?;
+    let manifest = read_manifest(&paths).unwrap_or_default();
+    Ok(json!({
+        "summary": format!("{} setup backups", manifest.records.len()),
+        "backups": manifest.records,
+    }))
+}
+
+fn backups_restore(args: SetupBackupRestoreArgs) -> Result<serde_json::Value> {
+    if !args.force && !args.dry_run {
+        return Err(Codex1Error::SetupRestore(
+            "setup backups restore requires --force unless --dry-run is used".into(),
+        ));
+    }
+    let paths = resolve_paths()?;
+    let manifest = read_manifest(&paths)?;
+    let record = manifest
+        .records
+        .iter()
+        .find(|record| record.id == args.id)
+        .ok_or_else(|| Codex1Error::SetupRestore(format!("unknown backup id {}", args.id)))?;
+    if !args.dry_run {
+        if record.existed {
+            let backup_path = record.backup_path.as_ref().ok_or_else(|| {
+                Codex1Error::SetupRestore(format!("backup {} has no file path", record.id))
+            })?;
+            if let Some(parent) = record.target_path.parent() {
+                fs::create_dir_all(parent).map_err(|source| {
+                    Codex1Error::SetupRestore(format!(
+                        "failed to create restore parent {}: {source}",
+                        parent.display()
+                    ))
+                })?;
+            }
+            fs::copy(backup_path, &record.target_path).map_err(|source| {
+                Codex1Error::SetupRestore(format!(
+                    "failed to restore {} from {}: {source}",
+                    record.target_path.display(),
+                    backup_path.display()
+                ))
+            })?;
+        } else {
+            match fs::remove_file(&record.target_path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(Codex1Error::SetupRestore(format!(
+                        "failed to restore missing state for {}: {error}",
+                        record.target_path.display()
+                    )))
+                }
+            }
+        }
+    }
+    Ok(json!({
+        "summary": format!("restored setup backup {}", record.id),
+        "restored": record,
+        "dry_run": args.dry_run,
+    }))
+}
+
+fn resolve_repo(repo: Option<PathBuf>) -> Result<PathBuf> {
+    discover_repo_root(repo)
+        .map_err(|error| Codex1Error::SetupArgument(format!("failed to resolve repo: {error}")))
+}
+
+fn resolve_paths() -> Result<SetupPaths> {
+    let home = home_dir()?;
+    let codex_home = match env::var_os("CODEX_HOME") {
+        Some(value) => PathBuf::from(value),
+        None => home.join(".codex"),
+    };
+    let codex1_home = match env::var_os("CODEX1_HOME") {
+        Some(value) => PathBuf::from(value),
+        None => home.join(".codex1"),
+    };
+    Ok(SetupPaths {
+        codex_config: codex_home.join(CONFIG_FILE),
+        codex_home,
+        codex1_config: codex1_home.join(CONFIG_FILE),
+        backups_dir: codex1_home.join("backups"),
+        backup_manifest: codex1_home.join("backups").join("manifest.json"),
+        codex1_home,
+    })
+}
+
+fn home_dir() -> Result<PathBuf> {
+    env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| Codex1Error::SetupArgument("HOME is required for setup".into()))
+}
+
+fn read_policy_or_default(paths: &SetupPaths) -> Result<ActivationPolicy> {
+    match read_policy(paths) {
+        Ok(policy) => Ok(policy),
+        Err(_) if !paths.codex1_config.exists() => Ok(ActivationPolicy::default()),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_policy(paths: &SetupPaths) -> Result<ActivationPolicy> {
+    let text = match fs::read_to_string(&paths.codex1_config) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(ActivationPolicy::default()),
+        Err(error) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "failed to read {}: {error}",
+                paths.codex1_config.display()
+            )))
+        }
+    };
+    parse_policy(&text)
+}
+
+fn parse_policy(text: &str) -> Result<ActivationPolicy> {
+    let doc = text
+        .parse::<DocumentMut>()
+        .map_err(|error| Codex1Error::SetupConfigParse(format!("invalid Codex1 TOML: {error}")))?;
+    let mode = match doc.get("mode").and_then(|value| value.as_str()) {
+        Some("off") => ActivationMode::Off,
+        Some("allowlist") | None => ActivationMode::Allowlist,
+        Some("denylist") => ActivationMode::Denylist,
+        Some("all") => ActivationMode::All,
+        Some(other) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "invalid activation mode {other}"
+            )))
+        }
+    };
+    let mut repos = Vec::new();
+    if let Some(array) = doc
+        .get("repos")
+        .and_then(|value| value.as_array_of_tables())
+    {
+        for table in array {
+            let path = table
+                .get("path")
+                .and_then(|value| value.as_str())
+                .ok_or_else(|| Codex1Error::SetupConfigParse("repo entry missing path".into()))?;
+            let enabled = table
+                .get("enabled")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(true);
+            repos.push(RepoPolicyEntry {
+                path: PathBuf::from(path),
+                enabled,
+            });
+        }
+    }
+    Ok(ActivationPolicy { mode, repos })
+}
+
+fn write_policy(
+    paths: &SetupPaths,
+    policy: &ActivationPolicy,
+    plan: &mut SetupPlan,
+    dry_run: bool,
+) -> Result<()> {
+    plan.writes.push(paths.codex1_config.clone());
+    if dry_run {
+        return Ok(());
+    }
+    backup_target(
+        paths,
+        &paths.codex1_config,
+        "codex1-config",
+        "write policy",
+        plan,
+    )?;
+    if let Some(parent) = paths.codex1_config.parent() {
+        fs::create_dir_all(parent).map_err(|source| {
+            Codex1Error::SetupConfigWrite(format!(
+                "failed to create {}: {source}",
+                parent.display()
+            ))
+        })?;
+    }
+    fs::write(&paths.codex1_config, policy.to_toml()).map_err(|source| {
+        Codex1Error::SetupConfigWrite(format!(
+            "failed to write {}: {source}",
+            paths.codex1_config.display()
+        ))
+    })
+}
+
+fn install_managed_hook(
+    config_path: &Path,
+    plan: &mut SetupPlan,
+    dry_run: bool,
+    reason: &str,
+) -> Result<()> {
+    plan.writes.push(config_path.to_path_buf());
+    if dry_run {
+        return Ok(());
+    }
+    let paths = resolve_paths()?;
+    backup_target(&paths, config_path, "codex-config", reason, plan)?;
+    let mut text = match fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "failed to read {}: {error}",
+                config_path.display()
+            )))
+        }
+    };
+    parse_toml_text(&text)?;
+    text = remove_managed_hook_block(&text);
+    if !text.trim().is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text.push_str(&managed_hook_block()?);
+    parse_toml_text(&text)?;
+    write_text(config_path, &text)
+}
+
+fn remove_managed_hook(
+    config_path: &Path,
+    plan: &mut SetupPlan,
+    dry_run: bool,
+    reason: &str,
+) -> Result<()> {
+    if !config_path.exists() {
+        return Ok(());
+    }
+    let original = fs::read_to_string(config_path).map_err(|source| {
+        Codex1Error::SetupConfigParse(format!(
+            "failed to read {}: {source}",
+            config_path.display()
+        ))
+    })?;
+    let edited = remove_managed_hook_block(&original);
+    if edited == original {
+        return Ok(());
+    }
+    plan.writes.push(config_path.to_path_buf());
+    if dry_run {
+        return Ok(());
+    }
+    let paths = resolve_paths()?;
+    backup_target(&paths, config_path, "codex-config", reason, plan)?;
+    parse_toml_text(&edited)?;
+    write_text(config_path, &edited)
+}
+
+fn managed_hook_count(config_path: &Path) -> usize {
+    let Ok(text) = fs::read_to_string(config_path) else {
+        return 0;
+    };
+    text.matches(MANAGED_HOOK_START).count()
+}
+
+fn managed_hook_block() -> Result<String> {
+    let exe = env::current_exe().io_context("failed to resolve current executable")?;
+    Ok(format!(
+        r#"{MANAGED_HOOK_START}
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "{} ralph stop-hook"
+timeout = 10
+statusMessage = "{MANAGED_HOOK_STATUS}"
+{MANAGED_HOOK_END}
+"#,
+        shell_quote(&exe)
+    ))
+}
+
+fn remove_managed_hook_block(text: &str) -> String {
+    let mut out = String::new();
+    let mut skipping = false;
+    for line in text.lines() {
+        if line.trim() == MANAGED_HOOK_START {
+            skipping = true;
+            continue;
+        }
+        if skipping && line.trim() == MANAGED_HOOK_END {
+            skipping = false;
+            continue;
+        }
+        if !skipping {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn parse_toml_file(path: &Path) -> Result<()> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "failed to read {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    parse_toml_text(&text)
+}
+
+fn parse_toml_text(text: &str) -> Result<()> {
+    text.parse::<DocumentMut>()
+        .map(|_| ())
+        .map_err(|error| Codex1Error::SetupConfigParse(format!("invalid TOML: {error}")))
+}
+
+fn materialize_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
+    let skill = repo.join(BUNDLE_SKILL);
+    let guidance = repo.join(BUNDLE_GUIDANCE);
+    let marker = bundle_marker_path(repo);
+    plan.materialized.push(skill.clone());
+    plan.materialized.push(guidance.clone());
+    plan.writes.push(marker.clone());
+    if dry_run {
+        return Ok(());
+    }
+    write_owned_file(&skill, skill_body())?;
+    write_owned_file(&guidance, guidance_body())?;
+    let marker_body = serde_json::to_string_pretty(&BundleMarker {
+        managed_by: "codex1-managed".to_string(),
+        version: BUNDLE_VERSION,
+        files: vec![BUNDLE_SKILL.into(), BUNDLE_GUIDANCE.into()],
+    })
+    .unwrap();
+    write_owned_file(&marker, &(marker_body + "\n"))?;
+    Ok(())
+}
+
+fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
+    let marker = bundle_marker_path(repo);
+    let marker_text = match fs::read_to_string(&marker) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Codex1Error::SetupBundle(format!(
+                "failed to read {}: {error}",
+                marker.display()
+            )))
+        }
+    };
+    let marker_data: BundleMarker = serde_json::from_str(&marker_text).map_err(|source| {
+        Codex1Error::SetupBundle(format!(
+            "failed to parse bundle marker {}: {source}",
+            marker.display()
+        ))
+    })?;
+    for relative in marker_data.files {
+        let path = repo.join(&relative);
+        plan.removes.push(path.clone());
+        if !dry_run {
+            remove_file_if_owned(&path)?;
+        }
+    }
+    plan.removes.push(marker.clone());
+    if !dry_run {
+        remove_file_if_owned(&marker)?;
+    }
+    Ok(())
+}
+
+fn write_owned_file(path: &Path, body: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| {
+            Codex1Error::SetupBundle(format!("failed to create {}: {source}", parent.display()))
+        })?;
+    }
+    if path.exists() {
+        let existing = fs::read_to_string(path).map_err(|source| {
+            Codex1Error::SetupBundle(format!("failed to read {}: {source}", path.display()))
+        })?;
+        if !existing.contains("codex1-managed") {
+            return Err(Codex1Error::SetupBundle(format!(
+                "refusing to overwrite non-managed file {}",
+                path.display()
+            )));
+        }
+    }
+    fs::write(path, body).map_err(|source| {
+        Codex1Error::SetupBundle(format!("failed to write {}: {source}", path.display()))
+    })
+}
+
+fn remove_file_if_owned(path: &Path) -> Result<()> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Codex1Error::SetupBundle(format!(
+                "failed to read {}: {error}",
+                path.display()
+            )))
+        }
+    };
+    if !text.contains("codex1-managed") {
+        return Err(Codex1Error::SetupBundle(format!(
+            "refusing to remove non-managed file {}",
+            path.display()
+        )));
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(Codex1Error::SetupBundle(format!(
+            "failed to remove {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn skill_body() -> &'static str {
+    r#"---
+name: codex1
+description: codex1-managed setup bundle skill for Codex1 artifact workflows in enabled repositories.
+---
+
+# Codex1
+
+This is a codex1-managed repo-scoped skill. Use Codex1 as a deterministic artifact helper through the `codex1` CLI, Ralph loop state, and the mission artifact conventions documented in this repository.
+
+Setup activation is mechanical. Do not treat setup status as mission truth, task readiness, review pass/fail, proof sufficiency, close readiness, or PRD satisfaction.
+"#
+}
+
+fn guidance_body() -> &'static str {
+    r#"# Codex1 Setup Guidance
+
+codex1-managed
+
+Codex1 is active for this repository when setup status says the bundle is materialized and hook policy allows it. Mission truth remains in human-facing artifacts; setup only controls activation.
+"#
+}
+
+fn bundle_marker_path(repo: &Path) -> PathBuf {
+    repo.join(BUNDLE_MARKER)
+}
+
+fn project_config_path(repo: &Path) -> PathBuf {
+    repo.join(".codex").join(CONFIG_FILE)
+}
+
+fn backup_target(
+    paths: &SetupPaths,
+    target: &Path,
+    target_kind: &str,
+    reason: &str,
+    plan: &mut SetupPlan,
+) -> Result<()> {
+    fs::create_dir_all(&paths.backups_dir).map_err(|source| {
+        Codex1Error::SetupBackup(format!(
+            "failed to create backups dir {}: {source}",
+            paths.backups_dir.display()
+        ))
+    })?;
+    let mut manifest = read_manifest(paths).unwrap_or_default();
+    let id = format!(
+        "{}-{}",
+        Utc::now().format("%Y%m%dT%H%M%S%3fZ"),
+        manifest.records.len() + 1
+    );
+    let existed = target.exists();
+    let backup_path = if existed {
+        let dir = paths.backups_dir.join(&id);
+        fs::create_dir_all(&dir).map_err(|source| {
+            Codex1Error::SetupBackup(format!("failed to create {}: {source}", dir.display()))
+        })?;
+        let backup = dir.join(safe_backup_name(target));
+        fs::copy(target, &backup).map_err(|source| {
+            Codex1Error::SetupBackup(format!(
+                "failed to back up {} to {}: {source}",
+                target.display(),
+                backup.display()
+            ))
+        })?;
+        Some(backup)
+    } else {
+        None
+    };
+    let record = BackupRecord {
+        id,
+        timestamp: Utc::now().to_rfc3339(),
+        target_kind: target_kind.to_string(),
+        target_path: target.to_path_buf(),
+        target_path_label: target.display().to_string(),
+        backup_path: backup_path.clone(),
+        existed,
+        reason: reason.to_string(),
+    };
+    manifest.records.push(record);
+    write_manifest(paths, &manifest)?;
+    if let Some(path) = backup_path {
+        plan.backups.push(path);
+    } else {
+        plan.backups.push(target.to_path_buf());
+    }
+    Ok(())
+}
+
+fn read_manifest(paths: &SetupPaths) -> Result<BackupManifest> {
+    let text = match fs::read_to_string(&paths.backup_manifest) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(BackupManifest::default()),
+        Err(error) => {
+            return Err(Codex1Error::SetupBackup(format!(
+                "failed to read backup manifest {}: {error}",
+                paths.backup_manifest.display()
+            )))
+        }
+    };
+    serde_json::from_str(&text).map_err(|source| {
+        Codex1Error::SetupBackup(format!(
+            "failed to parse backup manifest {}: {source}",
+            paths.backup_manifest.display()
+        ))
+    })
+}
+
+fn write_manifest(paths: &SetupPaths, manifest: &BackupManifest) -> Result<()> {
+    if let Some(parent) = paths.backup_manifest.parent() {
+        fs::create_dir_all(parent).map_err(|source| {
+            Codex1Error::SetupBackup(format!("failed to create {}: {source}", parent.display()))
+        })?;
+    }
+    let text = serde_json::to_string_pretty(manifest).unwrap();
+    fs::write(&paths.backup_manifest, text + "\n").map_err(|source| {
+        Codex1Error::SetupBackup(format!(
+            "failed to write backup manifest {}: {source}",
+            paths.backup_manifest.display()
+        ))
+    })
+}
+
+fn write_text(path: &Path, text: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| {
+            Codex1Error::SetupConfigWrite(format!(
+                "failed to create {}: {source}",
+                parent.display()
+            ))
+        })?;
+    }
+    fs::write(path, text).map_err(|source| {
+        Codex1Error::SetupConfigWrite(format!("failed to write {}: {source}", path.display()))
+    })
+}
+
+fn safe_backup_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or("config")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn toml_escape_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn mode_name(mode: ActivationMode) -> &'static str {
+    match mode {
+        ActivationMode::Off => "off",
+        ActivationMode::Allowlist => "allowlist",
+        ActivationMode::Denylist => "denylist",
+        ActivationMode::All => "all",
+    }
+}
+
+fn shell_quote(path: &Path) -> String {
+    let text = path.display().to_string();
+    format!("'{}'", text.replace('\'', r#"'\''"#))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activation_policy_modes_are_mechanical() {
+        let repo = PathBuf::from("/repo");
+        let mut policy = ActivationPolicy::default();
+        assert!(!policy.effective_for(&repo));
+
+        policy.set_repo(repo.clone(), true);
+        assert!(policy.effective_for(&repo));
+
+        policy.mode = ActivationMode::Off;
+        assert!(!policy.effective_for(&repo));
+
+        policy.mode = ActivationMode::All;
+        assert!(policy.effective_for(&PathBuf::from("/other")));
+
+        policy.mode = ActivationMode::Denylist;
+        policy.set_repo(repo.clone(), false);
+        assert!(!policy.effective_for(&repo));
+        assert!(policy.effective_for(&PathBuf::from("/other")));
+    }
+
+    #[test]
+    fn policy_toml_round_trips_stably() {
+        let mut policy = ActivationPolicy::default();
+        policy.set_repo(PathBuf::from("/tmp/repo"), true);
+        let text = policy.to_toml();
+        assert_eq!(
+            text,
+            "mode = \"allowlist\"\n\n[[repos]]\npath = \"/tmp/repo\"\nenabled = true\n"
+        );
+        assert_eq!(parse_policy(&text).unwrap(), policy);
+    }
+
+    #[test]
+    fn managed_hook_block_removal_preserves_neighbors() {
+        let text = format!(
+            "model = \"x\"\n{MANAGED_HOOK_START}\n[[hooks.Stop]]\n{MANAGED_HOOK_END}\n[other]\na = 1\n"
+        );
+        assert_eq!(
+            remove_managed_hook_block(&text),
+            "model = \"x\"\n[other]\na = 1\n"
+        );
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -24,7 +24,7 @@ const MANAGED_HOOK_START: &str = "# codex1-managed-ralph-start";
 const MANAGED_HOOK_END: &str = "# codex1-managed-ralph-end";
 const MANAGED_HOOK_STATUS: &str = "Codex1 Ralph";
 const BUNDLE_SKILL: &str = ".agents/skills/codex1/SKILL.md";
-const BUNDLE_GUIDANCE: &str = ".codex1/setup-guidance.md";
+const BUNDLE_GUIDANCE: &str = "AGENTS.md";
 const BUNDLE_MARKER: &str = ".codex1/setup-bundle.json";
 const MANAGED_BUNDLE_FILES: [&str; 2] = [BUNDLE_SKILL, BUNDLE_GUIDANCE];
 
@@ -98,7 +98,7 @@ impl ActivationPolicy {
             ActivationMode::Off => false,
             ActivationMode::Allowlist => explicit.unwrap_or(false),
             ActivationMode::Denylist => explicit.unwrap_or(true),
-            ActivationMode::All => explicit.unwrap_or(true),
+            ActivationMode::All => true,
         }
     }
 
@@ -109,6 +109,13 @@ impl ActivationPolicy {
             enabled,
         });
         self.repos.sort_by(|left, right| left.path.cmp(&right.path));
+    }
+
+    fn disable_repo(&mut self, repo: PathBuf) {
+        if matches!(self.mode, ActivationMode::All) {
+            self.mode = ActivationMode::Denylist;
+        }
+        self.set_repo(repo, false);
     }
 
     fn to_toml(&self) -> String {
@@ -209,15 +216,36 @@ struct BundleMarker {
     files: Vec<String>,
 }
 
-pub fn run(cli_json: bool, command: SetupCommand) -> Result<()> {
+pub fn run(cli_json: bool, global_repo: Option<PathBuf>, command: SetupCommand) -> Result<()> {
     match command {
-        SetupCommand::Install(args) => emit(cli_json, install(args)?),
-        SetupCommand::Enable(args) => emit(cli_json, enable(args)?),
-        SetupCommand::Disable(args) => emit(cli_json, disable(args)?),
-        SetupCommand::Uninstall(args) => emit(cli_json, uninstall(args)?),
-        SetupCommand::Migrate(args) => emit(cli_json, migrate(args)?),
-        SetupCommand::Status(args) => emit(cli_json, status_value(args.repo)?),
-        SetupCommand::Doctor(args) => emit(cli_json, doctor(args.repo)?),
+        SetupCommand::Install(mut args) => {
+            args.repo = args.repo.or_else(|| global_repo.clone());
+            emit(cli_json, install(args)?)
+        }
+        SetupCommand::Enable(mut args) => {
+            args.repo = args.repo.or_else(|| global_repo.clone());
+            emit(cli_json, enable(args)?)
+        }
+        SetupCommand::Disable(mut args) => {
+            args.repo = args.repo.or_else(|| global_repo.clone());
+            emit(cli_json, disable(args)?)
+        }
+        SetupCommand::Uninstall(mut args) => {
+            args.repo = args.repo.or_else(|| global_repo.clone());
+            emit(cli_json, uninstall(args)?)
+        }
+        SetupCommand::Migrate(mut args) => {
+            args.repo = args.repo.or_else(|| global_repo.clone());
+            emit(cli_json, migrate(args)?)
+        }
+        SetupCommand::Status(mut args) => {
+            args.repo = args.repo.or_else(|| global_repo.clone());
+            emit(cli_json, status_value(args.repo)?)
+        }
+        SetupCommand::Doctor(mut args) => {
+            args.repo = args.repo.or_else(|| global_repo.clone());
+            emit(cli_json, doctor(args.repo)?)
+        }
         SetupCommand::Backups { command } => match command {
             SetupBackupsCommand::List => emit(cli_json, backups_list()?),
             SetupBackupsCommand::Restore(args) => emit(cli_json, backups_restore(args)?),
@@ -226,8 +254,11 @@ pub fn run(cli_json: bool, command: SetupCommand) -> Result<()> {
 }
 
 pub fn ralph_should_scan_repo(repo: &Path, project_hook: bool) -> bool {
-    if project_hook {
+    if env::var_os("CODEX1_DOCTOR_SMOKE").is_some() {
         return true;
+    }
+    if project_hook {
+        return repo_bundle_materialized(repo);
     }
     let Ok(paths) = resolve_paths() else {
         return false;
@@ -238,7 +269,28 @@ pub fn ralph_should_scan_repo(repo: &Path, project_hook: bool) -> bool {
     let Ok(policy) = read_policy(&paths) else {
         return false;
     };
-    policy.effective_for(repo)
+    global_policy_should_scan_repo(&policy, repo)
+}
+
+fn global_policy_should_scan_repo(policy: &ActivationPolicy, repo: &Path) -> bool {
+    if !policy.effective_for(repo) {
+        return false;
+    }
+    match policy.mode {
+        ActivationMode::Off => false,
+        ActivationMode::Allowlist => repo_bundle_materialized(repo),
+        ActivationMode::Denylist | ActivationMode::All => true,
+    }
+}
+
+fn known_policy_repos(policy: &ActivationPolicy, fallback: &Path) -> Vec<PathBuf> {
+    let mut repos = vec![fallback.to_path_buf()];
+    for entry in &policy.repos {
+        if !repos.contains(&entry.path) {
+            repos.push(entry.path.clone());
+        }
+    }
+    repos
 }
 
 fn emit(cli_json: bool, data: serde_json::Value) -> Result<()> {
@@ -269,30 +321,51 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
     match scope {
         SetupScope::Global => {
             let mut policy = read_policy_or_default(&paths)?;
+            let cleanup_repos = if matches!(mode, ActivationMode::Off) {
+                known_policy_repos(&policy, &repo)
+            } else {
+                Vec::new()
+            };
             policy.mode = mode;
             if matches!(
                 policy.mode,
-                ActivationMode::Allowlist | ActivationMode::Denylist
+                ActivationMode::Allowlist | ActivationMode::Denylist | ActivationMode::All
             ) {
                 policy.set_repo(repo.clone(), true);
             }
             if policy.effective_for(&repo) {
+                let had_bundle = repo_bundle_materialized(&repo);
+                preflight_materialize_bundle(&repo)?;
                 materialize_bundle(&repo, &mut plan, args.dry_run)?;
-                install_managed_hook(
-                    &paths.codex_config,
-                    SetupScope::Global,
-                    &mut plan,
-                    args.dry_run,
-                    "global hook",
-                )?;
+                if let Err(error) =
+                    write_policy(&paths, &policy, &mut plan, args.dry_run).and_then(|()| {
+                        install_managed_hook(
+                            &paths.codex_config,
+                            SetupScope::Global,
+                            &mut plan,
+                            args.dry_run,
+                            "global hook",
+                        )
+                    })
+                {
+                    if !args.dry_run && !had_bundle {
+                        let _ = remove_bundle(&repo, &mut SetupPlan::new(false), false);
+                    }
+                    return Err(error);
+                }
             } else {
-                remove_bundle(&repo, &mut plan, args.dry_run)?;
+                for repo in cleanup_repos {
+                    remove_bundle(&repo, &mut plan, args.dry_run)?;
+                }
+                if !matches!(mode, ActivationMode::Off) {
+                    remove_bundle(&repo, &mut plan, args.dry_run)?;
+                }
+                write_policy(&paths, &policy, &mut plan, args.dry_run)?;
             }
-            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
         }
         SetupScope::Project => {
-            let project_config = project_config_path(&repo);
-            materialize_bundle(&repo, &mut plan, args.dry_run)?;
+            let project_config = project_config_path_checked(&repo)?;
+            preflight_materialize_bundle(&repo)?;
             install_managed_hook(
                 &project_config,
                 SetupScope::Project,
@@ -300,6 +373,7 @@ fn install(args: SetupInstallArgs) -> Result<serde_json::Value> {
                 args.dry_run,
                 "project hook",
             )?;
+            materialize_bundle(&repo, &mut plan, args.dry_run)?;
         }
     }
     Ok(json!({
@@ -329,15 +403,23 @@ fn enable(args: SetupRepoArgs) -> Result<serde_json::Value> {
         policy.mode = ActivationMode::Allowlist;
     }
     policy.set_repo(repo.clone(), true);
+    let had_bundle = repo_bundle_materialized(&repo);
+    preflight_materialize_bundle(&repo)?;
     materialize_bundle(&repo, &mut plan, args.dry_run)?;
-    install_managed_hook(
-        &paths.codex_config,
-        SetupScope::Global,
-        &mut plan,
-        args.dry_run,
-        "global hook",
-    )?;
-    write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+    if let Err(error) = write_policy(&paths, &policy, &mut plan, args.dry_run).and_then(|()| {
+        install_managed_hook(
+            &paths.codex_config,
+            SetupScope::Global,
+            &mut plan,
+            args.dry_run,
+            "global hook",
+        )
+    }) {
+        if !args.dry_run && !had_bundle {
+            let _ = remove_bundle(&repo, &mut SetupPlan::new(false), false);
+        }
+        return Err(error);
+    }
     Ok(json!({
         "summary": format!("setup enabled for {}", repo.display()),
         "command": "setup enable",
@@ -351,11 +433,11 @@ fn disable(args: SetupRepoArgs) -> Result<serde_json::Value> {
     let paths = resolve_paths()?;
     let mut plan = SetupPlan::new(args.dry_run);
     let mut policy = read_policy_or_default(&paths)?;
-    policy.set_repo(repo.clone(), false);
+    policy.disable_repo(repo.clone());
     write_policy(&paths, &policy, &mut plan, args.dry_run)?;
     remove_bundle(&repo, &mut plan, args.dry_run)?;
     remove_managed_hook(
-        &project_config_path(&repo),
+        &project_config_path_checked(&repo)?,
         &mut plan,
         args.dry_run,
         "project hook",
@@ -379,7 +461,7 @@ fn uninstall(args: SetupUninstallArgs) -> Result<serde_json::Value> {
         }
         SetupScope::Project => {
             remove_managed_hook(
-                &project_config_path(&repo),
+                &project_config_path_checked(&repo)?,
                 &mut plan,
                 args.dry_run,
                 "project hook",
@@ -403,19 +485,29 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
     let target = SetupScope::from_arg(Some(args.to));
     match target {
         SetupScope::Project => {
+            preflight_materialize_bundle(&repo)?;
+            let project_config = project_config_path_checked(&repo)?;
+            let mut policy = read_policy_or_default(&paths)?;
+            policy.disable_repo(repo.clone());
             install_managed_hook(
-                &project_config_path(&repo),
+                &project_config,
                 SetupScope::Project,
                 &mut plan,
                 args.dry_run,
                 "project hook",
             )?;
             materialize_bundle(&repo, &mut plan, args.dry_run)?;
-            let mut policy = read_policy_or_default(&paths)?;
-            policy.set_repo(repo.clone(), false);
             write_policy(&paths, &policy, &mut plan, args.dry_run)?;
         }
         SetupScope::Global => {
+            preflight_materialize_bundle(&repo)?;
+            let project_config = project_config_path_checked(&repo)?;
+            parse_toml_file(&project_config)?;
+            let mut policy = read_policy_or_default(&paths)?;
+            if matches!(policy.mode, ActivationMode::Off) {
+                policy.mode = ActivationMode::Allowlist;
+            }
+            policy.set_repo(repo.clone(), true);
             install_managed_hook(
                 &paths.codex_config,
                 SetupScope::Global,
@@ -423,19 +515,9 @@ fn migrate(args: SetupMigrateArgs) -> Result<serde_json::Value> {
                 args.dry_run,
                 "global hook",
             )?;
-            let mut policy = read_policy_or_default(&paths)?;
-            if matches!(policy.mode, ActivationMode::Off) {
-                policy.mode = ActivationMode::Allowlist;
-            }
-            policy.set_repo(repo.clone(), true);
-            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
-            remove_managed_hook(
-                &project_config_path(&repo),
-                &mut plan,
-                args.dry_run,
-                "project hook",
-            )?;
             materialize_bundle(&repo, &mut plan, args.dry_run)?;
+            write_policy(&paths, &policy, &mut plan, args.dry_run)?;
+            remove_managed_hook(&project_config, &mut plan, args.dry_run, "project hook")?;
         }
     }
     Ok(json!({
@@ -457,10 +539,14 @@ fn status_value(repo_arg: Option<PathBuf>) -> Result<serde_json::Value> {
 
 fn doctor(repo_arg: Option<PathBuf>) -> Result<serde_json::Value> {
     let status = status(repo_arg)?;
+    let paths = resolve_paths()?;
+    let project_config = project_config_path(&status.repo);
     let checks = vec![
         json!({"name": "codex_config_parseable", "ok": parse_toml_file(&status.codex_config).is_ok()}),
         json!({"name": "codex1_policy_parseable", "ok": status.global_config_parseable}),
-        json!({"name": "global_hook_installed", "ok": status.global_hook_installed}),
+        json!({"name": "backup_manifest_parseable", "ok": read_manifest(&paths).is_ok()}),
+        json!({"name": "global_hook_installed", "ok": status.global_hook_installed || status.project_hook_installed}),
+        json!({"name": "managed_hook_executable", "ok": managed_hook_executable_ok(&status.codex_config) && managed_hook_executable_ok(&project_config)}),
         json!({"name": "repo_bundle_materialized", "ok": status.repo_bundle_materialized}),
         json!({"name": "duplicate_hook_risk", "ok": !status.duplicate_hook_risk}),
     ];
@@ -485,16 +571,17 @@ fn status(repo_arg: Option<PathBuf>) -> Result<SetupStatus> {
         ),
         Err(_) => (ActivationPolicy::default(), true, Vec::new()),
     };
-    let global_hook_count = managed_hook_count(&paths.codex_config);
+    let global_hook_count = managed_hook_count_parseable(&paths.codex_config);
     let project_config = project_config_path(&repo);
-    let project_hook_count = managed_hook_count(&project_config);
-    let repo_bundle_materialized = bundle_marker_path(&repo).exists()
-        && repo.join(BUNDLE_SKILL).is_file()
-        && repo.join(BUNDLE_GUIDANCE).is_file();
+    let project_hook_count = managed_hook_count_parseable(&project_config);
+    let repo_bundle_materialized = repo_bundle_materialized(&repo);
     if project_hook_count > 0 {
         warnings.push("project-local hooks depend on official Codex project trust".to_string());
     }
     let repo_policy_enabled = policy.effective_for(&repo);
+    let effective_active = (global_hook_count > 0
+        && global_policy_should_scan_repo(&policy, &repo))
+        || (project_hook_count > 0 && repo_bundle_materialized);
     let backups_available = read_manifest(&paths)
         .map(|manifest| manifest.records.len())
         .unwrap_or(0);
@@ -507,8 +594,7 @@ fn status(repo_arg: Option<PathBuf>) -> Result<SetupStatus> {
         global_config_parseable,
         activation_mode: policy.mode,
         repo_policy_enabled,
-        effective_active: (global_hook_count > 0 && repo_policy_enabled)
-            || (project_hook_count > 0 && repo_bundle_materialized),
+        effective_active,
         global_hook_installed: global_hook_count > 0,
         project_hook_installed: project_hook_count > 0,
         repo_bundle_materialized,
@@ -522,7 +608,7 @@ fn status(repo_arg: Option<PathBuf>) -> Result<SetupStatus> {
 
 fn backups_list() -> Result<serde_json::Value> {
     let paths = resolve_paths()?;
-    let manifest = read_manifest(&paths).unwrap_or_default();
+    let manifest = read_manifest(&paths)?;
     Ok(json!({
         "summary": format!("{} setup backups", manifest.records.len()),
         "backups": manifest.records,
@@ -776,6 +862,113 @@ fn managed_hook_count(config_path: &Path) -> usize {
     text.matches(MANAGED_HOOK_START).count()
 }
 
+fn managed_hook_count_parseable(config_path: &Path) -> usize {
+    if parse_toml_file(config_path).is_err() {
+        return 0;
+    }
+    managed_hook_count(config_path)
+}
+
+fn managed_hook_executable_ok(config_path: &Path) -> bool {
+    let Ok(commands) = managed_hook_commands(config_path) else {
+        return false;
+    };
+    if managed_hook_count(config_path) == 0 {
+        return true;
+    }
+    if commands.is_empty() {
+        return false;
+    }
+    commands
+        .iter()
+        .all(|command| hook_command_executable(command).is_some_and(|path| path.is_file()))
+}
+
+fn managed_hook_commands(config_path: &Path) -> Result<Vec<String>> {
+    let text = match fs::read_to_string(config_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(Codex1Error::SetupConfigParse(format!(
+                "failed to read {}: {error}",
+                config_path.display()
+            )))
+        }
+    };
+    let mut commands = Vec::new();
+    let mut scanning = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == MANAGED_HOOK_START {
+            scanning = true;
+            continue;
+        }
+        if trimmed == MANAGED_HOOK_END {
+            scanning = false;
+            continue;
+        }
+        if !scanning {
+            continue;
+        }
+        let Some(rhs) = trimmed
+            .strip_prefix("command")
+            .and_then(|rest| rest.trim_start().strip_prefix('=').map(str::trim_start))
+        else {
+            continue;
+        };
+        let snippet = format!("value = {rhs}\n");
+        let doc = snippet.parse::<DocumentMut>().map_err(|error| {
+            Codex1Error::SetupConfigParse(format!("invalid managed hook command: {error}"))
+        })?;
+        let command = doc
+            .get("value")
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| {
+                Codex1Error::SetupConfigParse("managed hook command must be a string".into())
+            })?;
+        commands.push(command.to_string());
+    }
+    Ok(commands)
+}
+
+fn hook_command_executable(command: &str) -> Option<PathBuf> {
+    let command = command.trim_start();
+    if let Some(rest) = command.strip_prefix('\'') {
+        return posix_single_quoted_word(rest).map(PathBuf::from);
+    }
+    if let Some(rest) = command.strip_prefix('"') {
+        let mut path = String::new();
+        let mut chars = rest.chars().peekable();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '"' => return Some(PathBuf::from(path)),
+                '\\' if chars.peek() == Some(&'"') => {
+                    chars.next();
+                    path.push('"');
+                }
+                ch => path.push(ch),
+            }
+        }
+        return None;
+    }
+    command.split_whitespace().next().map(PathBuf::from)
+}
+
+fn posix_single_quoted_word(mut rest: &str) -> Option<String> {
+    let mut word = String::new();
+    loop {
+        let end = rest.find('\'')?;
+        word.push_str(&rest[..end]);
+        rest = &rest[end + 1..];
+        if let Some(next) = rest.strip_prefix("\\''") {
+            word.push('\'');
+            rest = next;
+            continue;
+        }
+        return Some(word);
+    }
+}
+
 fn managed_hook_block(scope: SetupScope) -> Result<String> {
     let exe = env::current_exe().io_context("failed to resolve current executable")?;
     Ok(managed_hook_block_for_command(&hook_command_for_exe(
@@ -800,12 +993,51 @@ statusMessage = "{MANAGED_HOOK_STATUS}"
 }
 
 fn hook_command_for_exe(exe: &Path, scope: SetupScope) -> String {
+    #[cfg(windows)]
+    let shell = CommandShell::WindowsCmd;
+    #[cfg(not(windows))]
+    let shell = CommandShell::PosixSh;
+    hook_command_for_exe_with_shell(exe, scope, shell)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+enum CommandShell {
+    PosixSh,
+    WindowsCmd,
+}
+
+fn hook_command_for_exe_with_shell(exe: &Path, scope: SetupScope, shell: CommandShell) -> String {
     let scope_arg = match scope {
         SetupScope::Global => "global",
         SetupScope::Project => "project",
     };
-    let exe = exe.display().to_string().replace('"', "\\\"");
-    format!("\"{exe}\" ralph stop-hook --scope {scope_arg}")
+    format!(
+        "{} ralph stop-hook --scope {scope_arg}",
+        shell_escape_exe(exe, shell)
+    )
+}
+
+fn shell_escape_exe(exe: &Path, shell: CommandShell) -> String {
+    let text = exe.display().to_string();
+    match shell {
+        CommandShell::PosixSh => format!("'{}'", text.replace('\'', r#"'\''"#)),
+        CommandShell::WindowsCmd => {
+            let mut out = String::from("\"");
+            for ch in text.chars() {
+                match ch {
+                    '^' | '%' | '!' => {
+                        out.push('^');
+                        out.push(ch);
+                    }
+                    '"' => out.push_str("\\\""),
+                    c => out.push(c),
+                }
+            }
+            out.push('"');
+            out
+        }
+    }
 }
 
 fn remove_managed_hook_block(text: &str) -> Result<String> {
@@ -858,6 +1090,58 @@ fn parse_toml_text(text: &str) -> Result<()> {
         .map_err(|error| Codex1Error::SetupConfigParse(format!("invalid TOML: {error}")))
 }
 
+fn repo_bundle_materialized(repo: &Path) -> bool {
+    validate_bundle(repo).is_ok()
+}
+
+fn validate_bundle(repo: &Path) -> Result<()> {
+    let marker = repo_bundle_target(repo, BUNDLE_MARKER)?;
+    let marker_text = fs::read_to_string(&marker).map_err(|source| {
+        Codex1Error::SetupBundle(format!(
+            "failed to read bundle marker {}: {source}",
+            marker.display()
+        ))
+    })?;
+    let marker_data = parse_bundle_marker(&marker, &marker_text)?;
+    if marker_data.files != MANAGED_BUNDLE_FILES.map(String::from) {
+        return Err(Codex1Error::SetupBundle(format!(
+            "bundle marker has unexpected files {}",
+            marker.display()
+        )));
+    }
+    for relative in MANAGED_BUNDLE_FILES {
+        let path = repo_bundle_target(repo, relative)?;
+        let text = fs::read_to_string(&path).map_err(|source| {
+            Codex1Error::SetupBundle(format!("failed to read {}: {source}", path.display()))
+        })?;
+        if text != expected_bundle_body(relative) {
+            return Err(Codex1Error::SetupBundle(format!(
+                "invalid managed bundle file {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn preflight_materialize_bundle(repo: &Path) -> Result<()> {
+    for relative in [BUNDLE_SKILL, BUNDLE_GUIDANCE, BUNDLE_MARKER] {
+        let path = repo_bundle_target(repo, relative)?;
+        if path.exists() {
+            let existing = fs::read_to_string(&path).map_err(|source| {
+                Codex1Error::SetupBundle(format!("failed to read {}: {source}", path.display()))
+            })?;
+            if existing != expected_bundle_body(relative) {
+                return Err(Codex1Error::SetupBundle(format!(
+                    "refusing to overwrite non-managed file {}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn materialize_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
     let skill = repo_bundle_target(repo, BUNDLE_SKILL)?;
     let guidance = repo_bundle_target(repo, BUNDLE_GUIDANCE)?;
@@ -870,13 +1154,7 @@ fn materialize_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Resul
     }
     write_owned_file(repo, &skill, skill_body())?;
     write_owned_file(repo, &guidance, guidance_body())?;
-    let marker_body = serde_json::to_string_pretty(&BundleMarker {
-        managed_by: "codex1-managed".to_string(),
-        version: BUNDLE_VERSION,
-        files: vec![BUNDLE_SKILL.into(), BUNDLE_GUIDANCE.into()],
-    })
-    .unwrap();
-    write_owned_file(repo, &marker, &(marker_body + "\n"))?;
+    write_owned_file(repo, &marker, &bundle_marker_body())?;
     Ok(())
 }
 
@@ -884,7 +1162,9 @@ fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()>
     let marker = repo_bundle_target(repo, BUNDLE_MARKER)?;
     let marker_text = match fs::read_to_string(&marker) {
         Ok(text) => text,
-        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return remove_known_bundle_files(repo, plan, dry_run);
+        }
         Err(error) => {
             return Err(Codex1Error::SetupBundle(format!(
                 "failed to read {}: {error}",
@@ -892,12 +1172,7 @@ fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()>
             )))
         }
     };
-    let marker_data: BundleMarker = serde_json::from_str(&marker_text).map_err(|source| {
-        Codex1Error::SetupBundle(format!(
-            "failed to parse bundle marker {}: {source}",
-            marker.display()
-        ))
-    })?;
+    let marker_data = parse_bundle_marker(&marker, &marker_text)?;
     if marker_data.managed_by != "codex1-managed" || marker_data.version != BUNDLE_VERSION {
         return Err(Codex1Error::SetupBundle(format!(
             "invalid Codex1 bundle marker {}",
@@ -914,12 +1189,45 @@ fn remove_bundle(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()>
         let path = repo_bundle_target(repo, &relative)?;
         plan.removes.push(path.clone());
         if !dry_run {
-            remove_file_if_owned(repo, &path)?;
+            remove_file_if_owned(repo, &path, &expected_bundle_body(&relative))?;
         }
     }
     plan.removes.push(marker.clone());
     if !dry_run {
-        remove_file_if_owned(repo, &marker)?;
+        remove_file_if_owned(repo, &marker, &bundle_marker_body())?;
+    }
+    Ok(())
+}
+
+fn parse_bundle_marker(marker: &Path, marker_text: &str) -> Result<BundleMarker> {
+    serde_json::from_str(marker_text).map_err(|source| {
+        Codex1Error::SetupBundle(format!(
+            "failed to parse bundle marker {}: {source}",
+            marker.display()
+        ))
+    })
+}
+
+fn remove_known_bundle_files(repo: &Path, plan: &mut SetupPlan, dry_run: bool) -> Result<()> {
+    for relative in MANAGED_BUNDLE_FILES {
+        let path = repo_bundle_target(repo, relative)?;
+        let text = match fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(Codex1Error::SetupBundle(format!(
+                    "failed to read {}: {error}",
+                    path.display()
+                )))
+            }
+        };
+        if text != expected_bundle_body(relative) {
+            continue;
+        }
+        plan.removes.push(path.clone());
+        if !dry_run {
+            remove_file_if_owned(repo, &path, &expected_bundle_body(relative))?;
+        }
     }
     Ok(())
 }
@@ -966,7 +1274,7 @@ fn write_owned_file(repo: &Path, path: &Path, body: &str) -> Result<()> {
         let existing = fs::read_to_string(path).map_err(|source| {
             Codex1Error::SetupBundle(format!("failed to read {}: {source}", path.display()))
         })?;
-        if !existing.contains("codex1-managed") {
+        if existing != body {
             return Err(Codex1Error::SetupBundle(format!(
                 "refusing to overwrite non-managed file {}",
                 path.display()
@@ -978,7 +1286,7 @@ fn write_owned_file(repo: &Path, path: &Path, body: &str) -> Result<()> {
     })
 }
 
-fn remove_file_if_owned(repo: &Path, path: &Path) -> Result<()> {
+fn remove_file_if_owned(repo: &Path, path: &Path, expected: &str) -> Result<()> {
     ensure_contained_for_write(repo, path).map_err(|error| {
         Codex1Error::SetupBundle(format!(
             "bundle path escapes repo or crosses a symlink: {}: {error}",
@@ -995,7 +1303,7 @@ fn remove_file_if_owned(repo: &Path, path: &Path) -> Result<()> {
             )))
         }
     };
-    if !text.contains("codex1-managed") {
+    if text != expected {
         return Err(Codex1Error::SetupBundle(format!(
             "refusing to remove non-managed file {}",
             path.display()
@@ -1009,6 +1317,25 @@ fn remove_file_if_owned(repo: &Path, path: &Path) -> Result<()> {
             path.display()
         ))),
     }
+}
+
+fn expected_bundle_body(relative: &str) -> String {
+    match relative {
+        BUNDLE_SKILL => skill_body().to_string(),
+        BUNDLE_GUIDANCE => guidance_body().to_string(),
+        BUNDLE_MARKER => bundle_marker_body(),
+        _ => String::new(),
+    }
+}
+
+fn bundle_marker_body() -> String {
+    let marker_body = serde_json::to_string_pretty(&BundleMarker {
+        managed_by: "codex1-managed".to_string(),
+        version: BUNDLE_VERSION,
+        files: vec![BUNDLE_SKILL.into(), BUNDLE_GUIDANCE.into()],
+    })
+    .unwrap();
+    marker_body + "\n"
 }
 
 fn skill_body() -> &'static str {
@@ -1034,12 +1361,19 @@ Codex1 is active for this repository when setup status says the bundle is materi
 "#
 }
 
-fn bundle_marker_path(repo: &Path) -> PathBuf {
-    repo.join(BUNDLE_MARKER)
-}
-
 fn project_config_path(repo: &Path) -> PathBuf {
     repo.join(".codex").join(CONFIG_FILE)
+}
+
+fn project_config_path_checked(repo: &Path) -> Result<PathBuf> {
+    let path = project_config_path(repo);
+    ensure_contained_for_write(repo, &path).map_err(|error| {
+        Codex1Error::SetupConfigWrite(format!(
+            "project config path escapes repo or crosses a symlink: {}: {error}",
+            path.display()
+        ))
+    })?;
+    Ok(path)
 }
 
 fn backup_target(
@@ -1055,7 +1389,7 @@ fn backup_target(
             paths.backups_dir.display()
         ))
     })?;
-    let mut manifest = read_manifest(paths).unwrap_or_default();
+    let mut manifest = read_manifest(paths)?;
     let id = format!(
         "{}-{}",
         Utc::now().format("%Y%m%dT%H%M%S%3fZ"),
@@ -1251,13 +1585,57 @@ mod tests {
 
     #[test]
     fn hook_command_is_toml_escaped_for_windows_paths() {
-        let command =
-            hook_command_for_exe(Path::new(r"C:\Users\me\codex1.exe"), SetupScope::Global);
+        let command = hook_command_for_exe_with_shell(
+            Path::new(r"C:\Users\me\codex1.exe"),
+            SetupScope::Global,
+            CommandShell::WindowsCmd,
+        );
         assert_eq!(
             toml_string(&command),
             r#""\"C:\\Users\\me\\codex1.exe\" ralph stop-hook --scope global""#
         );
         let block = managed_hook_block_for_command(&command);
         parse_toml_text(&block).unwrap();
+    }
+
+    #[test]
+    fn hook_command_shell_quotes_posix_metacharacters() {
+        let command = hook_command_for_exe_with_shell(
+            Path::new("/tmp/codex $`thing'/codex1"),
+            SetupScope::Project,
+            CommandShell::PosixSh,
+        );
+        assert_eq!(
+            command,
+            r#"'/tmp/codex $`thing'\''/codex1' ralph stop-hook --scope project"#
+        );
+        let block = managed_hook_block_for_command(&command);
+        parse_toml_text(&block).unwrap();
+    }
+
+    #[test]
+    fn hook_command_executable_parses_posix_quoted_path() {
+        let command = hook_command_for_exe_with_shell(
+            Path::new("/tmp/codex $`thing'/codex1"),
+            SetupScope::Project,
+            CommandShell::PosixSh,
+        );
+        assert_eq!(
+            hook_command_executable(&command).unwrap(),
+            PathBuf::from("/tmp/codex $`thing'/codex1")
+        );
+    }
+
+    #[test]
+    fn hook_command_executable_preserves_windows_backslashes() {
+        let command = hook_command_for_exe_with_shell(
+            Path::new(r"C:\Users\me\codex1.exe"),
+            SetupScope::Global,
+            CommandShell::WindowsCmd,
+        );
+        assert_eq!(
+            hook_command_executable(&command).unwrap(),
+            PathBuf::from(r"C:\Users\me\codex1.exe")
+        );
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -321,6 +321,63 @@ fn setup_dry_run_does_not_write_files() {
 }
 
 #[test]
+fn setup_enable_dry_run_bootstraps_same_plan_as_real_enable() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let value = json_output(
+        command
+            .args(["--json", "setup", "enable", "--dry-run", "--repo"])
+            .arg(repo.path()),
+    );
+    let writes = value["data"]["plan"]["writes"].as_array().unwrap();
+    assert!(writes
+        .iter()
+        .any(|path| path.as_str().unwrap().ends_with("codex-home/config.toml")));
+    assert!(writes
+        .iter()
+        .any(|path| path.as_str().unwrap().ends_with("codex1-home/config.toml")));
+    assert!(!home.path().join("codex-home/config.toml").exists());
+}
+
+#[test]
+fn setup_install_off_does_not_materialize_repo_bundle() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let value = json_output(
+        command
+            .args(["--json", "setup", "install", "--mode", "off", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["activation_mode"], "off");
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!repo.path().join(".codex1/setup-guidance.md").exists());
+}
+
+#[test]
+fn setup_project_install_rejects_mode_off() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args([
+            "--json", "setup", "install", "--scope", "project", "--mode", "off", "--repo",
+        ])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_ARGUMENT_ERROR");
+    assert!(!repo.path().join(".codex/config.toml").exists());
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[test]
 fn setup_disable_removes_bundle_without_deleting_mission_artifacts() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -346,6 +403,133 @@ fn setup_disable_removes_bundle_without_deleting_mission_artifacts() {
     assert_eq!(value["ok"], true);
     assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
     assert!(mission_prd.is_file());
+}
+
+#[test]
+fn setup_disable_rejects_tampered_bundle_marker_paths_outside_repo() {
+    let repo = repo();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside.path(), "codex1-managed outside").unwrap();
+    fs::create_dir_all(repo.path().join(".codex1")).unwrap();
+    fs::write(
+        repo.path().join(".codex1/setup-bundle.json"),
+        format!(
+            r#"{{
+  "managed_by": "codex1-managed",
+  "version": 1,
+  "files": ["{}"]
+}}"#,
+            outside.path().display()
+        ),
+    )
+    .unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    let output = disable
+        .args(["--json", "setup", "disable", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_BUNDLE_ERROR");
+    assert!(outside.path().exists());
+}
+
+#[test]
+fn setup_disable_rejects_tampered_marker_for_unmanaged_repo_file() {
+    let repo = repo();
+    let user_file = repo.path().join("notes.md");
+    fs::write(&user_file, "user text mentioning codex1-managed").unwrap();
+    fs::create_dir_all(repo.path().join(".codex1")).unwrap();
+    fs::write(
+        repo.path().join(".codex1/setup-bundle.json"),
+        r#"{
+  "managed_by": "codex1-managed",
+  "version": 1,
+  "files": ["notes.md"]
+}"#,
+    )
+    .unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    let output = disable
+        .args(["--json", "setup", "disable", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_BUNDLE_ERROR");
+    assert!(user_file.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_install_rejects_symlinked_repo_bundle_roots() {
+    let repo = repo();
+    let outside = tempfile::tempdir().unwrap();
+    symlink(outside.path(), repo.path().join(".agents")).unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_BUNDLE_ERROR");
+    assert!(!outside.path().join("skills/codex1/SKILL.md").exists());
+}
+
+#[test]
+fn setup_enable_reinstalls_missing_global_hook_for_existing_policy() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut uninstall = bin();
+    setup_env(&mut uninstall, &home);
+    json_output(
+        uninstall
+            .args([
+                "--json",
+                "setup",
+                "uninstall",
+                "--scope",
+                "global",
+                "--repo",
+            ])
+            .arg(repo.path()),
+    );
+    assert!(
+        !fs::read_to_string(home.path().join("codex-home/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
+
+    let mut enable = bin();
+    setup_env(&mut enable, &home);
+    json_output(
+        enable
+            .args(["--json", "setup", "enable", "--repo"])
+            .arg(repo.path()),
+    );
+    assert!(
+        fs::read_to_string(home.path().join("codex-home/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
 }
 
 #[test]
@@ -460,6 +644,83 @@ fn ralph_obeys_setup_activation_policy_and_fails_open() {
         "{}".to_string(),
     );
     assert!(malformed_allowed.get("decision").is_none());
+}
+
+#[test]
+fn project_scope_ralph_ignores_global_disable_after_migration() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut migrate = bin();
+    setup_env(&mut migrate, &home);
+    json_output(
+        migrate
+            .args(["--json", "setup", "migrate", "--to", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut start = bin();
+    setup_env(&mut start, &home);
+    json_output(
+        start
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "loop",
+                "start",
+                "--mode",
+                "autopilot",
+                "--message",
+                "Keep going",
+            ]),
+    );
+
+    let mut global_hook = bin();
+    setup_env(&mut global_hook, &home);
+    let global_allowed = json_output_with_stdin(
+        global_hook
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "ralph",
+                "stop-hook",
+                "--scope",
+                "global",
+            ]),
+        "{}".to_string(),
+    );
+    assert!(global_allowed.get("decision").is_none());
+
+    let mut project_hook = bin();
+    setup_env(&mut project_hook, &home);
+    let project_blocked = json_output_with_stdin(
+        project_hook
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "ralph",
+                "stop-hook",
+                "--scope",
+                "project",
+            ]),
+        "{}".to_string(),
+    );
+    assert_eq!(project_blocked["decision"], "block");
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,13 +14,38 @@ use tempfile::TempDir;
 use std::os::unix::fs::symlink;
 
 fn bin() -> Command {
-    Command::cargo_bin("codex1").unwrap()
+    let mut command = Command::cargo_bin("codex1").unwrap();
+    let base = std::env::temp_dir().join(format!("codex1-test-home-{}", std::process::id()));
+    let home = base.join("home");
+    let codex_home = base.join("codex-home");
+    let codex1_home = base.join("codex1-home");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&codex_home).unwrap();
+    fs::create_dir_all(&codex1_home).unwrap();
+    command
+        .env("HOME", home)
+        .env("CODEX_HOME", codex_home)
+        .env("CODEX1_HOME", codex1_home);
+    command
 }
 
 fn repo() -> TempDir {
     let dir = tempfile::tempdir().unwrap();
     fs::create_dir(dir.path().join(".git")).unwrap();
     dir
+}
+
+fn setup_env(command: &mut Command, home: &TempDir) {
+    let user_home = home.path().join("home");
+    let codex_home = home.path().join("codex-home");
+    let codex1_home = home.path().join("codex1-home");
+    fs::create_dir_all(&user_home).unwrap();
+    fs::create_dir_all(&codex_home).unwrap();
+    fs::create_dir_all(&codex1_home).unwrap();
+    command
+        .env("HOME", user_home)
+        .env("CODEX_HOME", codex_home)
+        .env("CODEX1_HOME", codex1_home);
 }
 
 fn json_output(command: &mut Command) -> Value {
@@ -178,6 +203,388 @@ fn leading_hyphen_mission_id_is_rejected() {
         .assert()
         .failure()
         .stdout(predicate::str::contains("MISSION_PATH_ERROR"));
+}
+
+#[test]
+fn setup_status_reports_activation_only() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "status", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let text = String::from_utf8(output.stdout).unwrap();
+    for forbidden in [
+        "next_action",
+        "task_status",
+        "review_passed",
+        "proof_sufficient",
+        "close_ready",
+        "prd_satisfied",
+    ] {
+        assert!(
+            !text.contains(forbidden),
+            "{forbidden} leaked into setup status"
+        );
+    }
+    let value: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+    assert_eq!(
+        value["data"]["status"]["anti_oracle"],
+        "setup status reports activation/config only"
+    );
+}
+
+#[test]
+fn setup_install_default_enables_only_target_repo_with_backups_and_bundle() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex_home = home.path().join("codex-home");
+    fs::create_dir_all(&codex_home).unwrap();
+    fs::write(codex_home.join("config.toml"), "model = \"gpt-test\"\n").unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    let value = json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["data"]["activation_mode"], "allowlist");
+
+    let codex_config = fs::read_to_string(codex_home.join("config.toml")).unwrap();
+    assert!(codex_config.contains("model = \"gpt-test\""));
+    assert!(codex_config.contains("codex1-managed-ralph-start"));
+    assert!(codex_config.contains("ralph stop-hook"));
+
+    let codex1_config = fs::read_to_string(home.path().join("codex1-home/config.toml")).unwrap();
+    assert!(codex1_config.contains("mode = \"allowlist\""));
+    assert!(codex1_config.contains(&repo.path().canonicalize().unwrap().display().to_string()));
+    assert!(!codex1_config.contains(
+        &other_repo
+            .path()
+            .canonicalize()
+            .unwrap()
+            .display()
+            .to_string()
+    ));
+
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").is_file());
+    assert!(repo.path().join(".codex1/setup-guidance.md").is_file());
+    assert!(repo.path().join(".codex1/setup-bundle.json").is_file());
+    assert!(home
+        .path()
+        .join("codex1-home/backups/manifest.json")
+        .is_file());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let active = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(active["data"]["status"]["effective_active"], true);
+
+    let mut other_status = bin();
+    setup_env(&mut other_status, &home);
+    let inactive = json_output(
+        other_status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(other_repo.path()),
+    );
+    assert_eq!(inactive["data"]["status"]["repo_policy_enabled"], false);
+}
+
+#[test]
+fn setup_dry_run_does_not_write_files() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let value = json_output(
+        command
+            .args(["--json", "setup", "install", "--dry-run", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["plan"]["dry_run"], true);
+    assert!(!home.path().join("codex-home/config.toml").exists());
+    assert!(!home.path().join("codex1-home/config.toml").exists());
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[test]
+fn setup_disable_removes_bundle_without_deleting_mission_artifacts() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+    let mission_prd = repo.path().join(".codex1/missions/alpha/PRD.md");
+    fs::write(&mission_prd, "mission truth").unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    let value = json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["ok"], true);
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(mission_prd.is_file());
+}
+
+#[test]
+fn setup_backups_can_restore_existing_and_missing_config_states() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex_home = home.path().join("codex-home");
+    fs::create_dir_all(&codex_home).unwrap();
+    let config = codex_home.join("config.toml");
+    fs::write(&config, "model = \"before\"\n").unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut list = bin();
+    setup_env(&mut list, &home);
+    let backups = json_output(list.args(["--json", "setup", "backups", "list"]));
+    let id = backups["data"]["backups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["target_path"] == config.display().to_string())
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut restore = bin();
+    setup_env(&mut restore, &home);
+    json_output(restore.args(["--json", "setup", "backups", "restore", &id, "--force"]));
+    assert_eq!(fs::read_to_string(&config).unwrap(), "model = \"before\"\n");
+}
+
+#[test]
+fn ralph_obeys_setup_activation_policy_and_fails_open() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut start = bin();
+    setup_env(&mut start, &home);
+    json_output(
+        start
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "loop",
+                "start",
+                "--mode",
+                "autopilot",
+                "--message",
+                "Keep going",
+            ]),
+    );
+
+    let mut ralph_block = bin();
+    setup_env(&mut ralph_block, &home);
+    let blocked = json_output_with_stdin(
+        ralph_block
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "ralph", "stop-hook"]),
+        "{}".to_string(),
+    );
+    assert_eq!(blocked["decision"], "block");
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
+    let mut ralph_disabled = bin();
+    setup_env(&mut ralph_disabled, &home);
+    let allowed = json_output_with_stdin(
+        ralph_disabled
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "ralph", "stop-hook"]),
+        "{}".to_string(),
+    );
+    assert!(allowed.get("decision").is_none());
+
+    fs::write(
+        home.path().join("codex1-home/config.toml"),
+        "mode = [nope\n",
+    )
+    .unwrap();
+    let mut ralph_malformed = bin();
+    setup_env(&mut ralph_malformed, &home);
+    let malformed_allowed = json_output_with_stdin(
+        ralph_malformed
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "ralph", "stop-hook"]),
+        "{}".to_string(),
+    );
+    assert!(malformed_allowed.get("decision").is_none());
+}
+
+#[test]
+fn setup_project_migrate_uninstall_and_enable_flows_are_reversible() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    let project_config = repo.path().join(".codex/config.toml");
+    assert!(fs::read_to_string(&project_config)
+        .unwrap()
+        .contains("codex1-managed-ralph-start"));
+    assert!(!home.path().join("codex-home/config.toml").exists());
+
+    let mut project_status = bin();
+    setup_env(&mut project_status, &home);
+    let status = json_output(
+        project_status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(status["data"]["status"]["effective_active"], true);
+    assert_eq!(status["data"]["status"]["project_trust_caveat"], true);
+
+    let mut migrate_global = bin();
+    setup_env(&mut migrate_global, &home);
+    json_output(
+        migrate_global
+            .args(["--json", "setup", "migrate", "--to", "global", "--repo"])
+            .arg(repo.path()),
+    );
+    assert!(!fs::read_to_string(&project_config)
+        .unwrap_or_default()
+        .contains("codex1-managed-ralph-start"));
+    assert!(
+        fs::read_to_string(home.path().join("codex-home/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
+
+    let mut uninstall_global = bin();
+    setup_env(&mut uninstall_global, &home);
+    json_output(
+        uninstall_global
+            .args([
+                "--json",
+                "setup",
+                "uninstall",
+                "--scope",
+                "global",
+                "--repo",
+            ])
+            .arg(repo.path()),
+    );
+    assert!(
+        !fs::read_to_string(home.path().join("codex-home/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+
+    let mut enable = bin();
+    setup_env(&mut enable, &home);
+    json_output(
+        enable
+            .args(["--json", "setup", "enable", "--repo"])
+            .arg(repo.path()),
+    );
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(
+        fs::read_to_string(home.path().join("codex1-home/config.toml"))
+            .unwrap()
+            .contains("enabled = true")
+    );
+}
+
+#[test]
+fn setup_restore_can_restore_a_previously_missing_file_to_absence() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex1_config = home.path().join("codex1-home/config.toml");
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    assert!(codex1_config.exists());
+
+    let mut list = bin();
+    setup_env(&mut list, &home);
+    let backups = json_output(list.args(["--json", "setup", "backups", "list"]));
+    let id = backups["data"]["backups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| {
+            record["target_path"] == codex1_config.display().to_string()
+                && record["existed"] == false
+        })
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut restore = bin();
+    setup_env(&mut restore, &home);
+    json_output(restore.args(["--json", "setup", "backups", "restore", &id, "--force"]));
+    assert!(!codex1_config.exists());
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -48,6 +48,16 @@ fn setup_env(command: &mut Command, home: &TempDir) {
         .env("CODEX1_HOME", codex1_home);
 }
 
+fn setup_install_repo(repo: &TempDir, home: &TempDir) {
+    let mut command = bin();
+    setup_env(&mut command, home);
+    json_output(
+        command
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+}
+
 fn json_output(command: &mut Command) -> Value {
     let output = command.output().unwrap();
     assert!(
@@ -519,6 +529,28 @@ fn setup_install_does_not_leave_global_hook_when_policy_write_fails() {
 }
 
 #[test]
+fn setup_install_does_not_leave_policy_when_global_hook_config_is_malformed() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex_config = home.path().join("codex-home/config.toml");
+    fs::create_dir_all(codex_config.parent().unwrap()).unwrap();
+    fs::write(&codex_config, "model = [nope\n").unwrap();
+
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_CONFIG_PARSE_ERROR");
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!home.path().join("codex1-home/config.toml").exists());
+}
+
+#[test]
 fn setup_dry_run_does_not_write_files() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -614,6 +646,83 @@ fn setup_install_off_removes_bundles_for_known_policy_repos() {
 }
 
 #[test]
+fn setup_install_off_removes_project_scoped_setup_for_target_repo() {
+    let project_repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&project_repo, "alpha");
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(project_repo.path()),
+    );
+    assert!(project_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+    assert!(
+        fs::read_to_string(project_repo.path().join(".codex/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
+
+    let mut off = bin();
+    setup_env(&mut off, &home);
+    json_output(
+        off.args(["--json", "setup", "install", "--mode", "off", "--repo"])
+            .arg(project_repo.path()),
+    );
+
+    assert!(!project_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+    assert!(
+        !fs::read_to_string(project_repo.path().join(".codex/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
+
+    let mut start = bin();
+    setup_env(&mut start, &home);
+    json_output(
+        start
+            .args(["--json", "--repo-root"])
+            .arg(project_repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "loop",
+                "start",
+                "--mode",
+                "autopilot",
+                "--message",
+                "Keep going",
+            ]),
+    );
+
+    let mut ralph = bin();
+    setup_env(&mut ralph, &home);
+    let allowed = json_output_with_stdin(
+        ralph
+            .args(["--json", "--repo-root"])
+            .arg(project_repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "ralph",
+                "stop-hook",
+                "--scope",
+                "project",
+            ]),
+        "{}".to_string(),
+    );
+    assert!(allowed.get("decision").is_none());
+}
+
+#[test]
 fn setup_project_install_rejects_mode_off() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -631,6 +740,21 @@ fn setup_project_install_rejects_mode_off() {
     assert_eq!(value["error"]["code"], "SETUP_ARGUMENT_ERROR");
     assert!(!repo.path().join(".codex/config.toml").exists());
     assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[test]
+fn setup_resolves_codex_homes_without_home() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    command.env_remove("HOME");
+    let value = json_output(
+        command
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], false);
 }
 
 #[cfg(unix)]
@@ -706,6 +830,65 @@ fn setup_project_install_preflights_bundle_before_hook_write() {
         fs::read_to_string(repo.path().join(".agents/skills/codex1/SKILL.md")).unwrap(),
         "user-authored skill that says codex1-managed"
     );
+}
+
+#[test]
+fn setup_project_install_failure_preserves_global_activation() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut global_install = bin();
+    setup_env(&mut global_install, &home);
+    json_output(
+        global_install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    fs::create_dir_all(repo.path().join(".codex")).unwrap();
+    fs::write(repo.path().join(".codex/config.toml"), "broken = [\n").unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    let output = project_install
+        .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+    assert_eq!(value["data"]["status"]["duplicate_hook_risk"], false);
+    assert!(
+        fs::read_to_string(home.path().join("codex1-home/config.toml"))
+            .unwrap()
+            .contains("enabled = true")
+    );
+}
+
+#[test]
+fn setup_project_install_does_not_touch_global_policy() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    assert!(!home.path().join("codex1-home/config.toml").exists());
+    assert!(repo.path().join(".codex/config.toml").exists());
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").exists());
 }
 
 #[test]
@@ -915,6 +1098,48 @@ fn setup_disable_rejects_tampered_marker_for_unmanaged_repo_file() {
     assert!(user_file.exists());
 }
 
+#[test]
+fn setup_disable_does_not_change_policy_when_bundle_cleanup_fails() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    fs::write(
+        repo.path().join(".codex1/setup-bundle.json"),
+        r#"{
+  "managed_by": "codex1-managed",
+  "version": 1,
+  "files": ["notes.md"]
+}"#,
+    )
+    .unwrap();
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    let output = disable
+        .args(["--json", "setup", "disable", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], true);
+}
+
 #[cfg(unix)]
 #[test]
 fn setup_install_rejects_symlinked_repo_bundle_roots() {
@@ -936,7 +1161,7 @@ fn setup_install_rejects_symlinked_repo_bundle_roots() {
 }
 
 #[test]
-fn setup_install_rejects_existing_file_that_only_mentions_managed_marker() {
+fn setup_install_preserves_existing_agents_md() {
     let repo = repo();
     fs::create_dir_all(repo.path().join(".codex1")).unwrap();
     fs::write(
@@ -947,14 +1172,22 @@ fn setup_install_rejects_existing_file_that_only_mentions_managed_marker() {
     let home = tempfile::tempdir().unwrap();
     let mut command = bin();
     setup_env(&mut command, &home);
-    let output = command
-        .args(["--json", "setup", "install", "--repo"])
-        .arg(repo.path())
-        .output()
-        .unwrap();
-    assert!(!output.status.success());
-    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(value["error"]["code"], "SETUP_BUNDLE_ERROR");
+    json_output(
+        command
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    let agents = fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
+    assert!(agents.contains("human note mentioning codex1-managed in passing"));
+    assert!(agents.contains("codex1-managed setup guidance start"));
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
     assert_eq!(
         fs::read_to_string(repo.path().join("AGENTS.md")).unwrap(),
         "human note mentioning codex1-managed in passing"
@@ -1044,6 +1277,57 @@ fn setup_backups_can_restore_existing_and_missing_config_states() {
 }
 
 #[test]
+fn setup_backups_restore_rejects_manifest_paths_outside_setup_roots() {
+    let home = tempfile::tempdir().unwrap();
+    let outside_target = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside_target.path(), "do not overwrite").unwrap();
+    let backup_file = home.path().join("codex1-home/backups/tampered/config.toml");
+    fs::create_dir_all(backup_file.parent().unwrap()).unwrap();
+    fs::write(&backup_file, "owned by tampered manifest").unwrap();
+    let manifest = home.path().join("codex1-home/backups/manifest.json");
+    fs::write(
+        &manifest,
+        format!(
+            r#"{{
+  "version": 1,
+  "records": [
+    {{
+      "id": "tampered",
+      "timestamp": "2026-04-26T00:00:00Z",
+      "target_kind": "codex-config",
+      "target_path": "{}",
+      "target_path_label": "{}",
+      "backup_path": "{}",
+      "existed": true,
+      "reason": "tampered"
+    }}
+  ]
+}}"#,
+            outside_target.path().display(),
+            outside_target.path().display(),
+            backup_file.display()
+        ),
+    )
+    .unwrap();
+
+    let mut restore = bin();
+    setup_env(&mut restore, &home);
+    let output = restore
+        .args([
+            "--json", "setup", "backups", "restore", "tampered", "--force",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_RESTORE_ERROR");
+    assert_eq!(
+        fs::read_to_string(outside_target.path()).unwrap(),
+        "do not overwrite"
+    );
+}
+
+#[test]
 fn setup_doctor_reports_stale_managed_hook_executable() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -1078,6 +1362,44 @@ statusMessage = "Codex1 Ralph"
         .find(|check| check["name"] == "managed_hook_executable")
         .unwrap();
     assert_eq!(check["ok"], false);
+}
+
+#[test]
+fn setup_status_treats_stale_global_hook_executable_as_inactive() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        home.path().join("codex-home/config.toml"),
+        r#"# codex1-managed-ralph-start
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "'/definitely/missing/codex1' ralph stop-hook --scope global"
+timeout = 10
+statusMessage = "Codex1 Ralph"
+# codex1-managed-ralph-end
+"#,
+    )
+    .unwrap();
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["global_hook_installed"], true);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
 }
 
 #[test]
@@ -1192,10 +1514,53 @@ fn ralph_obeys_setup_activation_policy_and_fails_open() {
         "{}".to_string(),
     );
     assert!(malformed_allowed.get("decision").is_none());
+
+    fs::remove_file(home.path().join("codex1-home/config.toml")).unwrap();
+    let mut ralph_missing_policy = bin();
+    setup_env(&mut ralph_missing_policy, &home);
+    let missing_policy_allowed = json_output_with_stdin(
+        ralph_missing_policy
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "ralph", "stop-hook"]),
+        "{}".to_string(),
+    );
+    assert!(missing_policy_allowed.get("decision").is_none());
 }
 
 #[test]
-fn global_all_and_denylist_modes_scan_repos_without_materialized_bundles() {
+fn ralph_preserves_legacy_loop_checks_without_setup_policy() {
+    let repo = repo();
+    init(&repo, "alpha");
+
+    bin()
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args([
+            "--mission",
+            "alpha",
+            "loop",
+            "start",
+            "--mode",
+            "autopilot",
+            "--message",
+            "Legacy hook should still block.",
+        ])
+        .assert()
+        .success();
+
+    let block = json_output_with_stdin(
+        bin()
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["--mission", "alpha", "ralph", "stop-hook"]),
+        "{}".to_string(),
+    );
+    assert_eq!(block["decision"], "block");
+}
+
+#[test]
+fn global_all_and_denylist_modes_require_materialized_bundle() {
     for mode in ["all", "denylist"] {
         let setup_repo = repo();
         let scanned_repo = crate::repo();
@@ -1241,7 +1606,7 @@ fn global_all_and_denylist_modes_scan_repos_without_materialized_bundles() {
                 .args(["--mission", "alpha", "ralph", "stop-hook"]),
             "{}".to_string(),
         );
-        assert_eq!(value["decision"], "block", "mode={mode}");
+        assert!(value.get("decision").is_none(), "mode={mode}");
 
         let mut status = bin();
         setup_env(&mut status, &home);
@@ -1251,7 +1616,7 @@ fn global_all_and_denylist_modes_scan_repos_without_materialized_bundles() {
                 .arg(scanned_repo.path()),
         );
         assert_eq!(
-            status_value["data"]["status"]["effective_active"], true,
+            status_value["data"]["status"]["effective_active"], false,
             "mode={mode}"
         );
     }
@@ -1628,6 +1993,82 @@ fn setup_project_migrate_uninstall_and_enable_flows_are_reversible() {
             .unwrap()
             .contains("enabled = true")
     );
+}
+
+#[test]
+fn setup_enable_removes_existing_project_hook() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut enable = bin();
+    setup_env(&mut enable, &home);
+    json_output(
+        enable
+            .args(["--json", "setup", "enable", "--repo"])
+            .arg(repo.path()),
+    );
+
+    assert!(
+        fs::read_to_string(home.path().join("codex-home/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
+    assert!(!fs::read_to_string(repo.path().join(".codex/config.toml"))
+        .unwrap_or_default()
+        .contains("codex1-managed-ralph-start"));
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+    assert_eq!(value["data"]["status"]["duplicate_hook_risk"], false);
+}
+
+#[test]
+fn setup_install_global_removes_existing_project_hook() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut global_install = bin();
+    setup_env(&mut global_install, &home);
+    json_output(
+        global_install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    assert!(!fs::read_to_string(repo.path().join(".codex/config.toml"))
+        .unwrap_or_default()
+        .contains("codex1-managed-ralph-start"));
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+    assert_eq!(value["data"]["status"]["duplicate_hook_risk"], false);
 }
 
 #[test]
@@ -2472,14 +2913,19 @@ fn inspect_is_inventory_only() {
 #[test]
 fn loop_state_and_ralph_block_only_for_explicit_active_loop() {
     let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    setup_install_repo(&repo, &home);
     init(&repo, "alpha");
     let mission_dir = repo.path().join(".codex1/missions/alpha");
 
+    let mut allow_command = bin();
+    setup_env(&mut allow_command, &home);
+    allow_command
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args(["ralph", "stop-hook"]);
     let allow = json_output_with_stdin(
-        bin()
-            .args(["--repo-root"])
-            .arg(repo.path())
-            .args(["ralph", "stop-hook"]),
+        &mut allow_command,
         format!(r#"{{"cwd":"{}"}}"#, mission_dir.display()),
     );
     assert!(allow.as_object().unwrap().get("decision").is_none());
@@ -2500,11 +2946,14 @@ fn loop_state_and_ralph_block_only_for_explicit_active_loop() {
         .assert()
         .success();
 
+    let mut block_command = bin();
+    setup_env(&mut block_command, &home);
+    block_command
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args(["ralph", "stop-hook"]);
     let block = json_output_with_stdin(
-        bin()
-            .args(["--repo-root"])
-            .arg(repo.path())
-            .args(["ralph", "stop-hook"]),
+        &mut block_command,
         format!(r#"{{"cwd":"{}"}}"#, mission_dir.display()),
     );
     assert_eq!(block["decision"], "block");
@@ -2513,11 +2962,14 @@ fn loop_state_and_ralph_block_only_for_explicit_active_loop() {
         .unwrap()
         .contains("Continue the mission."));
 
+    let mut active_hook_command = bin();
+    setup_env(&mut active_hook_command, &home);
+    active_hook_command
+        .args(["--repo-root"])
+        .arg(repo.path())
+        .args(["ralph", "stop-hook"]);
     let allow_active_hook = json_output_with_stdin(
-        bin()
-            .args(["--repo-root"])
-            .arg(repo.path())
-            .args(["ralph", "stop-hook"]),
+        &mut active_hook_command,
         format!(
             r#"{{"cwd":"{}","stop_hook_active":true}}"#,
             mission_dir.display()
@@ -2533,6 +2985,8 @@ fn loop_state_and_ralph_block_only_for_explicit_active_loop() {
 #[test]
 fn ralph_resolves_repo_root_from_hook_cwd_when_invoked_elsewhere() {
     let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    setup_install_repo(&repo, &home);
     let outside = tempfile::tempdir().unwrap();
     init(&repo, "alpha");
     let mission_dir = repo.path().join(".codex1/missions/alpha");
@@ -2554,6 +3008,7 @@ fn ralph_resolves_repo_root_from_hook_cwd_when_invoked_elsewhere() {
         .success();
 
     let mut command = bin();
+    setup_env(&mut command, &home);
     command
         .current_dir(outside.path())
         .args(["ralph", "stop-hook"]);
@@ -2571,6 +3026,8 @@ fn ralph_resolves_repo_root_from_hook_cwd_when_invoked_elsewhere() {
 #[test]
 fn ralph_blocks_from_normal_repo_cwd_for_single_active_loop() {
     let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    setup_install_repo(&repo, &home);
     init(&repo, "alpha");
 
     bin()
@@ -2590,6 +3047,7 @@ fn ralph_blocks_from_normal_repo_cwd_for_single_active_loop() {
         .success();
 
     let mut command = bin();
+    setup_env(&mut command, &home);
     command
         .current_dir(repo.path())
         .args(["ralph", "stop-hook"]);
@@ -2607,6 +3065,8 @@ fn ralph_blocks_from_normal_repo_cwd_for_single_active_loop() {
 #[test]
 fn ralph_blocks_with_deterministic_guidance_for_multiple_active_loops() {
     let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    setup_install_repo(&repo, &home);
     init(&repo, "beta");
     init(&repo, "alpha");
 
@@ -2629,6 +3089,7 @@ fn ralph_blocks_with_deterministic_guidance_for_multiple_active_loops() {
     }
 
     let mut command = bin();
+    setup_env(&mut command, &home);
     command
         .current_dir(repo.path())
         .args(["ralph", "stop-hook"]);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,6 +12,8 @@ use tempfile::TempDir;
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 fn bin() -> Command {
     let mut command = Command::cargo_bin("codex1").unwrap();
@@ -646,6 +648,138 @@ fn setup_install_off_removes_bundles_for_known_policy_repos() {
 }
 
 #[test]
+fn setup_install_off_does_not_partially_remove_bundle_when_marker_is_reformatted() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        repo.path().join(".codex1/setup-bundle.json"),
+        r#"{"managed_by":"codex1-managed","version":1,"files":[".agents/skills/codex1/SKILL.md","AGENTS.md"]}"#,
+    )
+    .unwrap();
+
+    let mut off = bin();
+    setup_env(&mut off, &home);
+    let output = off
+        .args(["--json", "setup", "install", "--mode", "off", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(repo.path().join("AGENTS.md").exists());
+}
+
+#[test]
+fn setup_install_off_does_not_remove_bundle_when_policy_backup_cannot_commit() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        home.path().join("codex1-home/backups/manifest.json"),
+        "{not json",
+    )
+    .unwrap();
+
+    let mut off = bin();
+    setup_env(&mut off, &home);
+    let output = off
+        .args(["--json", "setup", "install", "--mode", "off", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(repo.path().join("AGENTS.md").exists());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], true);
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_install_rolls_back_partial_bundle_when_guidance_write_fails() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let agents = repo.path().join("AGENTS.md");
+    fs::write(&agents, "human instructions\n").unwrap();
+    let mut permissions = fs::metadata(&agents).unwrap().permissions();
+    permissions.set_mode(0o444);
+    fs::set_permissions(&agents, permissions).unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    let output = install
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_enable_rolls_back_partial_bundle_when_guidance_write_fails() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install_other = bin();
+    setup_env(&mut install_other, &home);
+    json_output(
+        install_other
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(other_repo.path()),
+    );
+
+    let agents = repo.path().join("AGENTS.md");
+    fs::write(&agents, "human instructions\n").unwrap();
+    let mut permissions = fs::metadata(&agents).unwrap().permissions();
+    permissions.set_mode(0o444);
+    fs::set_permissions(&agents, permissions).unwrap();
+
+    let mut enable = bin();
+    setup_env(&mut enable, &home);
+    let output = enable
+        .args(["--json", "setup", "enable", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], false);
+}
+
+#[test]
 fn setup_install_off_removes_project_scoped_setup_for_target_repo() {
     let project_repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -723,6 +857,43 @@ fn setup_install_off_removes_project_scoped_setup_for_target_repo() {
 }
 
 #[test]
+fn setup_install_off_removes_project_scoped_repos_from_backup_manifest() {
+    let project_repo = repo();
+    let controller_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&project_repo, "alpha");
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(project_repo.path()),
+    );
+    assert!(project_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+
+    let mut off = bin();
+    setup_env(&mut off, &home);
+    json_output(
+        off.args(["--json", "setup", "install", "--mode", "off", "--repo"])
+            .arg(controller_repo.path()),
+    );
+
+    assert!(!project_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+    assert!(
+        !fs::read_to_string(project_repo.path().join(".codex/config.toml"))
+            .unwrap_or_default()
+            .contains("codex1-managed-ralph-start")
+    );
+}
+
+#[test]
 fn setup_project_install_rejects_mode_off() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -781,6 +952,62 @@ fn setup_project_install_rejects_symlinked_project_config() {
         fs::read_to_string(outside.path()).unwrap(),
         "model = \"outside\"\n"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_global_install_rejects_symlinked_global_config() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex_home = home.path().join("codex-home");
+    fs::create_dir_all(&codex_home).unwrap();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside.path(), "model = \"outside\"\n").unwrap();
+    symlink(outside.path(), codex_home.join("config.toml")).unwrap();
+
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_CONFIG_WRITE_ERROR");
+    assert_eq!(
+        fs::read_to_string(outside.path()).unwrap(),
+        "model = \"outside\"\n"
+    );
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_global_install_rejects_symlinked_policy_config() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex1_home = home.path().join("codex1-home");
+    fs::create_dir_all(&codex1_home).unwrap();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside.path(), "mode = \"allowlist\"\n").unwrap();
+    symlink(outside.path(), codex1_home.join("config.toml")).unwrap();
+
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_CONFIG_WRITE_ERROR");
+    assert_eq!(
+        fs::read_to_string(outside.path()).unwrap(),
+        "mode = \"allowlist\"\n"
+    );
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
 }
 
 #[test]
@@ -887,8 +1114,51 @@ fn setup_project_install_does_not_touch_global_policy() {
     );
 
     assert!(!home.path().join("codex1-home/config.toml").exists());
+    assert!(home
+        .path()
+        .join("codex1-home/backups/manifest.json")
+        .exists());
     assert!(repo.path().join(".codex/config.toml").exists());
     assert!(repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[test]
+fn setup_project_install_records_absence_backup_for_missing_config() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let project_config = repo.path().join(".codex/config.toml");
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut list = bin();
+    setup_env(&mut list, &home);
+    let backups = json_output(list.args(["--json", "setup", "backups", "list"]));
+    let project_config_label = project_config.canonicalize().unwrap().display().to_string();
+    let id = backups["data"]["backups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["target_path"] == project_config_label && record["existed"] == false)
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut restore = bin();
+    setup_env(&mut restore, &home);
+    json_output(
+        restore
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["setup", "backups", "restore", &id, "--force"]),
+    );
+    assert!(!project_config.exists());
 }
 
 #[test]
@@ -1140,6 +1410,43 @@ fn setup_disable_does_not_change_policy_when_bundle_cleanup_fails() {
     assert_eq!(value["data"]["status"]["repo_policy_enabled"], true);
 }
 
+#[test]
+fn setup_disable_does_not_change_policy_when_owned_bundle_file_was_modified() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        repo.path().join(".agents/skills/codex1/SKILL.md"),
+        "user replacement",
+    )
+    .unwrap();
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    let output = disable
+        .args(["--json", "setup", "disable", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], true);
+}
+
 #[cfg(unix)]
 #[test]
 fn setup_install_rejects_symlinked_repo_bundle_roots() {
@@ -1192,6 +1499,57 @@ fn setup_install_preserves_existing_agents_md() {
         fs::read_to_string(repo.path().join("AGENTS.md")).unwrap(),
         "human note mentioning codex1-managed in passing"
     );
+}
+
+#[test]
+fn setup_status_rejects_and_install_repairs_stale_guidance_block() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        repo.path().join("AGENTS.md"),
+        r#"# Existing Instructions
+
+Keep this.
+
+<!-- codex1-managed setup guidance start -->
+# Old Codex1 Guidance
+
+codex1-managed
+<!-- codex1-managed setup guidance end -->
+"#,
+    )
+    .unwrap();
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_bundle_materialized"], false);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+
+    let mut reinstall = bin();
+    setup_env(&mut reinstall, &home);
+    json_output(
+        reinstall
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    let agents = fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
+    assert!(agents.contains("# Existing Instructions"));
+    assert!(agents.contains("Keep this."));
+    assert!(agents.contains("# Codex1 Setup Guidance"));
+    assert!(!agents.contains("# Old Codex1 Guidance"));
 }
 
 #[test]
@@ -1276,6 +1634,55 @@ fn setup_backups_can_restore_existing_and_missing_config_states() {
     assert_eq!(fs::read_to_string(&config).unwrap(), "model = \"before\"\n");
 }
 
+#[cfg(unix)]
+#[test]
+fn setup_backups_restore_rejects_symlinked_global_config_target() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex_home = home.path().join("codex-home");
+    fs::create_dir_all(&codex_home).unwrap();
+    let config = codex_home.join("config.toml");
+    fs::write(&config, "model = \"before\"\n").unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut list = bin();
+    setup_env(&mut list, &home);
+    let backups = json_output(list.args(["--json", "setup", "backups", "list"]));
+    let id = backups["data"]["backups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["target_path"] == config.display().to_string())
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    fs::remove_file(&config).unwrap();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside.path(), "model = \"outside\"\n").unwrap();
+    symlink(outside.path(), &config).unwrap();
+
+    let mut restore = bin();
+    setup_env(&mut restore, &home);
+    let output = restore
+        .args(["--json", "setup", "backups", "restore", &id, "--force"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert_eq!(
+        fs::read_to_string(outside.path()).unwrap(),
+        "model = \"outside\"\n"
+    );
+}
+
 #[test]
 fn setup_backups_restore_rejects_manifest_paths_outside_setup_roots() {
     let home = tempfile::tempdir().unwrap();
@@ -1324,6 +1731,105 @@ fn setup_backups_restore_rejects_manifest_paths_outside_setup_roots() {
     assert_eq!(
         fs::read_to_string(outside_target.path()).unwrap(),
         "do not overwrite"
+    );
+}
+
+#[test]
+fn setup_backups_restore_allows_project_config_backups() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    fs::create_dir_all(repo.path().join(".codex")).unwrap();
+    let project_config = repo.path().join(".codex/config.toml");
+    fs::write(&project_config, "model = \"before-project\"\n").unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut list = bin();
+    setup_env(&mut list, &home);
+    let backups = json_output(list.args(["--json", "setup", "backups", "list"]));
+    let project_config_label = project_config.canonicalize().unwrap().display().to_string();
+    let id = backups["data"]["backups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|record| record["target_path"] == project_config_label)
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    fs::write(&project_config, "model = \"after-project\"\n").unwrap();
+    let mut restore = bin();
+    setup_env(&mut restore, &home);
+    json_output(
+        restore
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["setup", "backups", "restore", &id, "--force"]),
+    );
+    assert_eq!(
+        fs::read_to_string(&project_config).unwrap(),
+        "model = \"before-project\"\n"
+    );
+}
+
+#[test]
+fn setup_backups_restore_rejects_other_repo_project_config_backup() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+    let other_config = other_repo.path().join(".codex/config.toml");
+    fs::create_dir_all(other_config.parent().unwrap()).unwrap();
+    fs::write(&other_config, "other repo config").unwrap();
+    let backup_file = home.path().join("codex1-home/backups/tampered/config.toml");
+    fs::create_dir_all(backup_file.parent().unwrap()).unwrap();
+    fs::write(&backup_file, "tampered overwrite").unwrap();
+    let manifest = home.path().join("codex1-home/backups/manifest.json");
+    fs::write(
+        &manifest,
+        format!(
+            r#"{{
+  "version": 1,
+  "records": [
+    {{
+      "id": "other-project",
+      "timestamp": "2026-04-26T00:00:00Z",
+      "target_kind": "codex-config",
+      "target_path": "{}",
+      "target_path_label": "{}",
+      "backup_path": "{}",
+      "existed": true,
+      "reason": "tampered"
+    }}
+  ]
+}}"#,
+            other_config.display(),
+            other_config.display(),
+            backup_file.display()
+        ),
+    )
+    .unwrap();
+
+    let mut restore = bin();
+    setup_env(&mut restore, &home);
+    let output = restore
+        .args(["--json", "--repo-root"])
+        .arg(repo.path())
+        .args(["setup", "backups", "restore", "other-project", "--force"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_RESTORE_ERROR");
+    assert_eq!(
+        fs::read_to_string(&other_config).unwrap(),
+        "other repo config"
     );
 }
 
@@ -1400,6 +1906,120 @@ statusMessage = "Codex1 Ralph"
     );
     assert_eq!(value["data"]["status"]["global_hook_installed"], true);
     assert_eq!(value["data"]["status"]["effective_active"], false);
+}
+
+#[test]
+fn setup_status_treats_wrong_managed_hook_command_as_inactive() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        home.path().join("codex-home/config.toml"),
+        r#"# codex1-managed-ralph-start
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "/bin/sh"
+timeout = 10
+statusMessage = "Codex1 Ralph"
+# codex1-managed-ralph-end
+"#,
+    )
+    .unwrap();
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["global_hook_installed"], true);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+
+    let mut doctor = bin();
+    setup_env(&mut doctor, &home);
+    let doctor_value = json_output(
+        doctor
+            .args(["--json", "setup", "doctor", "--repo"])
+            .arg(repo.path()),
+    );
+    let check = doctor_value["data"]["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["name"] == "managed_hook_executable")
+        .unwrap();
+    assert_eq!(check["ok"], false);
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_status_treats_non_executable_global_hook_as_inactive() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let fake_bin = home.path().join("not-executable-codex1");
+    fs::write(&fake_bin, "#!/bin/sh\nexit 0\n").unwrap();
+    let mut permissions = fs::metadata(&fake_bin).unwrap().permissions();
+    permissions.set_mode(0o644);
+    fs::set_permissions(&fake_bin, permissions).unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        home.path().join("codex-home/config.toml"),
+        format!(
+            r#"# codex1-managed-ralph-start
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "'{}' ralph stop-hook --scope global"
+timeout = 10
+statusMessage = "Codex1 Ralph"
+# codex1-managed-ralph-end
+"#,
+            fake_bin.display()
+        ),
+    )
+    .unwrap();
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+
+    let mut doctor = bin();
+    setup_env(&mut doctor, &home);
+    let doctor_value = json_output(
+        doctor
+            .args(["--json", "setup", "doctor", "--repo"])
+            .arg(repo.path()),
+    );
+    let check = doctor_value["data"]["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["name"] == "managed_hook_executable")
+        .unwrap();
+    assert_eq!(check["ok"], false);
 }
 
 #[test]
@@ -1560,7 +2180,7 @@ fn ralph_preserves_legacy_loop_checks_without_setup_policy() {
 }
 
 #[test]
-fn global_all_and_denylist_modes_require_materialized_bundle() {
+fn global_all_and_denylist_modes_scan_repos_without_materialized_bundles() {
     for mode in ["all", "denylist"] {
         let setup_repo = repo();
         let scanned_repo = crate::repo();
@@ -1606,7 +2226,7 @@ fn global_all_and_denylist_modes_require_materialized_bundle() {
                 .args(["--mission", "alpha", "ralph", "stop-hook"]),
             "{}".to_string(),
         );
-        assert!(value.get("decision").is_none(), "mode={mode}");
+        assert_eq!(value["decision"], "block", "mode={mode}");
 
         let mut status = bin();
         setup_env(&mut status, &home);
@@ -1616,7 +2236,7 @@ fn global_all_and_denylist_modes_require_materialized_bundle() {
                 .arg(scanned_repo.path()),
         );
         assert_eq!(
-            status_value["data"]["status"]["effective_active"], false,
+            status_value["data"]["status"]["effective_active"], true,
             "mode={mode}"
         );
     }
@@ -1688,6 +2308,79 @@ fn project_scoped_ralph_rejects_tampered_bundle_marker() {
             .arg(repo.path()),
     );
     fs::write(repo.path().join(".codex1/setup-bundle.json"), "{not json").unwrap();
+
+    let mut start = bin();
+    setup_env(&mut start, &home);
+    json_output(
+        start
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "loop",
+                "start",
+                "--mode",
+                "autopilot",
+                "--message",
+                "Keep going",
+            ]),
+    );
+
+    let mut ralph = bin();
+    setup_env(&mut ralph, &home);
+    let value = json_output_with_stdin(
+        ralph
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "ralph",
+                "stop-hook",
+                "--scope",
+                "project",
+            ]),
+        "{}".to_string(),
+    );
+    assert!(value.get("decision").is_none());
+}
+
+#[test]
+fn project_scoped_ralph_rejects_tampered_bundle_marker_metadata() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        repo.path().join(".codex1/setup-bundle.json"),
+        r#"{
+  "managed_by": "someone-else",
+  "version": 999,
+  "files": [".agents/skills/codex1/SKILL.md", "AGENTS.md"]
+}"#,
+    )
+    .unwrap();
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let status_value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(
+        status_value["data"]["status"]["repo_bundle_materialized"],
+        false
+    );
+    assert_eq!(status_value["data"]["status"]["effective_active"], false);
 
     let mut start = bin();
     setup_env(&mut start, &home);
@@ -1996,7 +2689,64 @@ fn setup_project_migrate_uninstall_and_enable_flows_are_reversible() {
 }
 
 #[test]
-fn setup_enable_removes_existing_project_hook() {
+fn setup_uninstall_project_keeps_bundle_when_global_setup_remains() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut global_install = bin();
+    setup_env(&mut global_install, &home);
+    json_output(
+        global_install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    let policy_path = home.path().join("codex1-home/config.toml");
+    let policy = fs::read_to_string(&policy_path).unwrap();
+    fs::write(
+        &policy_path,
+        policy.replace("enabled = false", "enabled = true"),
+    )
+    .unwrap();
+
+    let mut uninstall = bin();
+    setup_env(&mut uninstall, &home);
+    json_output(
+        uninstall
+            .args([
+                "--json",
+                "setup",
+                "uninstall",
+                "--scope",
+                "project",
+                "--repo",
+            ])
+            .arg(repo.path()),
+    );
+
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!fs::read_to_string(repo.path().join(".codex/config.toml"))
+        .unwrap_or_default()
+        .contains("codex1-managed-ralph-start"));
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+    assert_eq!(value["data"]["status"]["duplicate_hook_risk"], false);
+}
+
+#[test]
+fn setup_enable_preserves_project_local_activation_after_disable() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
 
@@ -2008,6 +2758,19 @@ fn setup_enable_removes_existing_project_hook() {
             .arg(repo.path()),
     );
 
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
+    assert!(!home.path().join("codex1-home/config.toml").exists());
+    assert!(!fs::read_to_string(repo.path().join(".codex/config.toml"))
+        .unwrap_or_default()
+        .contains("codex1-managed-ralph-start"));
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+
     let mut enable = bin();
     setup_env(&mut enable, &home);
     json_output(
@@ -2016,13 +2779,10 @@ fn setup_enable_removes_existing_project_hook() {
             .arg(repo.path()),
     );
 
-    assert!(
-        fs::read_to_string(home.path().join("codex-home/config.toml"))
-            .unwrap()
-            .contains("codex1-managed-ralph-start")
-    );
-    assert!(!fs::read_to_string(repo.path().join(".codex/config.toml"))
-        .unwrap_or_default()
+    assert!(!home.path().join("codex1-home/config.toml").exists());
+    assert!(!home.path().join("codex-home/config.toml").exists());
+    assert!(fs::read_to_string(repo.path().join(".codex/config.toml"))
+        .unwrap()
         .contains("codex1-managed-ralph-start"));
 
     let mut status = bin();
@@ -2033,7 +2793,326 @@ fn setup_enable_removes_existing_project_hook() {
             .arg(repo.path()),
     );
     assert_eq!(value["data"]["status"]["effective_active"], true);
+    assert_eq!(value["data"]["status"]["global_hook_installed"], false);
+    assert_eq!(value["data"]["status"]["project_hook_installed"], true);
     assert_eq!(value["data"]["status"]["duplicate_hook_risk"], false);
+}
+
+#[test]
+fn setup_project_install_disables_existing_global_activation() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut global_install = bin();
+    setup_env(&mut global_install, &home);
+    json_output(
+        global_install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+    assert_eq!(value["data"]["status"]["project_hook_installed"], true);
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], false);
+    assert_eq!(value["data"]["status"]["duplicate_hook_risk"], false);
+}
+
+#[test]
+fn setup_project_install_disables_stale_global_activation() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut global_install = bin();
+    setup_env(&mut global_install, &home);
+    json_output(
+        global_install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        home.path().join("codex-home/config.toml"),
+        r#"# codex1-managed-ralph-start
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "'/definitely/missing/codex1' ralph stop-hook --scope global"
+timeout = 10
+statusMessage = "Codex1 Ralph"
+# codex1-managed-ralph-end
+"#,
+    )
+    .unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut enable_other = bin();
+    setup_env(&mut enable_other, &home);
+    json_output(
+        enable_other
+            .args(["--json", "setup", "enable", "--repo"])
+            .arg(other_repo.path()),
+    );
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+    assert_eq!(value["data"]["status"]["global_hook_installed"], true);
+    assert_eq!(value["data"]["status"]["project_hook_installed"], true);
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], false);
+    assert_eq!(value["data"]["status"]["duplicate_hook_risk"], false);
+}
+
+#[test]
+fn setup_uninstall_global_removes_bundle_when_no_project_hook_remains() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut uninstall = bin();
+    setup_env(&mut uninstall, &home);
+    json_output(
+        uninstall
+            .args([
+                "--json",
+                "setup",
+                "uninstall",
+                "--scope",
+                "global",
+                "--repo",
+            ])
+            .arg(repo.path()),
+    );
+
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!fs::read_to_string(repo.path().join("AGENTS.md"))
+        .unwrap_or_default()
+        .contains("codex1-managed setup guidance start"));
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], false);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+}
+
+#[test]
+fn setup_uninstall_global_keeps_shared_hook_for_other_enabled_repos() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&other_repo, "alpha");
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut enable_other = bin();
+    setup_env(&mut enable_other, &home);
+    json_output(
+        enable_other
+            .args(["--json", "setup", "enable", "--repo"])
+            .arg(other_repo.path()),
+    );
+
+    let mut uninstall = bin();
+    setup_env(&mut uninstall, &home);
+    json_output(
+        uninstall
+            .args([
+                "--json",
+                "setup",
+                "uninstall",
+                "--scope",
+                "global",
+                "--repo",
+            ])
+            .arg(repo.path()),
+    );
+
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(other_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+    assert!(
+        fs::read_to_string(home.path().join("codex-home/config.toml"))
+            .unwrap()
+            .contains("codex1-managed-ralph-start")
+    );
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(other_repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], true);
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+
+    let mut start = bin();
+    setup_env(&mut start, &home);
+    json_output(
+        start
+            .args(["--json", "--repo-root"])
+            .arg(other_repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "loop",
+                "start",
+                "--mode",
+                "autopilot",
+                "--message",
+                "Keep going",
+            ]),
+    );
+    let mut ralph = bin();
+    setup_env(&mut ralph, &home);
+    let blocked = json_output_with_stdin(
+        ralph
+            .args(["--json", "--repo-root"])
+            .arg(other_repo.path())
+            .args(["--mission", "alpha", "ralph", "stop-hook"]),
+        "{}".to_string(),
+    );
+    assert_eq!(blocked["decision"], "block");
+}
+
+#[test]
+fn setup_uninstall_project_removes_bundle_when_global_hook_is_stale() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut global_install = bin();
+    setup_env(&mut global_install, &home);
+    json_output(
+        global_install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        home.path().join("codex-home/config.toml"),
+        r#"# codex1-managed-ralph-start
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "'/definitely/missing/codex1' ralph stop-hook --scope global"
+timeout = 10
+statusMessage = "Codex1 Ralph"
+# codex1-managed-ralph-end
+"#,
+    )
+    .unwrap();
+
+    let mut uninstall = bin();
+    setup_env(&mut uninstall, &home);
+    json_output(
+        uninstall
+            .args([
+                "--json",
+                "setup",
+                "uninstall",
+                "--scope",
+                "project",
+                "--repo",
+            ])
+            .arg(repo.path()),
+    );
+
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[test]
+fn setup_uninstall_project_keeps_hook_when_bundle_cleanup_fails() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        repo.path().join(".codex1/setup-bundle.json"),
+        r#"{
+  "managed_by": "codex1-managed",
+  "version": 1,
+  "files": ["notes.md"]
+}"#,
+    )
+    .unwrap();
+
+    let mut uninstall = bin();
+    setup_env(&mut uninstall, &home);
+    let output = uninstall
+        .args([
+            "--json",
+            "setup",
+            "uninstall",
+            "--scope",
+            "project",
+            "--repo",
+        ])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(fs::read_to_string(repo.path().join(".codex/config.toml"))
+        .unwrap()
+        .contains("codex1-managed-ralph-start"));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -241,6 +241,60 @@ fn setup_status_reports_activation_only() {
 }
 
 #[test]
+fn setup_status_requires_parseable_hook_config_before_reporting_active() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(
+        home.path().join("codex-home/config.toml"),
+        "# codex1-managed-ralph-start\n[[hooks.Stop]\n# codex1-managed-ralph-end\n",
+    )
+    .unwrap();
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["global_hook_installed"], false);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+}
+
+#[test]
+fn setup_status_requires_valid_bundle_before_reporting_active() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(repo.path().join(".codex1/setup-bundle.json"), "{not json").unwrap();
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_bundle_materialized"], false);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+}
+
+#[test]
 fn setup_install_default_enables_only_target_repo_with_backups_and_bundle() {
     let repo = repo();
     let other_repo = crate::repo();
@@ -277,7 +331,7 @@ fn setup_install_default_enables_only_target_repo_with_backups_and_bundle() {
     ));
 
     assert!(repo.path().join(".agents/skills/codex1/SKILL.md").is_file());
-    assert!(repo.path().join(".codex1/setup-guidance.md").is_file());
+    assert!(repo.path().join("AGENTS.md").is_file());
     assert!(repo.path().join(".codex1/setup-bundle.json").is_file());
     assert!(home
         .path()
@@ -301,6 +355,167 @@ fn setup_install_default_enables_only_target_repo_with_backups_and_bundle() {
             .arg(other_repo.path()),
     );
     assert_eq!(inactive["data"]["status"]["repo_policy_enabled"], false);
+}
+
+#[test]
+fn setup_commands_honor_global_repo_root_flag() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args(["setup", "install"]),
+    );
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").is_file());
+    assert!(!other_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+
+    let codex1_config = fs::read_to_string(home.path().join("codex1-home/config.toml")).unwrap();
+    assert!(codex1_config.contains(&repo.path().canonicalize().unwrap().display().to_string()));
+    assert!(!codex1_config.contains(
+        &other_repo
+            .path()
+            .canonicalize()
+            .unwrap()
+            .display()
+            .to_string()
+    ));
+}
+
+#[test]
+fn setup_install_mode_all_overrides_disabled_repo_entry() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut all = bin();
+    setup_env(&mut all, &home);
+    json_output(
+        all.args(["--json", "setup", "install", "--mode", "all", "--repo"])
+            .arg(repo.path()),
+    );
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").is_file());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["activation_mode"], "all");
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], true);
+}
+
+#[test]
+fn setup_install_mode_all_records_materialized_repo_for_off_cleanup() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install_one = bin();
+    setup_env(&mut install_one, &home);
+    json_output(
+        install_one
+            .args(["--json", "setup", "install", "--mode", "all", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut install_other = bin();
+    setup_env(&mut install_other, &home);
+    json_output(
+        install_other
+            .args(["--json", "setup", "install", "--mode", "all", "--repo"])
+            .arg(other_repo.path()),
+    );
+    assert!(other_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+
+    let mut off = bin();
+    setup_env(&mut off, &home);
+    json_output(
+        off.args(["--json", "setup", "install", "--mode", "off", "--repo"])
+            .arg(repo.path()),
+    );
+
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!other_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+}
+
+#[test]
+fn setup_disable_overrides_all_mode_activation() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut all = bin();
+    setup_env(&mut all, &home);
+    json_output(
+        all.args(["--json", "setup", "install", "--mode", "all", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["activation_mode"], "denylist");
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], false);
+    assert_eq!(value["data"]["status"]["effective_active"], false);
+}
+
+#[test]
+fn setup_install_does_not_leave_global_hook_when_policy_write_fails() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    let codex1_home = home.path().join("codex1-home");
+    fs::remove_dir_all(&codex1_home).unwrap();
+    fs::write(&codex1_home, "not a directory").unwrap();
+
+    let output = install
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(!home.path().join("codex-home/config.toml").exists());
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!repo.path().join("AGENTS.md").exists());
 }
 
 #[test]
@@ -354,7 +569,48 @@ fn setup_install_off_does_not_materialize_repo_bundle() {
     );
     assert_eq!(value["data"]["activation_mode"], "off");
     assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
-    assert!(!repo.path().join(".codex1/setup-guidance.md").exists());
+    assert!(!repo.path().join("AGENTS.md").exists());
+}
+
+#[test]
+fn setup_install_off_removes_bundles_for_known_policy_repos() {
+    let repo = repo();
+    let other_repo = crate::repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install_one = bin();
+    setup_env(&mut install_one, &home);
+    json_output(
+        install_one
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut enable_other = bin();
+    setup_env(&mut enable_other, &home);
+    json_output(
+        enable_other
+            .args(["--json", "setup", "enable", "--repo"])
+            .arg(other_repo.path()),
+    );
+    assert!(repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(other_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
+
+    let mut off = bin();
+    setup_env(&mut off, &home);
+    json_output(
+        off.args(["--json", "setup", "install", "--mode", "off", "--repo"])
+            .arg(repo.path()),
+    );
+
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!other_repo
+        .path()
+        .join(".agents/skills/codex1/SKILL.md")
+        .exists());
 }
 
 #[test]
@@ -375,6 +631,173 @@ fn setup_project_install_rejects_mode_off() {
     assert_eq!(value["error"]["code"], "SETUP_ARGUMENT_ERROR");
     assert!(!repo.path().join(".codex/config.toml").exists());
     assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_project_install_rejects_symlinked_project_config() {
+    let repo = repo();
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    fs::write(outside.path(), "model = \"outside\"\n").unwrap();
+    fs::create_dir_all(repo.path().join(".codex")).unwrap();
+    symlink(outside.path(), repo.path().join(".codex/config.toml")).unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_CONFIG_WRITE_ERROR");
+    assert_eq!(
+        fs::read_to_string(outside.path()).unwrap(),
+        "model = \"outside\"\n"
+    );
+}
+
+#[test]
+fn setup_project_install_rejects_malformed_config_before_bundle_write() {
+    let repo = repo();
+    fs::create_dir_all(repo.path().join(".codex")).unwrap();
+    fs::write(repo.path().join(".codex/config.toml"), "model = [nope\n").unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_CONFIG_PARSE_ERROR");
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!repo.path().join("AGENTS.md").exists());
+}
+
+#[test]
+fn setup_project_install_preflights_bundle_before_hook_write() {
+    let repo = repo();
+    fs::create_dir_all(repo.path().join(".agents/skills/codex1")).unwrap();
+    fs::write(
+        repo.path().join(".agents/skills/codex1/SKILL.md"),
+        "user-authored skill that says codex1-managed",
+    )
+    .unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_BUNDLE_ERROR");
+    assert!(!repo.path().join(".codex/config.toml").exists());
+    assert_eq!(
+        fs::read_to_string(repo.path().join(".agents/skills/codex1/SKILL.md")).unwrap(),
+        "user-authored skill that says codex1-managed"
+    );
+}
+
+#[test]
+fn setup_doctor_treats_project_hook_as_installed_hook() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut doctor = bin();
+    setup_env(&mut doctor, &home);
+    let value = json_output(
+        doctor
+            .args(["--json", "setup", "doctor", "--repo"])
+            .arg(repo.path()),
+    );
+    let check = value["data"]["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["name"] == "global_hook_installed")
+        .unwrap();
+    assert_eq!(check["ok"], true);
+}
+
+#[test]
+fn setup_mutation_preserves_malformed_backup_manifest() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let manifest = home.path().join("codex1-home/backups/manifest.json");
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(&manifest, "{not json").unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    let output = install
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_BACKUP_ERROR");
+    assert_eq!(fs::read_to_string(&manifest).unwrap(), "{not json");
+}
+
+#[test]
+fn setup_backups_list_reports_malformed_manifest() {
+    let home = tempfile::tempdir().unwrap();
+    let manifest = home.path().join("codex1-home/backups/manifest.json");
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(&manifest, "{not json").unwrap();
+
+    let mut list = bin();
+    setup_env(&mut list, &home);
+    let output = list
+        .args(["--json", "setup", "backups", "list"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_BACKUP_ERROR");
+}
+
+#[test]
+fn setup_doctor_reports_malformed_backup_manifest() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let manifest = home.path().join("codex1-home/backups/manifest.json");
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(&manifest, "{not json").unwrap();
+
+    let mut doctor = bin();
+    setup_env(&mut doctor, &home);
+    let value = json_output(
+        doctor
+            .args(["--json", "setup", "doctor", "--repo"])
+            .arg(repo.path()),
+    );
+    let check = value["data"]["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["name"] == "backup_manifest_parseable")
+        .unwrap();
+    assert_eq!(check["ok"], false);
 }
 
 #[test]
@@ -403,6 +826,32 @@ fn setup_disable_removes_bundle_without_deleting_mission_artifacts() {
     assert_eq!(value["ok"], true);
     assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
     assert!(mission_prd.is_file());
+}
+
+#[test]
+fn setup_disable_removes_managed_bundle_files_when_marker_is_missing() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::remove_file(repo.path().join(".codex1/setup-bundle.json")).unwrap();
+
+    let mut disable = bin();
+    setup_env(&mut disable, &home);
+    json_output(
+        disable
+            .args(["--json", "setup", "disable", "--repo"])
+            .arg(repo.path()),
+    );
+
+    assert!(!repo.path().join(".agents/skills/codex1/SKILL.md").exists());
+    assert!(!repo.path().join("AGENTS.md").exists());
 }
 
 #[test]
@@ -484,6 +933,32 @@ fn setup_install_rejects_symlinked_repo_bundle_roots() {
     let value: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["error"]["code"], "SETUP_BUNDLE_ERROR");
     assert!(!outside.path().join("skills/codex1/SKILL.md").exists());
+}
+
+#[test]
+fn setup_install_rejects_existing_file_that_only_mentions_managed_marker() {
+    let repo = repo();
+    fs::create_dir_all(repo.path().join(".codex1")).unwrap();
+    fs::write(
+        repo.path().join("AGENTS.md"),
+        "human note mentioning codex1-managed in passing",
+    )
+    .unwrap();
+    let home = tempfile::tempdir().unwrap();
+    let mut command = bin();
+    setup_env(&mut command, &home);
+    let output = command
+        .args(["--json", "setup", "install", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["error"]["code"], "SETUP_BUNDLE_ERROR");
+    assert_eq!(
+        fs::read_to_string(repo.path().join("AGENTS.md")).unwrap(),
+        "human note mentioning codex1-managed in passing"
+    );
 }
 
 #[test]
@@ -569,6 +1044,79 @@ fn setup_backups_can_restore_existing_and_missing_config_states() {
 }
 
 #[test]
+fn setup_doctor_reports_stale_managed_hook_executable() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let codex_home = home.path().join("codex-home");
+    fs::create_dir_all(&codex_home).unwrap();
+    fs::write(
+        codex_home.join("config.toml"),
+        r#"# codex1-managed-ralph-start
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "'/definitely/missing/codex1' ralph stop-hook --scope global"
+timeout = 10
+statusMessage = "Codex1 Ralph"
+# codex1-managed-ralph-end
+"#,
+    )
+    .unwrap();
+
+    let mut doctor = bin();
+    setup_env(&mut doctor, &home);
+    let value = json_output(
+        doctor
+            .args(["--json", "setup", "doctor", "--repo"])
+            .arg(repo.path()),
+    );
+    let check = value["data"]["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["name"] == "managed_hook_executable")
+        .unwrap();
+    assert_eq!(check["ok"], false);
+}
+
+#[test]
+fn setup_doctor_reports_stale_project_hook_executable() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    fs::create_dir_all(repo.path().join(".codex")).unwrap();
+    fs::write(
+        repo.path().join(".codex/config.toml"),
+        r#"# codex1-managed-ralph-start
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "'/definitely/missing/codex1' ralph stop-hook --scope project"
+timeout = 10
+statusMessage = "Codex1 Ralph"
+# codex1-managed-ralph-end
+"#,
+    )
+    .unwrap();
+
+    let mut doctor = bin();
+    setup_env(&mut doctor, &home);
+    let value = json_output(
+        doctor
+            .args(["--json", "setup", "doctor", "--repo"])
+            .arg(repo.path()),
+    );
+    let check = value["data"]["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["name"] == "managed_hook_executable")
+        .unwrap();
+    assert_eq!(check["ok"], false);
+}
+
+#[test]
 fn ralph_obeys_setup_activation_policy_and_fails_open() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -647,6 +1195,173 @@ fn ralph_obeys_setup_activation_policy_and_fails_open() {
 }
 
 #[test]
+fn global_all_and_denylist_modes_scan_repos_without_materialized_bundles() {
+    for mode in ["all", "denylist"] {
+        let setup_repo = repo();
+        let scanned_repo = crate::repo();
+        let home = tempfile::tempdir().unwrap();
+        init(&scanned_repo, "alpha");
+
+        let mut install = bin();
+        setup_env(&mut install, &home);
+        json_output(
+            install
+                .args(["--json", "setup", "install", "--mode", mode, "--repo"])
+                .arg(setup_repo.path()),
+        );
+        assert!(!scanned_repo
+            .path()
+            .join(".codex1/setup-bundle.json")
+            .exists());
+
+        let mut start = bin();
+        setup_env(&mut start, &home);
+        json_output(
+            start
+                .args(["--json", "--repo-root"])
+                .arg(scanned_repo.path())
+                .args([
+                    "--mission",
+                    "alpha",
+                    "loop",
+                    "start",
+                    "--mode",
+                    "autopilot",
+                    "--message",
+                    "Keep going",
+                ]),
+        );
+
+        let mut ralph = bin();
+        setup_env(&mut ralph, &home);
+        let value = json_output_with_stdin(
+            ralph
+                .args(["--json", "--repo-root"])
+                .arg(scanned_repo.path())
+                .args(["--mission", "alpha", "ralph", "stop-hook"]),
+            "{}".to_string(),
+        );
+        assert_eq!(value["decision"], "block", "mode={mode}");
+
+        let mut status = bin();
+        setup_env(&mut status, &home);
+        let status_value = json_output(
+            status
+                .args(["--json", "setup", "status", "--repo"])
+                .arg(scanned_repo.path()),
+        );
+        assert_eq!(
+            status_value["data"]["status"]["effective_active"], true,
+            "mode={mode}"
+        );
+    }
+}
+
+#[test]
+fn project_scoped_ralph_requires_materialized_bundle() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::remove_file(repo.path().join(".agents/skills/codex1/SKILL.md")).unwrap();
+
+    let mut start = bin();
+    setup_env(&mut start, &home);
+    json_output(
+        start
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "loop",
+                "start",
+                "--mode",
+                "autopilot",
+                "--message",
+                "Keep going",
+            ]),
+    );
+
+    let mut ralph = bin();
+    setup_env(&mut ralph, &home);
+    let value = json_output_with_stdin(
+        ralph
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "ralph",
+                "stop-hook",
+                "--scope",
+                "project",
+            ]),
+        "{}".to_string(),
+    );
+    assert!(value.get("decision").is_none());
+}
+
+#[test]
+fn project_scoped_ralph_rejects_tampered_bundle_marker() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    init(&repo, "alpha");
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(repo.path().join(".codex1/setup-bundle.json"), "{not json").unwrap();
+
+    let mut start = bin();
+    setup_env(&mut start, &home);
+    json_output(
+        start
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "loop",
+                "start",
+                "--mode",
+                "autopilot",
+                "--message",
+                "Keep going",
+            ]),
+    );
+
+    let mut ralph = bin();
+    setup_env(&mut ralph, &home);
+    let value = json_output_with_stdin(
+        ralph
+            .args(["--json", "--repo-root"])
+            .arg(repo.path())
+            .args([
+                "--mission",
+                "alpha",
+                "ralph",
+                "stop-hook",
+                "--scope",
+                "project",
+            ]),
+        "{}".to_string(),
+    );
+    assert!(value.get("decision").is_none());
+}
+
+#[test]
 fn project_scope_ralph_ignores_global_disable_after_migration() {
     let repo = repo();
     let home = tempfile::tempdir().unwrap();
@@ -721,6 +1436,110 @@ fn project_scope_ralph_ignores_global_disable_after_migration() {
         "{}".to_string(),
     );
     assert_eq!(project_blocked["decision"], "block");
+}
+
+#[test]
+fn migrate_to_global_does_not_enable_global_hook_before_later_failures() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut project_install = bin();
+    setup_env(&mut project_install, &home);
+    json_output(
+        project_install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::write(repo.path().join(".codex/config.toml"), "model = [nope\n").unwrap();
+
+    let mut migrate = bin();
+    setup_env(&mut migrate, &home);
+    let output = migrate
+        .args(["--json", "setup", "migrate", "--to", "global", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    let global_config = home.path().join("codex-home/config.toml");
+    assert!(
+        !global_config.exists()
+            || !fs::read_to_string(global_config)
+                .unwrap()
+                .contains("codex1-managed-ralph-start")
+    );
+}
+
+#[test]
+fn migrate_to_project_keeps_global_policy_when_project_hook_install_fails() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+    fs::create_dir_all(repo.path().join(".codex")).unwrap();
+    fs::write(repo.path().join(".codex/config.toml"), "model = [nope\n").unwrap();
+
+    let mut migrate = bin();
+    setup_env(&mut migrate, &home);
+    let output = migrate
+        .args(["--json", "setup", "migrate", "--to", "project", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["repo_policy_enabled"], true);
+    assert_eq!(value["data"]["status"]["effective_active"], true);
+}
+
+#[test]
+fn migrate_to_global_keeps_project_hook_when_global_hook_install_fails() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--scope", "project", "--repo"])
+            .arg(repo.path()),
+    );
+    let global_config = home.path().join("codex-home/config.toml");
+    fs::write(&global_config, "model = [nope\n").unwrap();
+
+    let mut migrate = bin();
+    setup_env(&mut migrate, &home);
+    let output = migrate
+        .args(["--json", "setup", "migrate", "--to", "global", "--repo"])
+        .arg(repo.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    assert!(fs::read_to_string(repo.path().join(".codex/config.toml"))
+        .unwrap()
+        .contains("codex1-managed-ralph-start"));
+    let mut status = bin();
+    setup_env(&mut status, &home);
+    let value = json_output(
+        status
+            .args(["--json", "setup", "status", "--repo"])
+            .arg(repo.path()),
+    );
+    assert_eq!(value["data"]["status"]["effective_active"], true);
 }
 
 #[test]
@@ -2002,6 +2821,24 @@ fn doctor_runs_installed_command_and_loop_smoke() {
         value["data"]["installed_command"]["json_error_envelope"],
         true
     );
+    assert_eq!(value["data"]["loop_ralph_smoke"]["blocked"], true);
+}
+
+#[test]
+fn doctor_ralph_smoke_ignores_setup_allowlist_policy() {
+    let repo = repo();
+    let home = tempfile::tempdir().unwrap();
+    let mut install = bin();
+    setup_env(&mut install, &home);
+    json_output(
+        install
+            .args(["--json", "setup", "install", "--repo"])
+            .arg(repo.path()),
+    );
+
+    let mut doctor = bin();
+    setup_env(&mut doctor, &home);
+    let value = json_output(doctor.args(["--json", "doctor"]));
     assert_eq!(value["data"]["loop_ralph_smoke"]["blocked"], true);
 }
 


### PR DESCRIPTION
## Summary
- Tighten setup lifecycle behavior across global and project scopes so activation, disable, uninstall, and migrate flows preserve the intended hook state.
- Add rollback paths for partial bundle writes, policy updates, and hook changes so failed installs do not leave behind half-applied setup state.
- Harden config, backup, and bundle path handling against symlinks, tampered manifests, and malformed or stale managed files.
- Update CLI/docs/tests to reflect the revised setup contract and the new scope-aware behavior.

## Testing
- Added regression coverage for stale hooks, rollback on partial bundle writes, symlinked config targets, backup restore validation, and shared-hook cleanup.
- `cargo test` passed.
- `cargo clippy --all-targets -- -D warnings` passed.
- `git diff --check` passed.