### PR TITLE
Add the self-improve-codex skill and Codex session scan helper

### DIFF
--- a/.agents/skills/brutal-review/SKILL.md
+++ b/.agents/skills/brutal-review/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: brutal-review
+description: Run a ruthless, multi-perspective review of the latest jj change or git commit when the user asks for brutal review, exhaustive critique, adversarial review, or a hard-nosed pre-merge review.
+---
+
+# Brutal Review
+
+Perform a ruthless, in-depth, extremely critical code review of the most recent change: jj `@-` when inside a jj repo, otherwise git `HEAD`.
+
+This skill is for finding problems, not reassurance. Be direct, specific, and evidence-driven. Do not add empty praise or soften real concerns.
+
+## Assumptions
+
+- Only call tools that are required to complete the review.
+- Assume tests, lint, and formatting were already run unless the user says otherwise.
+- If you need to verify a suspected issue, inspect the relevant code path directly.
+- Do not modify code unless the user explicitly asks you to fix findings.
+
+## Step 1: Inspect the Change
+
+Determine the VCS:
+
+```bash
+jj root 2>/dev/null && echo "jj" || echo "git"
+```
+
+Read the full commit message and diff.
+
+For jj:
+
+```bash
+jj show --git --no-pager -r @-
+```
+
+For git:
+
+```bash
+git show HEAD
+```
+
+## Step 2: Gather Context Before Review
+
+Subagents do not inherit your context. Gather the useful context first, then write it to `/tmp/brutal-review-context-<ID>.md`.
+
+Gather:
+
+- Full diff from Step 1.
+- Change stack context.
+- Full contents of every modified file, not just the diff.
+- Callers, dependencies, interfaces, traits, types, and adjacent files touched by the change.
+- Project conventions or local architecture patterns that should shape the review.
+
+For jj stack context:
+
+```bash
+jj log -r 'trunk()..@-'
+jj log -r '@-::'
+```
+
+For git stack context:
+
+```bash
+git log --oneline main..HEAD
+```
+
+Get an ID for the temporary context file.
+
+For jj:
+
+```bash
+jj log -r @- --no-graph -T 'change_id.short()'
+```
+
+For git:
+
+```bash
+git rev-parse --short HEAD
+```
+
+Write the context block to `/tmp/brutal-review-context-<ID>.md`. Use clear section headers so each reviewer can quickly find the diff, stack, files, dependencies, and conventions.
+
+## Step 3: Review From Four Perspectives
+
+If a multi-agent/subagent tool is available, launch the four reviewers in parallel and instruct each one to read `/tmp/brutal-review-context-<ID>.md` as its first action. If no subagent tool is available, run the four perspective passes yourself, sequentially.
+
+Each reviewer reports concerns and questions with:
+
+- File, line number, and relevant snippet.
+- Technical explanation of the problem.
+- Concrete actionable fix or alternative.
+- Confidence score from 0 to 100.
+- Severity: `CRITICAL`, `MAJOR`, `MINOR`, or `NIT`.
+
+Use this reviewer prompt shape:
+
+```text
+You are an elite code reviewer with an uncompromising eye for quality. Your mission is to perform ruthless, in-depth code review. Do not add praise. Identify flaws, question assumptions, and demand evidence.
+
+First read /tmp/brutal-review-context-<ID>.md. Use it as the primary source. Re-read files only when you need context not included there.
+
+Review the change from this perspective:
+
+[PERSPECTIVE]
+
+For each finding, cite file/line/snippet, explain the issue precisely, provide an actionable fix, include confidence 0-100, and categorize as CRITICAL, MAJOR, MINOR, or NIT.
+```
+
+### Perspective 1: Core Logic
+
+Review logic, correctness, architecture, and design.
+
+- Is the algorithm correct? Prove it or find the bug.
+- Are there off-by-one errors, race conditions, overflow risks, ordering bugs, or state-machine gaps?
+- Does the code do what the commit message claims?
+- Does this change belong where it was made?
+- Does it introduce coupling or an abstraction mismatch?
+- Will this be maintainable in six months?
+
+### Perspective 2: Reliability And Testing
+
+Review tests, failure paths, and operational reliability.
+
+- Are the tests comprehensive enough for the risk?
+- Do tests cover edge cases, error paths, and concurrent scenarios where relevant?
+- Could the tests pass while the code is broken?
+- Do any tests simply restate the implementation?
+- What happens with null, empty, boundary, malformed, maximum-size, or duplicate inputs?
+- Are errors handled or silently swallowed?
+- In Rust, are there production-path `unwrap()` calls or avoidable panics?
+- Does this change introduce new failure modes?
+
+### Perspective 3: Maintainability
+
+Review code quality, local conventions, and documentation.
+
+- Is the code readable to someone unfamiliar with it?
+- Are names precise and domain-aligned?
+- Are functions and modules appropriately sized?
+- Does it follow established project patterns and instructions?
+- Is there unnecessary complexity or cleverness?
+- Is the commit message accurate and complete?
+- Are complex algorithms, invariants, unsafe blocks, or surprising choices explained where needed?
+
+### Perspective 4: Performance
+
+Review performance, resources, and scalability.
+
+- Are there allocations, clones, copies, or conversions in hot paths?
+- Could this cause memory pressure or unbounded growth?
+- Are blocking operations used in async or latency-sensitive contexts?
+- Are lock ordering and shared state safe?
+- Should metrics or observability be added?
+- Are there quadratic or worse algorithms that should be linear or `n log n`?
+
+## Step 4: Classify Findings
+
+Severity definitions:
+
+- `CRITICAL`: Must fix before merge. Bugs, data corruption, security issues, forbidden production panics, or panic-prone library code.
+- `MAJOR`: Should fix. Significant design issues, missing error handling, performance issues, or inadequate tests.
+- `MINOR`: Recommended. Maintainability gaps, style inconsistencies, suboptimal abstractions, or documentation gaps.
+- `NIT`: Optional. Minor style issues or micro-optimizations.
+
+Every finding should include confidence. Low-confidence findings should be framed as questions to verify, not facts.
+
+## Step 5: Synthesize Final Report
+
+Combine the four perspectives into one report.
+
+- Prioritize by severity and confidence.
+- Merge duplicates and related issues.
+- Filter false positives and irrelevant concerns.
+- Number synthesized findings sequentially.
+- Keep findings concise, concrete, and actionable.
+- Include open questions only when the answer changes whether a finding is real.
+
+Final report format:
+
+```text
+Findings:
+
+1. [SEVERITY, confidence NN] Title
+   File: path:line
+   Snippet: `...`
+   Problem: ...
+   Fix: ...
+   Question: ...
+
+Residual risk:
+...
+```
+
+If there are no real findings, say so plainly and note any remaining review limitations.
+
+## Mindset
+
+You are not here to make friends. You are here to prevent bugs from reaching production, maintain code quality, and catch problems while they are cheap to fix.
+
+Be direct. Be specific. Be relentless. The code must earn its place in the codebase.
+
+Do not:
+
+- Add empty praise.
+- Soften criticism.
+- Ignore small issues; they accumulate.
+- Assume the author knew better.
+
+Do:
+
+- Question everything.
+- Demand evidence and justification.
+- Provide concrete alternatives.
+- Hold the code to the highest standard.

--- a/.agents/skills/brutal-review/agents/openai.yaml
+++ b/.agents/skills/brutal-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Brutal Review"
+  short_description: "Run an adversarial multi-perspective review"
+  default_prompt: "Use $brutal-review to review the latest change with ruthless scrutiny."

--- a/.agents/skills/clarify/SKILL.md
+++ b/.agents/skills/clarify/SKILL.md
@@ -24,6 +24,10 @@ Ask the questions one at a time, waiting for feedback on each question before co
 
 If a question can be answered by exploring the codebase, explore the codebase instead.
 
+When success or scope is fuzzy, clarify observable success outcomes and boundaries. Preserve those answers as context for `$create-prd`; do not turn them into a PRD template, task graph, or execution plan.
+
+Before considering clarification complete, make sure known context is sufficient for `$create-prd` to synthesize actors/core behaviors, observable success criteria, `Always Preserve`, `Ask Before Changing`, `Out Of Scope`, and any unresolved human decisions. Ask only for genuinely unclear product, scope, UX, credential, or human-judgment answers; inspect the repo for code-answerable ones.
+
 </what-to-do>
 
 <supporting-info>

--- a/.agents/skills/create-prd/PRD-FORMAT.md
+++ b/.agents/skills/create-prd/PRD-FORMAT.md
@@ -4,7 +4,7 @@ Use this when `$create-prd` writes `PRD.md`.
 
 ## Required Quality Bar
 
-The PRD must be sufficient for `$plan` to design execution without reconstructing product intent. Write from the user's perspective first, then capture implementation and testing decisions.
+The PRD must be sufficient for `$plan` to design execution without reconstructing product intent. Write from the user's perspective first, then capture observable success criteria, mission boundaries, implementation decisions, and testing decisions.
 
 ## Template
 
@@ -19,15 +19,29 @@ The solution, from the user's perspective.
 
 ## User Stories
 
-A long numbered list of user stories:
+A long numbered list of behavior-focused user stories:
 
 1. As an <actor>, I want <feature>, so that <benefit>.
 
-Cover all major behavior, actors, edge cases, and artifact interactions.
+Each story should describe one coherent behavior or outcome. Avoid vague bundles like "manage settings" unless they are split into observable behaviors. Cover all major behavior, actors, edge cases, and artifact interactions.
 
 ## Success Criteria
 
-Observable facts that make the PRD satisfied.
+Observable, measurable outcomes that make the PRD satisfied. These are mission-level success facts, not implementation tasks or slice-level acceptance criteria.
+
+## Boundaries
+
+### Always Preserve
+
+Existing behaviors, contracts, data, user expectations, workflow boundaries, or artifacts that must remain intact.
+
+### Ask Before Changing
+
+Areas that require explicit human approval before the implementation changes them.
+
+### Out Of Scope
+
+Work this PRD intentionally does not include.
 
 ## Module Sketch
 
@@ -55,10 +69,6 @@ Do not include brittle file paths or code snippets.
 - Testing non-goals
 
 Tests should verify behavior through public interfaces, not implementation details.
-
-## Out Of Scope
-
-What this PRD intentionally does not include.
 
 ## Proof Expectations
 

--- a/.agents/skills/create-prd/SKILL.md
+++ b/.agents/skills/create-prd/SKILL.md
@@ -15,9 +15,9 @@ Write `PRD.md` as a Codex1 mission artifact.
 
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
-Capture the likely modules and test seams in the PRD. If a product, scope, UX, credential, or human-judgment decision is truly missing and the user is actively collaborating, ask. Otherwise record the assumption or unresolved question instead of restarting clarification.
+Capture the likely modules and test seams in the PRD. Capture observable success criteria and mission boundaries from known context. If a product, scope, UX, credential, or human-judgment decision is truly missing and the user is actively collaborating, ask. Otherwise record the assumption or unresolved question instead of restarting clarification.
 
-3. Write the PRD using the template below, then write it as `PRD.md` in the Codex1 mission artifact tree.
+3. Write the PRD using [PRD-FORMAT.md](./PRD-FORMAT.md), then write it as `PRD.md` in the Codex1 mission artifact tree. Keep the PRD at product/outcome level. Do not turn it into a task graph, dependency tracker, priority tracker, per-story acceptance-criteria engine, or execution plan; `$plan` owns execution design.
 
 <prd-template>
 
@@ -31,15 +31,37 @@ The solution to the problem, from the user's perspective.
 
 ## User Stories
 
-A LONG, numbered list of user stories. Each user story should be in the format of:
+A long numbered list of behavior-focused user stories. Each story should describe one coherent behavior or outcome, not a vague bundle. Use the format:
 
-1. As an <actor>, I want a <feature>, so that <benefit>
+1. As an <actor>, I want <feature>, so that <benefit>.
 
 <user-story-example>
-1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+1. As a mobile bank customer, I want to see balances for each of my accounts, so that I can make better informed decisions about my spending.
 </user-story-example>
 
-This list of user stories should be extremely extensive and cover all aspects of the feature.
+This list should cover major behavior, actors, edge cases, and artifact interactions, while staying specific enough that `$plan` can map slices back to the stories.
+
+## Success Criteria
+
+Observable, measurable outcomes that make the PRD satisfied. These are mission-level success facts, not implementation tasks or slice-level acceptance criteria.
+
+## Boundaries
+
+### Always Preserve
+
+Existing behaviors, contracts, data, user expectations, workflow boundaries, or artifacts that must remain intact.
+
+### Ask Before Changing
+
+Areas that require explicit human approval before the implementation changes them.
+
+### Out Of Scope
+
+Work this PRD intentionally does not include.
+
+## Module Sketch
+
+Likely modules, interfaces, contracts, and deep-module opportunities. Use stable names and concepts, not brittle paths.
 
 ## Implementation Decisions
 
@@ -51,6 +73,7 @@ A list of implementation decisions that were made. This can include:
 - Architectural decisions
 - Schema changes
 - API contracts
+- State ownership
 - Specific interactions
 
 Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
@@ -64,10 +87,15 @@ A list of testing decisions that were made. Include:
 - A description of what makes a good test (only test external behavior, not implementation details)
 - Which modules will be tested
 - Prior art for the tests (i.e. similar types of tests in the codebase)
+- Testing non-goals
 
-## Out of Scope
+## Proof Expectations
 
-A description of the things that are out of scope for this PRD.
+Commands, tests, screenshots, manual checks, review evidence, or other proof expected later.
+
+## Review Expectations
+
+Reviewer posture, review artifacts, triage expectations, or explicit "no special review" statement.
 
 ## Further Notes
 

--- a/.codex1/setup-bundle.json
+++ b/.codex1/setup-bundle.json
@@ -1,6 +1,6 @@
 {
   "managed_by": "codex1-managed",
-  "version": 8,
+  "version": 9,
   "files": [
     ".agents/skills/codex1/SKILL.md",
     ".agents/skills/codex1/agents/openai.yaml",
@@ -38,6 +38,8 @@
     ".agents/skills/codex-review/SKILL.md",
     ".agents/skills/codex-review/agents/openai.yaml",
     ".agents/skills/codex-review/scripts/codex-review",
+    ".agents/skills/brutal-review/SKILL.md",
+    ".agents/skills/brutal-review/agents/openai.yaml",
     "docs/agents/codex1-workflow.md",
     "docs/agents/codex1-domain.md",
     "docs/agents/codex1-artifact-briefs.md",

--- a/docs/agents/codex1-artifact-briefs.md
+++ b/docs/agents/codex1-artifact-briefs.md
@@ -4,9 +4,13 @@ Codex1 artifacts should stay durable as code changes. Prefer behavior, interface
 
 ## PRD Quality
 
-`PRD.md` should include problem statement, solution, extensive user stories, success criteria, module sketch, implementation decisions, testing decisions, out-of-scope work, proof expectations, review expectations, and PR intent.
+`PRD.md` should include problem statement, solution, extensive user stories, success criteria, boundaries, module sketch, implementation decisions, testing decisions, proof expectations, review expectations, and PR intent.
 
-User stories should be numbered and broad enough that `$plan` can map slices back to them.
+Success criteria should be observable, measurable outcomes that make the PRD satisfied. They are not implementation tasks or slice-level acceptance criteria.
+
+Boundaries should separate `Always Preserve`, `Ask Before Changing`, and `Out Of Scope` work so execution agents know what must remain stable, what needs human approval, and what is intentionally excluded.
+
+User stories should be numbered, behavior-focused, and broad enough that `$plan` can map slices back to them. Each story should describe one coherent behavior or outcome, not a vague bundle.
 
 ## Subplans As Agent Briefs
 

--- a/skills/self-improve-codex/SKILL.md
+++ b/skills/self-improve-codex/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: self-improve-codex
+description: "Codex-only session introspection for evidence-backed skill, AGENTS.md, and memory improvement proposals."
+---
+
+# Self Improve Codex
+
+## Purpose
+
+Use this Codex-only power skill to inspect local Codex session evidence, find repeated improvement signals, and propose durable changes to Codex skills, project or global `AGENTS.md`, and workspace memory. It combines Codex-native self-improvement with technical skill discovery.
+
+This is not a Cursor, Claude, or general agent-log workflow. Assume Codex local state, Codex rollout JSONL files, Codex skill folders, Codex project/global `AGENTS.md` conventions, and, when the current repo uses it, Codex1 artifact conventions.
+
+Default stance: propose first. Do not patch `SKILL.md`, project `AGENTS.md`, global `~/.codex/AGENTS.md`, `MEMORY.md`, daily memory, or other instruction files unless the user explicitly approves the exact target and change.
+
+## Source Discovery
+
+Prefer Codex's authoritative local session index:
+
+1. `~/.codex/state_5.sqlite`
+2. `threads.rollout_path` values from that SQLite index
+3. rollout files under `~/.codex/sessions/**/*.jsonl` and `~/.codex/archived_sessions/**/*.jsonl`
+
+Gracefully fall back to supporting sources when the database is missing, locked, or its schema changed:
+
+- `~/.codex/sessions/**/*.jsonl`
+- `~/.codex/archived_sessions/**/*.jsonl`
+- `~/.codex/history.jsonl`
+- `~/.codex/session_index.jsonl`
+- `~/.codex/log/**/*.jsonl`
+- repo-local telemetry or instructions such as `AGENTS.md`, `docs/agents/*`, and existing skill metadata
+
+Treat incomplete convenience indexes such as `session_index.jsonl` as supporting evidence only. They can help find files, but they are not the source of truth when `state_5.sqlite` is usable.
+
+When schema assumptions fail, inspect SQLite tables and columns, report the mismatch, and degrade to path inventory. Do not fail the whole workflow just because one Codex version moved a column.
+
+Use the bundled safe inventory helper when useful:
+
+```bash
+python3 skills/self-improve-codex/scripts/scan_codex_sessions.py --recent 20
+```
+
+The helper only counts JSONL files and prints session metadata or rollout paths. It does not parse or dump full transcripts.
+
+## Operating Modes
+
+### `scan`
+
+Inventory available Codex session sources. Report whether `~/.codex/state_5.sqlite` exists, whether a `threads` table is readable, which rollout/session directories exist, JSONL counts, and recent rollout paths. Use this before deeper analysis.
+
+### `dream`
+
+Run a broad introspection pass over recent sessions. Mine repeated user corrections, preference nudges, frustration cues, autonomy/persistence gaps, tool-use mistakes, and instruction gaps. Output evidence-backed proposals for skills, `AGENTS.md`, or memory.
+
+### `skill-audit`
+
+Inspect installed skills and compare them with session evidence. Find uncovered rules, scripts that should be added, references that would reduce repeated reasoning, or skill descriptions that should trigger more reliably. Prefer updating an existing Codex skill when coverage is close.
+
+### `technical-skill-finder`
+
+Focus on recurring technical pain: command failures, stack traces, auth/setup loops, package-manager failures, type/lint/test failures, Git/CI/review loops, browser/screenshot automation friction, Obsidian workflows, OpenClaw workspace management as mentioned inside Codex sessions, 1Password flows, GitHub triage, and repeated manual command line rituals. Normalize and cluster signals before recommending reuse, update, or a new skill.
+
+### `proposal`
+
+Produce patch proposals without applying them. Include target path, rationale, evidence, score, privacy/risk notes, and an explicit next action. Patch previews should be small and reviewable.
+
+### `apply-approved`
+
+Apply only patches the user explicitly approved. Re-state the approved target before editing. Keep changes scoped to the approved files, validate frontmatter for skill edits, and show the resulting diff.
+
+## Signal Classes
+
+Mine two disjoint classes of signal.
+
+Behavior and instruction signals:
+
+- repeated user corrections or preference statements
+- "continue", "keep going", "don't stop", and similar persistence nudges
+- user frustration cues
+- repeated style preferences
+- autonomy and persistence gaps
+- repeated tool-use mistakes
+- missing project instructions
+- places where project `AGENTS.md` should be updated
+
+Technical skill signals:
+
+- recurring command failures
+- stack traces and exception signatures
+- authentication, setup, or credential flow failures
+- package-manager failures
+- type-check, lint, and test failures
+- Git, CI, PR review, and review-triage loops
+- repeated manual workflows that could become scripts
+- recurring local domains such as GitHub triage, browser automation, screenshots, Obsidian, OpenClaw workspace management, 1Password, and similar Codex-driven workflows
+
+Keep these classes separate in the report. A behavior preference may belong in `AGENTS.md`; a repeated failure pattern may belong in a skill or helper script.
+
+## Clustering
+
+Cluster evidence before recommending changes:
+
+- by distinct Codex thread/session, not raw message count
+- by date and cwd to avoid inflating same-day retries
+- by domain such as Rust, Python, frontend, docs, GitHub, Browser, Obsidian, OpenAI API, or Codex1
+- by command lineage such as `cargo test`, `pytest`, `npm install`, `gh pr`, `git worktree`, `python3 script.py`, or Browser automation
+- by normalized error signature, not full stack trace text
+- by target surface: skill, project instruction, global instruction, memory, or no action
+
+For technical failures, reduce noisy logs into signatures such as `pytest import error`, `cargo clippy lint`, `npm peer dependency`, `gh auth`, `browser blank canvas`, `sqlite schema mismatch`, or `git dirty worktree conflict`.
+
+## Scoring
+
+Use a 0-5 score for each dimension, then turn it into a clear recommendation. Read `references/scoring-and-routing.md` when doing a full ranking pass.
+
+Core dimensions:
+
+- `frequency`: how often the pattern appears
+- `recency`: whether it appeared recently
+- `impact`: time lost, user frustration, or risk
+- `confidence`: how directly the evidence supports the recommendation
+- `distinct_sessions`: recurrence across separate threads
+- `current_skill_coverage`: whether an existing skill already covers it
+- `automation_ease`: whether a script, checklist, or deterministic workflow can help
+- `privacy_risk`: whether evidence or proposed text may expose private data
+- `target_fit`: whether the fix belongs in a skill, project `AGENTS.md`, global `AGENTS.md`, memory, or no action
+
+High-priority recommendations usually have frequency >= 3, distinct_sessions >= 2, impact >= 3, confidence >= 3, and privacy_risk <= 2. Promote lower-frequency items only when impact is high and the evidence is very clear.
+
+## Routing
+
+Route every recommendation to exactly one primary target:
+
+- `new Codex skill`: repeated technical or workflow pattern with enough scope for a reusable workflow
+- `update existing Codex/OpenClaw skill`: existing skill nearly covers the pattern or has a trigger/workflow gap
+- `project AGENTS.md`: repo-specific behavior, tooling, domain vocabulary, proof rule, or workflow constraint
+- `global ~/.codex/AGENTS.md`: durable preference that applies across most Codex work
+- `workspace memory`: durable personal/project context that is useful but not an instruction
+- `no action / observe only`: too ambiguous, too private, too rare, already covered, or not worth proceduralizing
+
+Do not put the same rule in both global and project instructions unless there is a clear reason. If the rule is project-specific, keep it project-local. If it is personal preference across repos, consider global instructions. If it is factual context rather than an instruction, route to memory.
+
+For Codex1 repositories, respect the native goal boundary and artifact conventions:
+
+- Codex1 artifacts provide durable mission context and proof; they do not own native goal state.
+- Do not start `$clarify`, `$create-prd`, or `$plan` just to run this skill unless the user explicitly asks for a Codex1 mission.
+- For Codex1-related recommendations, prefer project `AGENTS.md`, repo-local skills, or docs under `docs/agents/` only when evidence shows a repo-local workflow gap.
+
+## Evidence Rules
+
+Every recommendation must cite:
+
+- session or thread id when available
+- timestamp or date
+- rollout path or source path
+- short evidence summary
+- confidence
+- why this is not a one-off
+
+Prefer paraphrase over verbatim user or assistant messages. Include private message contents only when necessary, safe, and specifically relevant. Never dump raw full transcripts by default.
+
+Separate facts from inference:
+
+- Facts: "Thread X on 2026-05-20 used `cargo test` three times and failed with the same Rust compile error."
+- Inference: "A Rust diagnosis checklist may reduce repeated command churn."
+- Proposal: "Update `$diagnose` with a Rust compile-error triage subsection."
+
+## Workflow
+
+1. Confirm scope: mode, timeframe, repo/workspace filters, and whether personal/private logs are explicitly authorized. Personal chat logs are out of scope by default.
+2. Run `scan` or manually inventory sources. Prefer SQLite rollout paths when available.
+3. Sample sessions conservatively. Start with metadata, then inspect only the cited rollout snippets needed to validate a pattern.
+4. Extract behavior/instruction signals and technical skill signals into separate buckets.
+5. Cluster by distinct session, domain, command lineage, and error signature.
+6. Compare clusters with existing skills by `name`, frontmatter `description`, and relevant `SKILL.md` workflow text.
+7. Score and route each recommendation.
+8. Produce a proposal report with patch previews, not applied patches.
+9. If the user approves specific patches, switch to `apply-approved`, edit only those targets, validate, and show the diff.
+
+## Existing Skill Coverage Check
+
+Inspect skill roots that exist:
+
+- repo-local `skills/*/SKILL.md`
+- repo-local `.agents/skills/*/SKILL.md`
+- global `~/.codex/skills/*/SKILL.md`
+- legacy `~/.agents/skills/*/SKILL.md`
+- plugin skills only when they are visible in the current session context or explicitly relevant
+
+Match candidate clusters to existing skills by:
+
+- skill name and aliases
+- frontmatter description trigger language
+- domain words in headings
+- bundled scripts and references
+- whether the skill already gives a deterministic workflow for the repeated pain
+
+If a skill exists but did not trigger often enough, propose a frontmatter description update. If the trigger is fine but execution repeated the same manual logic, propose a workflow section, reference file, or script.
+
+## Report Format
+
+Use this practical report shape:
+
+```markdown
+# Self Improve Codex Report
+
+## Executive Summary
+- analyzed:
+- strongest recommendation:
+- safest next action:
+
+## Source Coverage
+- state db:
+- rollout paths:
+- fallback sources:
+- timeframe:
+- limitations:
+
+## Top Recommendations
+### 1. <title>
+- target: <new skill | existing skill | project AGENTS.md | global AGENTS.md | memory | observe>
+- score: <overall> (frequency, recency, impact, confidence, privacy_risk)
+- evidence: <thread id/date/path summaries>
+- why not one-off:
+- suggested patch summary:
+- risk/privacy notes:
+- next action:
+
+## Observed But Not Actioned
+- <cluster>: <reason>
+```
+
+Keep reports compact. Load full evidence only when needed to justify a specific recommendation.
+
+## Safety And Privacy
+
+- Never dump full transcripts by default.
+- Never print secrets, API keys, tokens, environment dumps, or credential material.
+- Treat personal/private chat logs as out of scope unless the user explicitly authorizes that source.
+- Prefer paraphrase to raw quotes.
+- Default to propose-first.
+- Avoid overfitting one-off sessions.
+- Keep recommendation buckets disjoint.
+- Treat convenience indexes as supporting evidence only.
+- If privacy risk is high, recommend no action or a private memory update with redacted wording.
+- Before applying approved patches, re-check that the patch does not encode private content as a general instruction.
+
+## Applying Approved Changes
+
+When approval is explicit:
+
+1. Identify the exact approved target and patch intent.
+2. Re-read the current target file.
+3. Apply the smallest durable edit.
+4. Validate skill frontmatter if a `SKILL.md` changed.
+5. Run any relevant helper script tests.
+6. Show `git diff -- <targets>`.
+
+Never treat a proposal report as approval.

--- a/skills/self-improve-codex/references/scoring-and-routing.md
+++ b/skills/self-improve-codex/references/scoring-and-routing.md
@@ -1,0 +1,109 @@
+# Scoring And Routing Reference
+
+Use this reference during `dream`, `skill-audit`, `technical-skill-finder`, and `proposal` modes when a full ranking pass is needed.
+
+## Scoring Dimensions
+
+Score each dimension from 0 to 5.
+
+| Dimension | 0 | 3 | 5 |
+| --- | --- | --- | --- |
+| `frequency` | one occurrence | 2-3 related occurrences | frequent repeated pattern |
+| `recency` | old or stale | seen in recent months | seen in recent weeks |
+| `impact` | cosmetic or low effort | noticeable rework or friction | repeated user frustration, risk, or major time loss |
+| `confidence` | weak inference | evidence points to pattern | direct repeated evidence |
+| `distinct_sessions` | one thread | two distinct sessions | many distinct sessions/projects |
+| `current_skill_coverage` | already covered well | partial coverage | no effective coverage |
+| `automation_ease` | cannot automate | checklist/reference helps | deterministic script/workflow likely helps |
+| `privacy_risk` | no private content | manageable with paraphrase | high risk; avoid or redact |
+| `target_fit` | unclear target | plausible target | obvious single target |
+
+For `current_skill_coverage`, score high when coverage is missing and low when an existing skill already handles the issue. If an existing skill is close, prefer an update over a new skill.
+
+## Overall Priority
+
+Use judgment, but this weighted shape is a good default:
+
+```text
+priority =
+  frequency * 1.2
+  + recency * 0.8
+  + impact * 1.4
+  + confidence * 1.4
+  + distinct_sessions * 1.1
+  + current_skill_coverage * 0.8
+  + automation_ease * 0.7
+  + target_fit * 0.8
+  - privacy_risk * 1.5
+```
+
+Priority bands:
+
+- `>= 28`: strong recommendation
+- `22-27`: good candidate; propose if evidence is clean
+- `16-21`: observe or include as secondary
+- `< 16`: no action unless user specifically asks
+
+Promote a lower score only when impact is high and evidence is direct. Demote anything with privacy risk >= 4 unless the output can be safely redacted.
+
+## Routing Matrix
+
+Choose one primary target.
+
+| Pattern | Primary Target | Notes |
+| --- | --- | --- |
+| repeated tool or workflow failure across projects | new Codex skill | use when existing skills do not cover the domain |
+| repeated issue inside a known skill's domain | update existing Codex/OpenClaw skill | update trigger text, workflow, reference, or script |
+| repo-specific command, proof, domain, or artifact rule | project `AGENTS.md` | nearest repo-local instructions only |
+| durable preference across most work | global `~/.codex/AGENTS.md` | avoid project-only details |
+| durable fact/context, not an instruction | workspace memory | keep it factual and scoped |
+| one-off, ambiguous, private, or already covered | no action / observe only | record the reason |
+
+## Evidence Quality
+
+Strong evidence includes:
+
+- two or more distinct Codex sessions
+- recent recurrence
+- source paths from SQLite rollout metadata
+- matching command lineage or normalized error signatures
+- user correction or frustration repeated in more than one context
+
+Weak evidence includes:
+
+- one session only
+- one long thread with repeated retries
+- inferred preferences with no explicit user correction
+- convenience index entries without rollout validation
+- raw transcript content that cannot be safely paraphrased
+
+## Technical Signal Normalization
+
+Normalize logs into stable signatures:
+
+- `auth`: `gh auth`, SSH key, 1Password, API key, OAuth, permission denied
+- `package-manager`: `npm`, `pnpm`, `yarn`, `pip`, `uv`, `cargo`, lockfile or resolver failures
+- `type-check`: TypeScript, Rust compile, Python typing, schema validation
+- `lint-format`: formatter/linter failure, style churn
+- `test`: failing test command, flaky test, missing fixture
+- `runtime`: exception, stack trace, crash, browser console error
+- `git-ci-review`: merge conflict, dirty worktree, branch, PR, CI, review triage
+- `browser-visual`: screenshot, blank canvas, viewport, asset loading, DOM overlap
+- `local-workflow`: Obsidian, Codex worktrees, OpenClaw workspace management, local app automation
+
+Cluster by command lineage first, then error signature, then domain. Do not create separate candidates for the same failure with different wording.
+
+## Proposal Patch Shape
+
+Every proposal should contain:
+
+- target path or target class
+- one-sentence rationale
+- score and key dimension values
+- evidence anchors with thread id/date/source path
+- why it recurs across distinct sessions
+- exact patch summary
+- privacy note
+- recommended next action
+
+Patch previews should be minimal. If a candidate needs more design work, propose a first iteration instead of drafting a giant skill.

--- a/skills/self-improve-codex/scripts/scan_codex_sessions.py
+++ b/skills/self-improve-codex/scripts/scan_codex_sessions.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_CODEX_HOME = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser()
+
+
+@dataclass(frozen=True)
+class JsonlRoot:
+    label: str
+    path: Path
+    pattern: str = "**/*.jsonl"
+
+
+def utc_from_timestamp(value: object) -> str:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return "n/a"
+
+    if number > 10_000_000_000:
+        number = number / 1000
+    try:
+        return datetime.fromtimestamp(number, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    except (OverflowError, OSError, ValueError):
+        return "n/a"
+
+
+def short_path(path: Path, home: Path) -> str:
+    try:
+        resolved_path = path.expanduser().resolve()
+        resolved_home = home.resolve()
+    except OSError:
+        return str(path)
+
+    try:
+        return "~/" + str(resolved_path.relative_to(resolved_home))
+    except ValueError:
+        return str(resolved_path)
+
+
+def iter_jsonl(root: Path, pattern: str, max_files: int | None) -> Iterable[Path]:
+    if not root.exists():
+        return
+    seen = 0
+    try:
+        for path in root.rglob(pattern.removeprefix("**/")) if pattern.startswith("**/") else root.glob(pattern):
+            if not path.is_file():
+                continue
+            yield path
+            seen += 1
+            if max_files is not None and seen >= max_files:
+                return
+    except OSError:
+        return
+
+
+def count_jsonl(root: Path, pattern: str, max_files: int | None) -> tuple[int, bool]:
+    count = 0
+    truncated = False
+    for count, _ in enumerate(iter_jsonl(root, pattern, max_files), start=1):
+        pass
+    if max_files is not None and count >= max_files:
+        truncated = True
+    return count, truncated
+
+
+def sqlite_connect_readonly(path: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+
+
+def sqlite_tables(path: Path) -> list[str]:
+    with sqlite_connect_readonly(path) as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+        ).fetchall()
+    return [row[0] for row in rows]
+
+
+def sqlite_columns(path: Path, table: str) -> list[str]:
+    with sqlite_connect_readonly(path) as conn:
+        rows = conn.execute(f"PRAGMA table_info({quote_ident(table)})").fetchall()
+    return [row[1] for row in rows]
+
+
+def quote_ident(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def recent_threads(path: Path, limit: int) -> tuple[list[str], list[dict[str, object]]]:
+    columns = sqlite_columns(path, "threads")
+    wanted = [
+        "id",
+        "updated_at",
+        "created_at",
+        "cwd",
+        "rollout_path",
+        "archived",
+        "source",
+        "model",
+        "title",
+    ]
+    selected = [column for column in wanted if column in columns]
+    if not selected:
+        return columns, []
+
+    order_column = "updated_at" if "updated_at" in columns else "rowid"
+    sql = (
+        "SELECT "
+        + ", ".join(quote_ident(column) for column in selected)
+        + f" FROM {quote_ident('threads')} ORDER BY {quote_ident(order_column)} DESC LIMIT ?"
+    )
+    with sqlite_connect_readonly(path) as conn:
+        rows = conn.execute(sql, (limit,)).fetchall()
+    return columns, [dict(zip(selected, row)) for row in rows]
+
+
+def print_state_db(codex_home: Path, recent: int, show_titles: bool) -> None:
+    state_db = codex_home / "state_5.sqlite"
+    print("State DB")
+    print(f"- path: {state_db}")
+    print(f"- exists: {'yes' if state_db.exists() else 'no'}")
+    if not state_db.exists():
+        return
+
+    try:
+        tables = sqlite_tables(state_db)
+    except sqlite3.Error as exc:
+        print(f"- readable: no ({exc})")
+        return
+
+    print("- readable: yes")
+    print(f"- tables: {', '.join(tables) if tables else 'none'}")
+    if "threads" not in tables:
+        print("- threads: missing; falling back to JSONL path inventory")
+        return
+
+    try:
+        columns, rows = recent_threads(state_db, recent)
+    except sqlite3.Error as exc:
+        print(f"- threads readable: no ({exc})")
+        return
+
+    print(f"- threads columns: {', '.join(columns)}")
+    print(f"- recent rows shown: {len(rows)}")
+    for row in rows:
+        thread_id = str(row.get("id", "n/a"))
+        updated = utc_from_timestamp(row.get("updated_at"))
+        rollout = str(row.get("rollout_path") or "")
+        rollout_exists = Path(rollout).exists() if rollout else False
+        cwd = str(row.get("cwd") or "")
+        archived = row.get("archived", "n/a")
+        bits = [
+            f"thread={thread_id}",
+            f"updated={updated}",
+            f"archived={archived}",
+            f"rollout_exists={'yes' if rollout_exists else 'no'}",
+        ]
+        if cwd:
+            bits.append(f"cwd={cwd}")
+        if rollout:
+            bits.append(f"rollout={rollout}")
+        if show_titles and row.get("title"):
+            bits.append(f"title={row.get('title')}")
+        print("  - " + " | ".join(bits))
+
+
+def print_jsonl_roots(codex_home: Path, max_count: int | None, recent_paths: int) -> None:
+    roots = [
+        JsonlRoot("sessions", codex_home / "sessions"),
+        JsonlRoot("archived_sessions", codex_home / "archived_sessions"),
+        JsonlRoot("log", codex_home / "log"),
+        JsonlRoot("history", codex_home, "history.jsonl"),
+        JsonlRoot("session_index", codex_home, "session_index.jsonl"),
+    ]
+    home = Path.home()
+    print()
+    print("JSONL Sources")
+    for root in roots:
+        count, truncated = count_jsonl(root.path, root.pattern, max_count)
+        status = "exists" if root.path.exists() else "missing"
+        suffix = " (truncated)" if truncated else ""
+        print(f"- {root.label}: {root.path} [{status}], jsonl={count}{suffix}")
+
+        if recent_paths <= 0 or count == 0:
+            continue
+        files = sorted(
+            iter_jsonl(root.path, root.pattern, max_count),
+            key=lambda item: item.stat().st_mtime if item.exists() else 0,
+            reverse=True,
+        )[:recent_paths]
+        for path in files:
+            try:
+                mtime = utc_from_timestamp(path.stat().st_mtime)
+            except OSError:
+                mtime = "n/a"
+            print(f"  - {mtime} {short_path(path, home)}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Safely inventory local Codex session sources without printing transcript contents."
+        )
+    )
+    parser.add_argument(
+        "--codex-home",
+        type=Path,
+        default=DEFAULT_CODEX_HOME,
+        help="Codex home directory. Defaults to CODEX_HOME or ~/.codex.",
+    )
+    parser.add_argument(
+        "--recent",
+        type=int,
+        default=10,
+        help="Number of recent SQLite thread rows to show.",
+    )
+    parser.add_argument(
+        "--recent-paths",
+        type=int,
+        default=3,
+        help="Number of recent JSONL paths to show per source root.",
+    )
+    parser.add_argument(
+        "--max-count-scan",
+        type=int,
+        default=100000,
+        help="Maximum JSONL files to count per root before truncating.",
+    )
+    parser.add_argument(
+        "--show-titles",
+        action="store_true",
+        help="Include thread titles from SQLite metadata. Off by default for privacy.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    codex_home = args.codex_home.expanduser()
+    max_count = None if args.max_count_scan <= 0 else args.max_count_scan
+
+    print("Codex Session Source Scan")
+    print(f"- codex_home: {codex_home}")
+    print("- transcript_contents: not read")
+    print("- secrets: not inspected")
+    print()
+
+    print_state_db(codex_home, max(args.recent, 0), args.show_titles)
+    print_jsonl_roots(codex_home, max_count, max(args.recent_paths, 0))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -14,7 +14,7 @@ use crate::error::{Codex1Error, Result};
 use crate::paths::{create_dir_all_contained, discover_repo_root, ensure_contained_for_write};
 
 const BACKUP_MANIFEST_VERSION: u32 = 1;
-const BUNDLE_VERSION: u32 = 9;
+const BUNDLE_VERSION: u32 = 10;
 const MANAGED_GUIDANCE_START: &str = "<!-- codex1-managed setup guidance start -->";
 const MANAGED_GUIDANCE_END: &str = "<!-- codex1-managed setup guidance end -->";
 const OVERVIEW_SKILL: &str = ".agents/skills/codex1/SKILL.md";
@@ -1550,6 +1550,10 @@ Ask the questions one at a time, waiting for feedback on each question before co
 
 If a question can be answered by exploring the codebase, explore the codebase instead.
 
+When success or scope is fuzzy, clarify observable success outcomes and boundaries. Preserve those answers as context for `$create-prd`; do not turn them into a PRD template, task graph, or execution plan.
+
+Before considering clarification complete, make sure known context is sufficient for `$create-prd` to synthesize actors/core behaviors, observable success criteria, `Always Preserve`, `Ask Before Changing`, `Out Of Scope`, and any unresolved human decisions. Ask only for genuinely unclear product, scope, UX, credential, or human-judgment answers; inspect the repo for code-answerable ones.
+
 </what-to-do>
 
 <supporting-info>
@@ -1646,9 +1650,9 @@ Write `PRD.md` as a Codex1 mission artifact.
 
 A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
 
-Capture the likely modules and test seams in the PRD. If a product, scope, UX, credential, or human-judgment decision is truly missing and the user is actively collaborating, ask. Otherwise record the assumption or unresolved question instead of restarting clarification.
+Capture the likely modules and test seams in the PRD. Capture observable success criteria and mission boundaries from known context. If a product, scope, UX, credential, or human-judgment decision is truly missing and the user is actively collaborating, ask. Otherwise record the assumption or unresolved question instead of restarting clarification.
 
-3. Write the PRD using the template below, then write it as `PRD.md` in the Codex1 mission artifact tree.
+3. Write the PRD using [PRD-FORMAT.md](./PRD-FORMAT.md), then write it as `PRD.md` in the Codex1 mission artifact tree. Keep the PRD at product/outcome level. Do not turn it into a task graph, dependency tracker, priority tracker, per-story acceptance-criteria engine, or execution plan; `$plan` owns execution design.
 
 <prd-template>
 
@@ -1662,15 +1666,37 @@ The solution to the problem, from the user's perspective.
 
 ## User Stories
 
-A LONG, numbered list of user stories. Each user story should be in the format of:
+A long numbered list of behavior-focused user stories. Each story should describe one coherent behavior or outcome, not a vague bundle. Use the format:
 
-1. As an <actor>, I want a <feature>, so that <benefit>
+1. As an <actor>, I want <feature>, so that <benefit>.
 
 <user-story-example>
-1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+1. As a mobile bank customer, I want to see balances for each of my accounts, so that I can make better informed decisions about my spending.
 </user-story-example>
 
-This list of user stories should be extremely extensive and cover all aspects of the feature.
+This list should cover major behavior, actors, edge cases, and artifact interactions, while staying specific enough that `$plan` can map slices back to the stories.
+
+## Success Criteria
+
+Observable, measurable outcomes that make the PRD satisfied. These are mission-level success facts, not implementation tasks or slice-level acceptance criteria.
+
+## Boundaries
+
+### Always Preserve
+
+Existing behaviors, contracts, data, user expectations, workflow boundaries, or artifacts that must remain intact.
+
+### Ask Before Changing
+
+Areas that require explicit human approval before the implementation changes them.
+
+### Out Of Scope
+
+Work this PRD intentionally does not include.
+
+## Module Sketch
+
+Likely modules, interfaces, contracts, and deep-module opportunities. Use stable names and concepts, not brittle paths.
 
 ## Implementation Decisions
 
@@ -1682,6 +1708,7 @@ A list of implementation decisions that were made. This can include:
 - Architectural decisions
 - Schema changes
 - API contracts
+- State ownership
 - Specific interactions
 
 Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
@@ -1695,10 +1722,15 @@ A list of testing decisions that were made. Include:
 - A description of what makes a good test (only test external behavior, not implementation details)
 - Which modules will be tested
 - Prior art for the tests (i.e. similar types of tests in the codebase)
+- Testing non-goals
 
-## Out of Scope
+## Proof Expectations
 
-A description of the things that are out of scope for this PRD.
+Commands, tests, screenshots, manual checks, review evidence, or other proof expected later.
+
+## Review Expectations
+
+Reviewer posture, review artifacts, triage expectations, or explicit "no special review" statement.
 
 ## Further Notes
 
@@ -1933,7 +1965,7 @@ Use this when `$create-prd` writes `PRD.md`.
 
 ## Required Quality Bar
 
-The PRD must be sufficient for `$plan` to design execution without reconstructing product intent. Write from the user's perspective first, then capture implementation and testing decisions.
+The PRD must be sufficient for `$plan` to design execution without reconstructing product intent. Write from the user's perspective first, then capture observable success criteria, mission boundaries, implementation decisions, and testing decisions.
 
 ## Template
 
@@ -1948,15 +1980,29 @@ The solution, from the user's perspective.
 
 ## User Stories
 
-A long numbered list of user stories:
+A long numbered list of behavior-focused user stories:
 
 1. As an <actor>, I want <feature>, so that <benefit>.
 
-Cover all major behavior, actors, edge cases, and artifact interactions.
+Each story should describe one coherent behavior or outcome. Avoid vague bundles like "manage settings" unless they are split into observable behaviors. Cover all major behavior, actors, edge cases, and artifact interactions.
 
 ## Success Criteria
 
-Observable facts that make the PRD satisfied.
+Observable, measurable outcomes that make the PRD satisfied. These are mission-level success facts, not implementation tasks or slice-level acceptance criteria.
+
+## Boundaries
+
+### Always Preserve
+
+Existing behaviors, contracts, data, user expectations, workflow boundaries, or artifacts that must remain intact.
+
+### Ask Before Changing
+
+Areas that require explicit human approval before the implementation changes them.
+
+### Out Of Scope
+
+Work this PRD intentionally does not include.
 
 ## Module Sketch
 
@@ -1984,10 +2030,6 @@ Do not include brittle file paths or code snippets.
 - Testing non-goals
 
 Tests should verify behavior through public interfaces, not implementation details.
-
-## Out Of Scope
-
-What this PRD intentionally does not include.
 
 ## Proof Expectations
 
@@ -2240,9 +2282,13 @@ Codex1 artifacts should stay durable as code changes. Prefer behavior, interface
 
 ## PRD Quality
 
-`PRD.md` should include problem statement, solution, extensive user stories, success criteria, module sketch, implementation decisions, testing decisions, out-of-scope work, proof expectations, review expectations, and PR intent.
+`PRD.md` should include problem statement, solution, extensive user stories, success criteria, boundaries, module sketch, implementation decisions, testing decisions, proof expectations, review expectations, and PR intent.
 
-User stories should be numbered and broad enough that `$plan` can map slices back to them.
+Success criteria should be observable, measurable outcomes that make the PRD satisfied. They are not implementation tasks or slice-level acceptance criteria.
+
+Boundaries should separate `Always Preserve`, `Ask Before Changing`, and `Out Of Scope` work so execution agents know what must remain stable, what needs human approval, and what is intentionally excluded.
+
+User stories should be numbered, behavior-focused, and broad enough that `$plan` can map slices back to them. Each story should describe one coherent behavior or outcome, not a vague bundle.
 
 ## Subplans As Agent Briefs
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -14,7 +14,7 @@ use crate::error::{Codex1Error, Result};
 use crate::paths::{create_dir_all_contained, discover_repo_root, ensure_contained_for_write};
 
 const BACKUP_MANIFEST_VERSION: u32 = 1;
-const BUNDLE_VERSION: u32 = 8;
+const BUNDLE_VERSION: u32 = 9;
 const MANAGED_GUIDANCE_START: &str = "<!-- codex1-managed setup guidance start -->";
 const MANAGED_GUIDANCE_END: &str = "<!-- codex1-managed setup guidance end -->";
 const OVERVIEW_SKILL: &str = ".agents/skills/codex1/SKILL.md";
@@ -55,6 +55,8 @@ const PROTOTYPE_UI: &str = ".agents/skills/prototype/UI.md";
 const CODEX_REVIEW_SKILL: &str = ".agents/skills/codex-review/SKILL.md";
 const CODEX_REVIEW_OPENAI_YAML: &str = ".agents/skills/codex-review/agents/openai.yaml";
 const CODEX_REVIEW_HELPER: &str = ".agents/skills/codex-review/scripts/codex-review";
+const BRUTAL_REVIEW_SKILL: &str = ".agents/skills/brutal-review/SKILL.md";
+const BRUTAL_REVIEW_OPENAI_YAML: &str = ".agents/skills/brutal-review/agents/openai.yaml";
 const LEGACY_PLAN_EXECUTION_PROMPT_FORMAT: &str = ".agents/skills/plan/EXECUTION-PROMPT-FORMAT.md";
 const WORKFLOW_DOC: &str = "docs/agents/codex1-workflow.md";
 const DOMAIN_DOC: &str = "docs/agents/codex1-domain.md";
@@ -63,7 +65,7 @@ const BUNDLE_GUIDANCE: &str = "AGENTS.md";
 const BUNDLE_MARKER: &str = ".codex1/setup-bundle.json";
 const BACKUP_MANIFEST: &str = ".codex1/setup-backups/manifest.json";
 const BACKUP_DIR: &str = ".codex1/setup-backups/files";
-const MANAGED_SKILL_FILES: [&str; 9] = [
+const MANAGED_SKILL_FILES: [&str; 10] = [
     OVERVIEW_SKILL,
     CLARIFY_SKILL,
     CREATE_PRD_SKILL,
@@ -73,8 +75,9 @@ const MANAGED_SKILL_FILES: [&str; 9] = [
     ARCHITECTURE_SKILL,
     PROTOTYPE_SKILL,
     CODEX_REVIEW_SKILL,
+    BRUTAL_REVIEW_SKILL,
 ];
-const MANAGED_SUPPORTING_DOC_FILES: [&str; 30] = [
+const MANAGED_SUPPORTING_DOC_FILES: [&str; 31] = [
     OVERVIEW_OPENAI_YAML,
     CLARIFY_OPENAI_YAML,
     CLARIFY_ADR_FORMAT,
@@ -102,11 +105,56 @@ const MANAGED_SUPPORTING_DOC_FILES: [&str; 30] = [
     PROTOTYPE_UI,
     CODEX_REVIEW_OPENAI_YAML,
     CODEX_REVIEW_HELPER,
+    BRUTAL_REVIEW_OPENAI_YAML,
     WORKFLOW_DOC,
     DOMAIN_DOC,
     ARTIFACT_BRIEFS_DOC,
 ];
-const MANAGED_BUNDLE_FILES: [&str; 40] = [
+const MANAGED_BUNDLE_FILES: [&str; 42] = [
+    OVERVIEW_SKILL,
+    OVERVIEW_OPENAI_YAML,
+    CLARIFY_SKILL,
+    CLARIFY_OPENAI_YAML,
+    CLARIFY_ADR_FORMAT,
+    CLARIFY_CONTEXT_FORMAT,
+    CREATE_PRD_SKILL,
+    CREATE_PRD_OPENAI_YAML,
+    CREATE_PRD_FORMAT,
+    PLAN_SKILL,
+    PLAN_OPENAI_YAML,
+    PLAN_ADR_FORMAT,
+    PLAN_SUBPLAN_BRIEF,
+    PLAN_GOAL_BRIEF_FORMAT,
+    TDD_SKILL,
+    TDD_OPENAI_YAML,
+    TDD_TESTS,
+    TDD_MOCKING,
+    TDD_DEEP_MODULES,
+    TDD_INTERFACE_DESIGN,
+    TDD_REFACTORING,
+    DIAGNOSE_SKILL,
+    DIAGNOSE_OPENAI_YAML,
+    DIAGNOSE_HITL_LOOP_TEMPLATE,
+    ARCHITECTURE_SKILL,
+    ARCHITECTURE_OPENAI_YAML,
+    ARCHITECTURE_LANGUAGE,
+    ARCHITECTURE_INTERFACE_DESIGN,
+    ARCHITECTURE_DEEPENING,
+    PROTOTYPE_SKILL,
+    PROTOTYPE_OPENAI_YAML,
+    PROTOTYPE_LOGIC,
+    PROTOTYPE_UI,
+    CODEX_REVIEW_SKILL,
+    CODEX_REVIEW_OPENAI_YAML,
+    CODEX_REVIEW_HELPER,
+    BRUTAL_REVIEW_SKILL,
+    BRUTAL_REVIEW_OPENAI_YAML,
+    WORKFLOW_DOC,
+    DOMAIN_DOC,
+    ARTIFACT_BRIEFS_DOC,
+    BUNDLE_GUIDANCE,
+];
+const LEGACY_BUNDLE_FILES_V8: [&str; 40] = [
     OVERVIEW_SKILL,
     OVERVIEW_OPENAI_YAML,
     CLARIFY_SKILL,
@@ -1300,6 +1348,7 @@ fn is_current_marker(marker: &BundleMarker) -> bool {
 fn is_managed_bundle_marker(marker: &BundleMarker) -> bool {
     marker.managed_by == "codex1-managed"
         && (marker.files == bundle_files(MANAGED_BUNDLE_FILES)
+            || marker.files == bundle_files(LEGACY_BUNDLE_FILES_V8)
             || marker.files == bundle_files(LEGACY_BUNDLE_FILES_V6)
             || marker.files == bundle_files(LEGACY_BUNDLE_FILES_V5)
             || marker.files == bundle_files(LEGACY_BUNDLE_FILES_V4)
@@ -1394,6 +1443,10 @@ fn expected_body(relative: &str) -> String {
         }
         CODEX_REVIEW_HELPER => {
             include_str!("../.agents/skills/codex-review/scripts/codex-review").to_string()
+        }
+        BRUTAL_REVIEW_SKILL => include_str!("../.agents/skills/brutal-review/SKILL.md").to_string(),
+        BRUTAL_REVIEW_OPENAI_YAML => {
+            include_str!("../.agents/skills/brutal-review/agents/openai.yaml").to_string()
         }
         LEGACY_PLAN_EXECUTION_PROMPT_FORMAT => legacy_execution_prompt_format_body().to_string(),
         WORKFLOW_DOC => workflow_doc_body().to_string(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -971,6 +971,19 @@ fn setup_install_materializes_repo_scoped_guidance() {
 
     let guidance = fs::read_to_string(repo.path().join("AGENTS.md")).unwrap();
     assert!(guidance.contains("codex1-managed setup guidance start"));
+    let clarify = fs::read_to_string(repo.path().join(".agents/skills/clarify/SKILL.md")).unwrap();
+    assert!(clarify.contains("clarify observable success outcomes and boundaries"));
+    assert!(clarify.contains("Before considering clarification complete"));
+    assert!(clarify.contains("Always Preserve"));
+    let prd_skill =
+        fs::read_to_string(repo.path().join(".agents/skills/create-prd/SKILL.md")).unwrap();
+    assert!(prd_skill.contains("per-story acceptance-criteria engine"));
+    assert!(prd_skill.contains("## Boundaries"));
+    let prd_format =
+        fs::read_to_string(repo.path().join(".agents/skills/create-prd/PRD-FORMAT.md")).unwrap();
+    assert!(prd_format.contains("A long numbered list of behavior-focused user stories"));
+    assert!(prd_format.contains("### Always Preserve"));
+    assert!(prd_format.contains("### Ask Before Changing"));
     assert!(!repo.path().join(".codex/config.toml").exists());
 }
 
@@ -1114,7 +1127,7 @@ fn setup_enable_repairs_stale_managed_skill_and_marker() {
     let marker = fs::read_to_string(&marker_path).unwrap();
     fs::write(
         &marker_path,
-        marker.replace(r#""version": 8"#, r#""version": 7"#),
+        marker.replace(r#""version": 10"#, r#""version": 9"#),
     )
     .unwrap();
     fs::write(
@@ -1134,7 +1147,7 @@ fn setup_enable_repairs_stale_managed_skill_and_marker() {
     let marker = fs::read_to_string(repo.path().join(".codex1/setup-bundle.json")).unwrap();
     assert!(skill.contains("$clarify"));
     assert!(repo.path().join(".agents/skills/plan/SKILL.md").is_file());
-    assert!(marker.contains(r#""version": 9"#));
+    assert!(marker.contains(r#""version": 10"#));
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 #[cfg(unix)]
 use std::os::unix::fs::{symlink, PermissionsExt};
 
-const MANAGED_SKILLS: [&str; 9] = [
+const MANAGED_SKILLS: [&str; 10] = [
     ".agents/skills/codex1/SKILL.md",
     ".agents/skills/clarify/SKILL.md",
     ".agents/skills/create-prd/SKILL.md",
@@ -22,9 +22,10 @@ const MANAGED_SKILLS: [&str; 9] = [
     ".agents/skills/improve-codebase-architecture/SKILL.md",
     ".agents/skills/prototype/SKILL.md",
     ".agents/skills/codex-review/SKILL.md",
+    ".agents/skills/brutal-review/SKILL.md",
 ];
 
-const MANAGED_SUPPORTING_DOCS: [&str; 30] = [
+const MANAGED_SUPPORTING_DOCS: [&str; 31] = [
     ".agents/skills/codex1/agents/openai.yaml",
     ".agents/skills/clarify/agents/openai.yaml",
     ".agents/skills/clarify/ADR-FORMAT.md",
@@ -52,6 +53,7 @@ const MANAGED_SUPPORTING_DOCS: [&str; 30] = [
     ".agents/skills/prototype/UI.md",
     ".agents/skills/codex-review/agents/openai.yaml",
     ".agents/skills/codex-review/scripts/codex-review",
+    ".agents/skills/brutal-review/agents/openai.yaml",
     "docs/agents/codex1-workflow.md",
     "docs/agents/codex1-domain.md",
     "docs/agents/codex1-artifact-briefs.md",
@@ -1132,7 +1134,7 @@ fn setup_enable_repairs_stale_managed_skill_and_marker() {
     let marker = fs::read_to_string(repo.path().join(".codex1/setup-bundle.json")).unwrap();
     assert!(skill.contains("$clarify"));
     assert!(repo.path().join(".agents/skills/plan/SKILL.md").is_file());
-    assert!(marker.contains(r#""version": 8"#));
+    assert!(marker.contains(r#""version": 9"#));
 }
 
 #[test]
@@ -1399,6 +1401,8 @@ fn setup_backups_restore_previous_marker_absence_from_prior_bundle() {
                 ".agents/skills/codex-review/SKILL.md",
                 ".agents/skills/codex-review/agents/openai.yaml",
                 ".agents/skills/codex-review/scripts/codex-review",
+                ".agents/skills/brutal-review/SKILL.md",
+                ".agents/skills/brutal-review/agents/openai.yaml",
                 "docs/agents/codex1-workflow.md",
                 "docs/agents/codex1-domain.md",
                 "docs/agents/codex1-artifact-briefs.md",


### PR DESCRIPTION
## Summary
- Add a new Codex-only `self-improve-codex` power skill for evidence-backed introspection over Codex sessions, skills, `AGENTS.md`, and memory
- Add a scoring and routing reference plus a conservative session inventory script that reads Codex state and rollout metadata without dumping transcripts
- Update Codex1 setup and supporting skill docs to align with the new workflow and artifact guidance

## Testing
- YAML frontmatter validation passed for the new skill
- Python helper smoke-tested with `--help` and a safe scan run
- Local syntax and diff checks passed